### PR TITLE
fix: better handling for non-file uris

### DIFF
--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -44,6 +44,13 @@ is_walkdir_error(::Base.SystemError) = true
 is_walkdir_error(err::Base.TaskFailedException) = is_walkdir_error(err.task.exception)
 
 function read_text_file_from_uri(uri::URI; return_nothing_on_io_error=false)
+    if uri.scheme !== "file"
+        if ignore_io_errors
+            return nothing
+        else
+            error("Trying to read non-file content from $uri.")
+        end
+    end
     path = uri2filepath(uri)
 
     language_id = if is_path_julia_file(path)
@@ -84,9 +91,17 @@ function read_text_file_from_uri(uri::URI; return_nothing_on_io_error=false)
 end
 
 function read_path_into_textdocuments(uri::URI; ignore_io_errors=false)
-    path = uri2filepath(uri)
-
     result = TextFile[]
+
+    if uri.scheme !== "file"
+        if ignore_io_errors
+            return result
+        else
+            error("Trying to read non-file content from $uri.")
+        end
+    end
+
+    path = uri2filepath(uri)
 
     for (root, _, files) in walkdir(path, onerror=x -> x)
         for file in files

--- a/src/layer_projects.jl
+++ b/src/layer_projects.jl
@@ -11,6 +11,8 @@ Salsa.@derived function derived_potential_project_folders(rt)
     mf = Dict{URI,URI}()
 
     for file_uri in project_files
+        @assert file_uri.scheme === "file"
+
         file_path = uri2filepath(file_uri)
         folder_path = dirname(file_path)
         fodler_uri = filepath2uri(folder_path)
@@ -57,7 +59,7 @@ Salsa.@derived function derived_project(rt, uri)
     project_file = project_folders[uri].project_file
     manifest_file = project_folders[uri].manifest_file
 
-    if manifest_file===nothing
+    if manifest_file === nothing || manifest_file.scheme != "file"
         return nothing
     end
 
@@ -108,14 +110,14 @@ Salsa.@derived function derived_project(rt, uri)
             git_tree_sha1_of_regular_package = v_entry[1]["git-tree-sha1"]
 
             version_of_regular_package = v_entry[1]["version"]
-            
+
             regular_packages[k_entry] = JuliaProjectEntryRegularPackage(k_entry, uuid_of_regular_package, version_of_regular_package, git_tree_sha1_of_regular_package)
         elseif haskey(v_entry[1], "uuid")
             uuid_of_stdlib_package = tryparse(UUID, v_entry[1]["uuid"])
             uuid_of_stdlib_package !== nothing || continue
 
             version_of_stdlib_package = get(v_entry[1], "version", nothing)
-            
+
             stdlib_packages[k_entry] = JuliaProjectEntryStdlibPackage(k_entry, uuid_of_stdlib_package, version_of_stdlib_package)
         else
             error("Unknown manifest entry type $(keys(e_entry[1]))")

--- a/src/layer_testitems.jl
+++ b/src/layer_testitems.jl
@@ -21,7 +21,10 @@ function vec_startswith(a, b)
 end
 
 function find_package_for_file(packages::Vector{URI}, file::URI)
+    file.scheme != "file" && return nothing
+
     file_path = uri2filepath(file)
+
     package = packages |>
         x -> map(x) do i
             package_folder_path = uri2filepath(i)
@@ -38,6 +41,8 @@ function find_package_for_file(packages::Vector{URI}, file::URI)
 end
 
 function find_project_for_file(projects::Vector{URI}, file::URI)
+    file.scheme != "file" && return nothing
+
     file_path = uri2filepath(file)
     project = projects |>
         x -> map(x) do i


### PR DESCRIPTION
We've not been super consistent about checking `uri.scheme == "file"` before calling `uri2filepath` on it. This fixes that.