### PR TITLE
fix(symbolserver): don't crash cache_methods on non-Function callables

### DIFF
--- a/shared/symbolserver/symbols.jl
+++ b/shared/symbolserver/symbols.jl
@@ -290,7 +290,10 @@ function cache_methods(@nospecialize(f), name, env, get_return_type; min_world::
         end
     end
 
-    func_vr = VarRef(VarRef(parentmodule(f)), name)
+    # non-Function callables (e.g. SymbolicUtils.BasicSymbolic, #319) have no
+    # `parentmodule` method; fall back to the type's module
+    fmod = f isa Union{Module,Function,Type} ? parentmodule(f) : parentmodule(typeof(f))
+    func_vr = VarRef(VarRef(fmod), name)
     for m in ms
         mvr = VarRef(m[1])
         # `cont=true` follows VarRef chains to the actual ModuleStore: a module's

--- a/test/test_symbolserver.jl
+++ b/test/test_symbolserver.jl
@@ -194,6 +194,32 @@ end
     @test sigh[2].second == FakeTypeName(Vararg{Int,2})
 end
 
+@testitem "SymbolServer: #319 cache_methods handles non-Function callables" begin
+    using JuliaWorkspaces.SymbolServer: cache_methods, EnvStore, ModuleStore, VarRef, FunctionStore
+
+    # A callable struct instance (e.g. SymbolicUtils.BasicSymbolic reaching
+    # cache_new_methods! while indexing AbstractAlgebra) has no
+    # `parentmodule(::Callable)` method and used to crash cache_methods.
+    fakemod = Module(:_TestPkgCallable)
+    Core.eval(fakemod, quote
+        struct Callable end
+        (::Callable)(x::Number) = x + 1
+    end)
+    f = Core.eval(fakemod, :(Callable()))
+
+    env = EnvStore()
+    name = nameof(fakemod)
+    env[name] = ModuleStore(VarRef(fakemod), Dict{Symbol,Any}(), "", true, Symbol[], Symbol[])
+
+    ms = cache_methods(f, :callable, env, false)   # must not throw
+    @test length(ms) == 1
+    @test haskey(env[name], :callable)
+    @test env[name][:callable] isa FunctionStore
+    @test length(env[name][:callable].methods) == 1
+    # extends resolves to the type's module
+    @test env[name][:callable].extends.parent.name == name
+end
+
 @testitem "SymbolServer: cache_methods min_world filter skips pre-existing methods" begin
     using JuliaWorkspaces.SymbolServer: cache_methods, EnvStore, ModuleStore, VarRef,
                                         FunctionStore, method_world


### PR DESCRIPTION
parentmodule has no method for arbitrary callable objects (e.g. SymbolicUtils.BasicSymbolic hitting cache_new_methods! while indexing AbstractAlgebra), which killed the whole indexing run. Fall back to the type's module for the extends VarRef.

Fixes julia-vscode/SymbolServer.jl#319