### PR TITLE
Fix parsing of `Manifest-v{VERSION}.toml`

### DIFF
--- a/src/JuliaWorkspaces.jl
+++ b/src/JuliaWorkspaces.jl
@@ -7,6 +7,8 @@ using Salsa
 
 using AutoHashEquals
 
+include("utils.jl")
+
 include("compat.jl")
 
 import Pkg

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -11,7 +11,8 @@ end
 function is_path_manifest_file(path)
     basename_lower_case = basename(lowercase(path))
 
-    return basename_lower_case=="manifest.toml" || basename_lower_case=="juliamanifest.toml"
+    # Manifest.toml, Manifest-v1.11.toml, JuliaManifest.toml, etc.
+    return occursin(r"^manifest(\-v\d+(\.\d+)*)?\.toml$", basename_lower_case) || basename_lower_case == "juliamanifest.toml"
 end
 
 function is_path_lintconfig_file(path)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,7 @@
+@inline function safe_getproperty(x, s::Symbol)
+    if isnothing(x)
+        return nothing
+    else
+        return getproperty(x, s)
+    end
+end

--- a/test/test_testitems.jl
+++ b/test/test_testitems.jl
@@ -439,3 +439,60 @@ end
 
     @test ti.name == "Test1"
 end
+
+@testitem "fallback project without manifest causes content_hash error" begin
+    using JuliaWorkspaces
+    using JuliaWorkspaces.URIs2: filepath2uri
+
+    mktempdir() do temp_dir
+        # Create fallback project with Project.toml but NO Manifest.toml
+        fallback_dir = joinpath(temp_dir, "FallbackProject")
+        mkpath(fallback_dir)
+
+        fallback_project_toml = joinpath(fallback_dir, "Project.toml")
+        write(
+            fallback_project_toml,
+            """
+name = "FallbackProject"
+uuid = "12345678-1234-1234-1234-123456789abc"
+version = "0.1.0"
+""",
+        )
+        # NO MANIFEST - this makes derived_project return nothing
+
+        # Create a Julia file in a completely separate directory (not under any project)
+        separate_dir = joinpath(temp_dir, "SeparateDir")
+        mkpath(separate_dir)
+        julia_file = joinpath(separate_dir, "isolated.jl")
+        write(julia_file, "# Julia file not under any project")
+
+        # Add files to workspace
+        fallback_project_uri = filepath2uri(fallback_project_toml)
+        julia_uri = filepath2uri(julia_file)
+        fallback_folder_uri = filepath2uri(fallback_dir)
+
+        jw = JuliaWorkspace()
+        add_file!(
+            jw,
+            TextFile(
+                fallback_project_uri,
+                SourceText(read(fallback_project_toml, String), "toml"),
+            ),
+        )
+        add_file!(jw, TextFile(julia_uri, SourceText("# test", "julia")))
+
+        # Set the no-manifest project as fallback
+        JuliaWorkspaces.set_input_fallback_test_project!(jw.runtime, fallback_folder_uri)
+
+        # Manually trigger the exact bug condition that was demonstrated in final_bug_reproducer.jl
+        rt = jw.runtime
+        fallback = JuliaWorkspaces.input_fallback_test_project(rt)
+
+        # Verify bug conditions: fallback exists but derived_project returns nothing
+        fallback_derived = JuliaWorkspaces.derived_project(rt, fallback)
+        @test fallback_derived === nothing
+
+        # This line mimics what happens on line 132 of derived_testenv when the bug occurs
+        @test_throws "type Nothing has no field content_hash" fallback_derived.content_hash
+    end
+end


### PR DESCRIPTION
This fixes the behavior when using `Manifest-v1.11.toml`.

I also cleaned up `derived_testenv` (I found the logic a bit hard to follow but could be just me) and made it more robust against nothing return values.

I'm not sure if this will fix the issues in https://github.com/julia-vscode/TestItemRunner.jl/issues/112 and https://github.com/julia-vscode/julia-vscode/issues/3817 but fingers crossed. 