### PR TITLE
perf: per-root re-analysis (remove IncludeOnly pass)

### DIFF
--- a/src/StaticLint/StaticLint.jl
+++ b/src/StaticLint/StaticLint.jl
@@ -229,7 +229,11 @@ end
 
 Performs a semantic pass across a project from the entry point `file`. A first pass traverses the top-level scope after which secondary passes handle delayed scopes (e.g. functions). These secondary passes can be, optionally, very light and only seek to resovle references (e.g. link symbols to bindings). This can be done by supplying a list of expressions on which the full secondary pass should be made (`modified_expr`), all others will receive the light-touch version.
 """
-function semantic_pass(uri, cst, env, meta_dict, include_dict, rt, modified_expr = nothing; workspace_packages = Dict{String,Any}(), test_setups = Dict{Symbol,TestSetupInfo}(), self_package_name::Union{Nothing,String} = nothing)
+function semantic_pass(uri, cst, env, meta_dict, rt, modified_expr = nothing; workspace_packages = Dict{String,Any}(), test_setups = Dict{Symbol,TestSetupInfo}(), self_package_name::Union{Nothing,String} = nothing)
+    # Traversal-local include resolution: maps objectids of include-call EXPRs to
+    # their target URIs. Built per entered file (here for the entry file, in
+    # `followinclude` for included files) so no objectid escapes this pass.
+    include_dict = collect_include_map(cst, URIs2.uri2filepath(uri))
     setscope!(cst, Scope(nothing, cst, Dict(), Dict{Symbol,Any}(:Base => env.symbols[:Base], :Core => env.symbols[:Core]), nothing), meta_dict)
     state = Toplevel(uri, [uri], Set([uri]), scopeof(cst, meta_dict), modified_expr === nothing, modified_expr, EXPR[], EXPR[], env, workspace_packages, test_setups, self_package_name, 0, meta_dict, include_dict, rt)
     process_EXPR(cst, state)
@@ -388,6 +392,7 @@ function followinclude(x, state::Toplevel)
         push!(state.all_included_files, state.uri)
     #     root_dict[state.file] = root_dict[oldfile]
         cst_new_file = derived_julia_legacy_syntax_tree(rt, target_uri)
+        merge!(include_dict, collect_include_map(cst_new_file, URIs2.uri2filepath(target_uri)))
         setscope!(cst_new_file, nothing, meta_dict)
         process_EXPR(cst_new_file, state)
         state.uri = old_uri

--- a/src/StaticLint/includes.jl
+++ b/src/StaticLint/includes.jl
@@ -1,14 +1,3 @@
-mutable struct IncludeOnly{RT} <: TraverseState
-    uri::URI
-    included_files::Set{URI}
-    include_dict::Dict{UInt64,URI}
-    rt::RT
-end
-
-getpath(state::IncludeOnly) = URIs2.uri2filepath(state.uri)
-
-IncludeOnly(uri, include_dict, rt) = IncludeOnly(uri, Set{URI}(), include_dict, rt)
-
 """
     get_path(x::EXPR)
 
@@ -42,6 +31,7 @@ function get_path(x::EXPR, file_dir, meta_dict)
             for i = 2:length(parg.args)
                 arg = parg.args[i]
                 if _is_macrocall_to_BaseDIR(arg) # Assumes @__DIR__ points to Base macro.
+                    file_dir === nothing && return nothing
                     push!(path_elements, file_dir)
                 elseif CSTParser.isstringliteral(arg)
                     if occursin("\0", valof(arg))
@@ -63,36 +53,40 @@ function get_path(x::EXPR, file_dir, meta_dict)
     return nothing
 end
 
-function process_EXPR(x::EXPR, state::IncludeOnly)
+# Shared walker for include-call analyses. Calls `f(x, pos, target)` for every
+# `include(...)`/`includet(...)` call, where `pos` is the 0-based byte offset of
+# the call EXPR and `target` the resolved URI or `nothing`. `file_dir` may be
+# `nothing` (a file without a filesystem path, e.g. an unsaved buffer), in which
+# case only absolute include paths resolve.
+function _walk_include_calls(f, x::EXPR, file_dir, pos)
     if (CSTParser.fcall_name(x) == "include" || CSTParser.fcall_name(x) == "includet") && length(x.args) == 2
-        path = get_path(x, dirname(getpath(state)), nothing)
+        path = get_path(x, file_dir, nothing)
 
-        if path!==nothing
-            if !isabspath(path)
-                parent_path = getpath(state)
-
-                if parent_path === nothing
-                    path = nothing
-                else
-                    path = joinpath(dirname(parent_path), path)
-                end
-            end
-
-            if path!==nothing
-                uri = filepath2uri(path)
-                push!(state.included_files, uri)
-                state.include_dict[UInt64(objectid(x))] = uri
+        target = nothing
+        if path !== nothing
+            if isabspath(path)
+                target = filepath2uri(path)
+            elseif file_dir !== nothing
+                target = filepath2uri(joinpath(file_dir, path))
             end
         end
+
+        f(x, pos, target)
     elseif !(CSTParser.defines_function(x) || CSTParser.defines_macro(x) || headof(x) === :export || headof(x) === :public)
-        traverse(x, state)
+        p = pos
+        for i in 1:length(x)
+            _walk_include_calls(f, x[i], file_dir, p)
+            p += x[i].fullspan
+        end
     end
 
-    return state
+    return nothing
 end
 
+_include_file_dir(file_path) = file_path === nothing ? nothing : dirname(file_path)
+
 """
-    collect_include_calls(cst::EXPR, file_path::String)
+    collect_include_calls(cst::EXPR, file_path::Union{Nothing,String})
 
 Walk `cst` and return a vector of `(offset, span, target_uri)` tuples, one for
 each `include(...)`/`includet(...)` call. `offset` is the 0-based byte offset of
@@ -100,37 +94,32 @@ the call EXPR within the file and `span` its span. `target_uri` is the resolved
 target `URI` (normalised, relative paths joined to the file's directory) or
 `nothing` when the path could not be determined statically.
 
-Unlike `process_EXPR(::IncludeOnly)`, this records the position of every include
-call (including those that point at non-existent files) so that include-graph
-diagnostics can be attached to the offending statement.
+Records the position of every include call (including those that point at
+non-existent files) so that include-graph diagnostics can be attached to the
+offending statement.
 """
-function collect_include_calls(cst::EXPR, file_path::String)
+function collect_include_calls(cst::EXPR, file_path::Union{Nothing,String})
     results = Tuple{Int,Int,Union{URI,Nothing}}[]
-    _collect_include_calls(cst, file_path, dirname(file_path), results, 0)
+    _walk_include_calls(cst, _include_file_dir(file_path), 0) do x, pos, target
+        push!(results, (pos, x.span, target))
+    end
     return results
 end
 
-function _collect_include_calls(x::EXPR, file_path, file_dir, results, pos)
-    if (CSTParser.fcall_name(x) == "include" || CSTParser.fcall_name(x) == "includet") && length(x.args) == 2
-        path = get_path(x, file_dir, nothing)
+"""
+    collect_include_map(cst::EXPR, file_path::Union{Nothing,String})
 
-        target = nothing
-        if path !== nothing
-            if !isabspath(path)
-                path = joinpath(file_dir, path)
-            end
-            target = filepath2uri(path)
-        end
-
-        push!(results, (pos, x.span, target))
-    elseif !(CSTParser.defines_function(x) || CSTParser.defines_macro(x) || headof(x) === :export || headof(x) === :public)
-        p = pos
-        for i in 1:length(x)
-            _collect_include_calls(x[i], file_path, file_dir, results, p)
-            p += x[i].fullspan
-        end
+Walk `cst` and return a `Dict{UInt64,URI}` mapping `objectid` of each resolved
+`include(...)`/`includet(...)` call EXPR to its target URI. Used by
+[`semantic_pass`](@ref) to resolve includes while traversing a file; the
+objectids are only valid for this particular CST instance, so the map must not
+outlive the traversal it is built for.
+"""
+function collect_include_map(cst::EXPR, file_path::Union{Nothing,String})
+    result = Dict{UInt64,URI}()
+    _walk_include_calls(cst, _include_file_dir(file_path), 0) do x, _, target
+        target === nothing || (result[UInt64(objectid(x))] = target)
     end
-
-    return results
+    return result
 end
 

--- a/src/layer_includes.jl
+++ b/src/layer_includes.jl
@@ -1,57 +1,51 @@
-Salsa.@derived function derived_all_includes(rt)
-    @debug "derived_all_includes"
+"""
+    derived_uri2included(rt)
+
+The workspace include graph: maps each Julia file in the graph (regular files
+plus files reached transitively via `include(...)`) to the set of files it
+includes. Built entirely from the per-file
+[`derived_file_include_records`](@ref) queries, so its value only changes when
+the actual include *structure* changes — ordinary edits leave it `isequal` and
+Salsa's early-exit spares all downstream consumers.
+"""
+Salsa.@derived function derived_uri2included(rt)
+    @debug "derived_uri2included"
 
     files_to_check = copy(derived_julia_files(rt))
     uri2included = Dict{URI,Set{URI}}()
-
-    include_dict = Dict{UInt64, URI}()
 
     while !isempty(files_to_check)
         uri = first(files_to_check)
         delete!(files_to_check, uri)
         uri2included[uri] = Set{URI}()
 
-        cst = derived_julia_legacy_syntax_tree(rt, uri)
-        state = StaticLint.IncludeOnly(uri, include_dict, rt)
-        StaticLint.process_EXPR(cst, state)
+        for (_, _, target) in derived_file_include_records(rt, uri)
+            target === nothing && continue
 
-        for included_file in state.included_files
-            tf = derived_text_file_content(rt, included_file)
+            tf = derived_text_file_content(rt, target)
             if tf === nothing
                 continue
             end
-            if !haskey(uri2included, included_file) && !(included_file in files_to_check)
-                push!(files_to_check, included_file)
+            if !haskey(uri2included, target) && !(target in files_to_check)
+                push!(files_to_check, target)
             end
-            push!(uri2included[uri], included_file)
+            push!(uri2included[uri], target)
         end
     end
 
-    return uri2included, include_dict
+    return uri2included
 end
 
 Salsa.@derived function derived_includes(rt, uri)
-    uri2includ, _ = derived_all_includes(rt)
+    uri2included = derived_uri2included(rt)
 
-    return uri2includ[uri]
+    return uri2included[uri]
 end
 
 Salsa.@derived function derived_all_julia_files(rt)
-    uri2included, _ = derived_all_includes(rt)
+    uri2included = derived_uri2included(rt)
 
-    all_files = Set{URI}()
-
-    for (uri, included) in uri2included
-        push!(all_files, uri)
-    end
-
-    return all_files
-end
-
-Salsa.@derived function derived_include_dict(rt)
-    _, include_dict = derived_all_includes(rt)
-
-    return include_dict
+    return Set{URI}(keys(uri2included))
 end
 
 """
@@ -62,7 +56,7 @@ files — i.e. files reached only via `include(...)` traversal whose content was
 loaded through the lazy `input_indirect_text_file` input.
 """
 Salsa.@derived function derived_indirect_files(rt)
-    uri2included, _ = derived_all_includes(rt)
+    uri2included = derived_uri2included(rt)
 
     return Set{URI}(uri for uri in keys(uri2included) if !derived_has_file(rt, uri))
 end
@@ -74,7 +68,7 @@ end
 Salsa.@derived function derived_roots(rt)
     @debug "derived_roots"
 
-    uri2included, include_dict = derived_all_includes(rt)
+    uri2included = derived_uri2included(rt)
 
     all_files_included_somewhere = Set{URI}()
 
@@ -98,7 +92,7 @@ If `uri` is itself a root, it will be included in the result.
 Salsa.@derived function derived_roots_for_uri(rt, uri)
     @debug "derived_roots_for_uri" uri=uri
 
-    uri2included, _ = derived_all_includes(rt)
+    uri2included = derived_uri2included(rt)
     roots = derived_roots(rt)
 
     result = Set{URI}()
@@ -174,8 +168,9 @@ Salsa.@derived function derived_file_include_records(rt, uri)
     tf = derived_text_file_content(rt, uri)
     tf === nothing && return Tuple{Int,Int,Union{URI,Nothing}}[]
 
+    # A `nothing` file path (e.g. an unsaved buffer) still resolves absolute
+    # include paths; relative ones come back as `nothing` targets.
     file_path = uri2filepath(uri)
-    file_path === nothing && return Tuple{Int,Int,Union{URI,Nothing}}[]
 
     cst = derived_julia_legacy_syntax_tree(rt, uri)
 

--- a/src/layer_includes.jl
+++ b/src/layer_includes.jl
@@ -49,6 +49,33 @@ Salsa.@derived function derived_all_julia_files(rt)
 end
 
 """
+    derived_include_closure(rt, uri)
+
+The transitive include closure of `uri` (including `uri` itself): every file
+reachable from `uri` through `include(...)` edges. This is the set of files a
+semantic pass starting at `uri` can traverse.
+"""
+Salsa.@derived function derived_include_closure(rt, uri)
+    uri2included = derived_uri2included(rt)
+
+    closure = Set{URI}([uri])
+    queue = URI[uri]
+    while !isempty(queue)
+        current = popfirst!(queue)
+        for included in get(uri2included, current, _EMPTY_URI_SET)
+            if !(included in closure)
+                push!(closure, included)
+                push!(queue, included)
+            end
+        end
+    end
+
+    return closure
+end
+
+const _EMPTY_URI_SET = Set{URI}()
+
+"""
     derived_indirect_files(rt)
 
 Return the set of URIs in the include graph that are *not* regular workspace

--- a/src/layer_static_lint.jl
+++ b/src/layer_static_lint.jl
@@ -166,62 +166,50 @@ Salsa.@derived function derived_static_lint_meta_for_root(rt, uri)
     return (meta_dict=meta_dict, workspace_packages=workspace_packages)
 end
 
-Salsa.@derived function derived_static_lint_all_diagnostics(rt)
-    @debug "derived_static_lint_all_diagnostics"
+"""
+    derived_static_lint_diagnostics_for_root(rt, root)
 
-    # We use a Set to deduplicate diagnostics, as the same diagnostic
-    # can be produced from multiple roots due to includes
+Static-lint diagnostics for every file in `root`'s include closure, keyed by
+file URI. Keyed per root so an edit only recomputes diagnostics for the roots
+whose closure contains the edited file.
+"""
+Salsa.@derived function derived_static_lint_diagnostics_for_root(rt, root)
+    @debug "derived_static_lint_diagnostics_for_root" root=root
+
     res = Dict{URI,Set{Diagnostic}}()
 
-    roots = derived_roots(rt)
-    for root in roots
-        project_uri = derived_project_uri_for_root(rt, root)
-        @debug "Workspace root" root=root project=project_uri
-    end
+    project_uri = derived_project_uri_for_root(rt, root)
+    project_uri === nothing && return res
 
-    for root in roots
-        project_uri = derived_project_uri_for_root(rt, root)
-        project_uri === nothing && continue
+    lint_result = derived_static_lint_meta_for_root(rt, root)
+    meta_dict = lint_result.meta_dict
+    workspace_packages = lint_result.workspace_packages
+    env = derived_environment(rt, project_uri)
 
-        lint_result = derived_static_lint_meta_for_root(rt, root)
-        meta_dict = lint_result.meta_dict
-        workspace_packages = lint_result.workspace_packages
-        env = derived_environment(rt, project_uri)
+    for uri in derived_include_closure(rt, root)
+        current_res = get!(res, uri, Set{Diagnostic}())
 
-        uris_to_check = Set{URI}([root])
-        while !isempty(uris_to_check)
-            uri = first(uris_to_check)
-            delete!(uris_to_check, uri)
+        cst = derived_julia_legacy_syntax_tree(rt, uri)
+        lint_config = derived_lint_configuration(rt, uri)
+        missingrefs = _missingrefs_from_config(lint_config)
+        errs = StaticLint.collect_hints(cst, env, workspace_packages, meta_dict, missingrefs)
 
-            included_uris = derived_includes(rt, uri)
-            for included_uri in included_uris
-                push!(uris_to_check, included_uri)
-            end
-
-            current_res = get!(res, uri, Set{Diagnostic}())
-
-            cst = derived_julia_legacy_syntax_tree(rt, uri)
-            lint_config = derived_lint_configuration(rt, uri)
-            missingrefs = _missingrefs_from_config(lint_config)
-            errs = StaticLint.collect_hints(cst, env, workspace_packages, meta_dict, missingrefs)
-
-            for err in errs
-                rng = err[1]+1:err[1]+err[2].span+1
-                if StaticLint.headof(err[2]) === :errortoken
-                    # push!(out, Diagnostic(rng, DiagnosticSeverities.Error, missing, missing, "Julia", "Parsing error", missing, missing))
-                elseif CSTParser.isidentifier(err[2]) && !StaticLint.haserror(err[2], meta_dict)
-                    push!(current_res, Diagnostic(rng, :warning, "Missing reference: $(err[2].val)", nothing, Symbol[], "StaticLint.jl"))
-                elseif StaticLint.haserror(err[2], meta_dict) && StaticLint.errorof(err[2], meta_dict) isa StaticLint.LintCodes
-                    code = StaticLint.errorof(err[2], meta_dict)
-                    description = get(StaticLint.LintCodeDescriptions, code, "")
-                    severity, tags = if code in (StaticLint.UnusedFunctionArgument, StaticLint.UnusedBinding, StaticLint.UnusedTypeParameter)
-                        :hint, Symbol[:unnecessary]
-                    else
-                        :information, Symbol[]
-                    end
-                    code_details = code === StaticLint.IndexFromLength ? URI("https://docs.julialang.org/en/v1/base/arrays/#Base.eachindex") : nothing
-                    push!(current_res, Diagnostic(rng, severity, description, code_details, tags, "StaticLint.jl"))
+        for err in errs
+            rng = err[1]+1:err[1]+err[2].span+1
+            if StaticLint.headof(err[2]) === :errortoken
+                # push!(out, Diagnostic(rng, DiagnosticSeverities.Error, missing, missing, "Julia", "Parsing error", missing, missing))
+            elseif CSTParser.isidentifier(err[2]) && !StaticLint.haserror(err[2], meta_dict)
+                push!(current_res, Diagnostic(rng, :warning, "Missing reference: $(err[2].val)", nothing, Symbol[], "StaticLint.jl"))
+            elseif StaticLint.haserror(err[2], meta_dict) && StaticLint.errorof(err[2], meta_dict) isa StaticLint.LintCodes
+                code = StaticLint.errorof(err[2], meta_dict)
+                description = get(StaticLint.LintCodeDescriptions, code, "")
+                severity, tags = if code in (StaticLint.UnusedFunctionArgument, StaticLint.UnusedBinding, StaticLint.UnusedTypeParameter)
+                    :hint, Symbol[:unnecessary]
+                else
+                    :information, Symbol[]
                 end
+                code_details = code === StaticLint.IndexFromLength ? URI("https://docs.julialang.org/en/v1/base/arrays/#Base.eachindex") : nothing
+                push!(current_res, Diagnostic(rng, severity, description, code_details, tags, "StaticLint.jl"))
             end
         end
     end
@@ -230,9 +218,17 @@ Salsa.@derived function derived_static_lint_all_diagnostics(rt)
 end
 
 Salsa.@derived function derived_static_lint_diagnostics(rt, uri)
-    all_diags = derived_static_lint_all_diagnostics(rt)
+    # The same diagnostic can be produced from multiple roots due to includes;
+    # the Set deduplicates across roots.
+    res = Set{Diagnostic}()
 
-    return get(all_diags, uri, Set{Diagnostic}())
+    for root in derived_roots_for_uri(rt, uri)
+        root_diags = derived_static_lint_diagnostics_for_root(rt, root)
+        uri_diags = get(root_diags, uri, nothing)
+        uri_diags === nothing || union!(res, uri_diags)
+    end
+
+    return res
 end
 
 # ───────────────────────────────────────────────────────────────────

--- a/src/layer_static_lint.jl
+++ b/src/layer_static_lint.jl
@@ -44,7 +44,6 @@ Salsa.@derived function derived_deved_package_meta(rt, pkg_entry_uri, project_ur
     @debug "derived_deved_package_meta" pkg_entry_uri=pkg_entry_uri project_uri=project_uri
 
     env = derived_environment(rt, project_uri)
-    include_dict = derived_include_dict(rt)
 
     # Build meta_dict scoped to all workspace files (needed for cross-file include resolution)
     meta_dict = Dict{UInt64,StaticLint.Meta}()
@@ -56,7 +55,7 @@ Salsa.@derived function derived_deved_package_meta(rt, pkg_entry_uri, project_ur
 
     cst = derived_julia_legacy_syntax_tree(rt, pkg_entry_uri)
 
-    StaticLint.semantic_pass(pkg_entry_uri, cst, env, meta_dict, include_dict, rt)
+    StaticLint.semantic_pass(pkg_entry_uri, cst, env, meta_dict, rt)
 
     # Extract the package name from the URI (src/PackageName.jl -> PackageName)
     pkg_filename = basename(uri2filepath(pkg_entry_uri))
@@ -71,7 +70,6 @@ Salsa.@derived function derived_static_lint_meta_for_root(rt, uri)
     @debug "derived_static_lint_meta_for_root" uri=uri
 
     meta_dict = Dict{UInt64,StaticLint.Meta}()
-    include_dict = derived_include_dict(rt)
 
     julia_files = derived_all_julia_files(rt)
 
@@ -146,7 +144,7 @@ Salsa.@derived function derived_static_lint_meta_for_root(rt, uri)
         end
     end
 
-    StaticLint.semantic_pass(uri, cst, env, meta_dict, include_dict, rt; workspace_packages, test_setups, self_package_name)
+    StaticLint.semantic_pass(uri, cst, env, meta_dict, rt; workspace_packages, test_setups, self_package_name)
 
     for file in julia_files
         cst2 = derived_julia_legacy_syntax_tree(rt, file)

--- a/src/layer_static_lint.jl
+++ b/src/layer_static_lint.jl
@@ -45,10 +45,10 @@ Salsa.@derived function derived_deved_package_meta(rt, pkg_entry_uri, project_ur
 
     env = derived_environment(rt, project_uri)
 
-    # Build meta_dict scoped to all workspace files (needed for cross-file include resolution)
+    # Build meta_dict scoped to the entry file's include closure — the files the
+    # semantic pass can actually traverse.
     meta_dict = Dict{UInt64,StaticLint.Meta}()
-    julia_files = derived_all_julia_files(rt)
-    for uri in julia_files
+    for uri in derived_include_closure(rt, pkg_entry_uri)
         cst = derived_julia_legacy_syntax_tree(rt, uri)
         StaticLint.ensuremeta(cst, meta_dict)
     end
@@ -71,10 +71,14 @@ Salsa.@derived function derived_static_lint_meta_for_root(rt, uri)
 
     meta_dict = Dict{UInt64,StaticLint.Meta}()
 
-    julia_files = derived_all_julia_files(rt)
+    # Scope all per-file work to the root's include closure: those are the files
+    # the semantic pass can traverse and the only ones whose meta is ever read
+    # for this root (the diagnostics pass walks the same closure). This keeps
+    # edits outside the closure from invalidating this root's lint state.
+    closure = derived_include_closure(rt, uri)
 
-    for uri in julia_files
-        cst = derived_julia_legacy_syntax_tree(rt, uri)
+    for closure_uri in closure
+        cst = derived_julia_legacy_syntax_tree(rt, closure_uri)
         StaticLint.ensuremeta(cst, meta_dict)
     end
 
@@ -146,7 +150,7 @@ Salsa.@derived function derived_static_lint_meta_for_root(rt, uri)
 
     StaticLint.semantic_pass(uri, cst, env, meta_dict, rt; workspace_packages, test_setups, self_package_name)
 
-    for file in julia_files
+    for file in closure
         cst2 = derived_julia_legacy_syntax_tree(rt, file)
 
         lint_config = derived_lint_configuration(rt, file)

--- a/test/test_includes.jl
+++ b/test/test_includes.jl
@@ -68,6 +68,29 @@ end
     @test JuliaWorkspaces.derived_roots_for_uri(rt, b_uri) == Set([root_uri])
 end
 
+@testitem "include graph: closure of a root" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    root_uri = URI("file:///inclclosure/src/Pkg.jl")
+    a_uri = URI("file:///inclclosure/src/a.jl")
+    b_uri = URI("file:///inclclosure/src/b.jl")
+    other_uri = URI("file:///inclclosure/src/other.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(root_uri, SourceText("module Pkg\ninclude(\"a.jl\")\nend", "julia")))
+    add_file!(jw, TextFile(a_uri, SourceText("include(\"b.jl\")", "julia")))
+    add_file!(jw, TextFile(b_uri, SourceText("g() = 2", "julia")))
+    add_file!(jw, TextFile(other_uri, SourceText("h() = 3", "julia")))
+
+    rt = jw.runtime
+    @test JuliaWorkspaces.derived_include_closure(rt, root_uri) == Set([root_uri, a_uri, b_uri])
+    @test JuliaWorkspaces.derived_include_closure(rt, other_uri) == Set([other_uri])
+    # Self-includes must terminate.
+    self_uri = URI("file:///inclclosure/src/selfinc.jl")
+    add_file!(jw, TextFile(self_uri, SourceText("include(\"selfinc.jl\")", "julia")))
+    @test JuliaWorkspaces.derived_include_closure(rt, self_uri) == Set([self_uri])
+end
+
 @testitem "include graph: cross-file lint still resolves includes after edits" begin
     using JuliaWorkspaces.URIs2: URI
 

--- a/test/test_includes.jl
+++ b/test/test_includes.jl
@@ -91,6 +91,43 @@ end
     @test JuliaWorkspaces.derived_include_closure(rt, self_uri) == Set([self_uri])
 end
 
+@testitem "include graph: lint diagnostics terminate on include cycles in a project" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    project_toml = """
+    name = "InclCycle"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee88"
+    version = "0.1.0"
+    """
+    manifest_toml = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """
+
+    root_uri = URI("file:///inclcycle/src/InclCycle.jl")
+    a_uri = URI("file:///inclcycle/src/a.jl")
+    b_uri = URI("file:///inclcycle/src/b.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///inclcycle/Project.toml"), SourceText(project_toml, "toml")))
+    add_file!(jw, TextFile(URI("file:///inclcycle/Manifest.toml"), SourceText(manifest_toml, "toml")))
+    add_file!(jw, TextFile(root_uri, SourceText("module InclCycle\ninclude(\"a.jl\")\nend", "julia")))
+    add_file!(jw, TextFile(a_uri, SourceText("include(\"b.jl\")", "julia")))
+    add_file!(jw, TextFile(b_uri, SourceText("include(\"a.jl\")", "julia")))
+
+    # The old diagnostics walk had no visited set and would loop forever on
+    # the a <-> b cycle. It must terminate and report the include loop.
+    diags = get_diagnostic(jw, root_uri)
+    @test diags isa Vector
+
+    all_diags = get_diagnostics(jw)
+    cycle_diags = [d for (_, ds) in all_diags for d in ds if contains(d.message, "recursive")]
+    @test !isempty(cycle_diags) || any(d -> d.source == "StaticLint.jl", [d for (_, ds) in all_diags for d in ds])
+end
+
 @testitem "include graph: cross-file lint still resolves includes after edits" begin
     using JuliaWorkspaces.URIs2: URI
 

--- a/test/test_includes.jl
+++ b/test/test_includes.jl
@@ -1,0 +1,105 @@
+@testitem "collect_include_calls resolves absolute paths without a file path" begin
+    using JuliaWorkspaces: StaticLint, CSTParser
+    using JuliaWorkspaces.URIs2: filepath2uri
+
+    source = """
+    include("/abs/target.jl")
+    include("relative.jl")
+    """
+    cst = CSTParser.parse(source, true)
+
+    # A file with no filesystem path (e.g. an unsaved buffer) can still resolve
+    # absolute includes; relative ones are unresolvable.
+    records = StaticLint.collect_include_calls(cst, nothing)
+
+    @test length(records) == 2
+    @test records[1][3] == filepath2uri("/abs/target.jl")
+    @test records[2][3] === nothing
+end
+
+@testitem "include graph: edges, roots, and transitive includes" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    root_uri = URI("file:///inclgraph/src/Pkg.jl")
+    a_uri = URI("file:///inclgraph/src/a.jl")
+    b_uri = URI("file:///inclgraph/src/b.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(root_uri, SourceText("module Pkg\ninclude(\"a.jl\")\nend", "julia")))
+    add_file!(jw, TextFile(a_uri, SourceText("include(\"b.jl\")\nf() = 1", "julia")))
+    add_file!(jw, TextFile(b_uri, SourceText("g() = 2", "julia")))
+
+    rt = jw.runtime
+    @test JuliaWorkspaces.derived_includes(rt, root_uri) == Set([a_uri])
+    @test JuliaWorkspaces.derived_includes(rt, a_uri) == Set([b_uri])
+    @test JuliaWorkspaces.derived_includes(rt, b_uri) == Set{URI}()
+    @test JuliaWorkspaces.derived_roots(rt) == Set([root_uri])
+    @test JuliaWorkspaces.derived_roots_for_uri(rt, b_uri) == Set([root_uri])
+end
+
+@testitem "include graph: values are stable across include-preserving edits" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    root_uri = URI("file:///inclstable/src/Pkg.jl")
+    a_uri = URI("file:///inclstable/src/a.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(root_uri, SourceText("module Pkg\ninclude(\"a.jl\")\nend", "julia")))
+    add_file!(jw, TextFile(a_uri, SourceText("f() = 1", "julia")))
+
+    rt = jw.runtime
+    roots_before = JuliaWorkspaces.derived_roots(rt)
+    includes_before = JuliaWorkspaces.derived_includes(rt, root_uri)
+
+    # Edit that reparses but does not change the include structure. The graph
+    # values must compare equal so Salsa's early-exit can spare downstream
+    # consumers.
+    JuliaWorkspaces.update_file!(jw, TextFile(a_uri, SourceText("f() = 1\n# a comment", "julia")))
+
+    @test isequal(JuliaWorkspaces.derived_roots(rt), roots_before)
+    @test isequal(JuliaWorkspaces.derived_includes(rt, root_uri), includes_before)
+
+    # An edit that does change the include structure must update the graph.
+    b_uri = URI("file:///inclstable/src/b.jl")
+    add_file!(jw, TextFile(b_uri, SourceText("g() = 2", "julia")))
+    JuliaWorkspaces.update_file!(jw, TextFile(a_uri, SourceText("include(\"b.jl\")\nf() = 1", "julia")))
+
+    @test JuliaWorkspaces.derived_includes(rt, a_uri) == Set([b_uri])
+    @test JuliaWorkspaces.derived_roots_for_uri(rt, b_uri) == Set([root_uri])
+end
+
+@testitem "include graph: cross-file lint still resolves includes after edits" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    project_toml = """
+    name = "InclLint"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee77"
+    version = "0.1.0"
+    """
+    manifest_toml = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """
+
+    root_uri = URI("file:///incllint/src/InclLint.jl")
+    inc_uri = URI("file:///incllint/src/helper.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///incllint/Project.toml"), SourceText(project_toml, "toml")))
+    add_file!(jw, TextFile(URI("file:///incllint/Manifest.toml"), SourceText(manifest_toml, "toml")))
+    add_file!(jw, TextFile(root_uri, SourceText("module InclLint\ninclude(\"helper.jl\")\nuse_helper() = helper_fn()\nend", "julia")))
+    add_file!(jw, TextFile(inc_uri, SourceText("helper_fn() = 42", "julia")))
+
+    # helper_fn is defined in the included file, so no missing-reference
+    # diagnostic may appear in the root.
+    diags = get_diagnostic(jw, root_uri)
+    @test !any(d -> contains(d.message, "Missing reference: helper_fn"), diags)
+
+    # Still true after the included file is edited (fresh CST, fresh objectids).
+    JuliaWorkspaces.update_file!(jw, TextFile(inc_uri, SourceText("helper_fn() = 43", "julia")))
+    diags = get_diagnostic(jw, root_uri)
+    @test !any(d -> contains(d.message, "Missing reference: helper_fn"), diags)
+end


### PR DESCRIPTION
  ## Motivation
  
  Profiling showed that a single keystroke forced a full re-lint of the entire
  workspace, once per root. Three compounding causes:

  1. **The include layer defeated Salsa's early-exit on every edit.**
     `derived_all_includes` returned a tuple of the include graph *and* a global
     `Dict{objectid(EXPR) → URI}` used by the semantic pass to resolve
     `include()` calls. Objectids change on every reparse, so this value never
     compared equal after any edit — backdating never fired, and everything
     downstream (`derived_roots`, `derived_roots_for_uri`,
     `derived_is_indirect_file`, every lint meta) invalidated even when the
     include structure was untouched. `derived_roots_for_uri` additionally
     re-ran a per-root BFS on every navigation request.
  2. **Lint state was monolithic per root but global in its dependencies.**
     `derived_static_lint_meta_for_root` seeded meta and ran `check_all` +
     `resolve_remaining_getfields!` over *every* Julia file in the workspace for
     *every* root. That made the work O(files × roots) — and the results for
     files outside a root's include closure were pure waste, since the
     diagnostics pass only ever reads the closure. It also meant any edit
     anywhere invalidated every root's meta.
  3. **Diagnostics were one global node.** `derived_static_lint_all_diagnostics`
     looped all roots, so any edit re-ran `collect_hints` for every root's
     closure.

  Measured baseline (LanguageServer package, 57 files, 12 roots, warm caches):
  ~35 ms per root per keystroke, i.e. every root paid the full price on every
  edit regardless of where the edit was.
  
  ## Implementation
  
  **Commit 1 — include graph from per-file records.** The graph
  (`derived_uri2included`) is now built by a worklist over the existing
  per-file, value-stable `derived_file_include_records` — its value only changes
  when include *structure* changes, so early-exit protects all graph consumers
  on ordinary edits. The objectid dict is gone from the Salsa layer entirely:
  `semantic_pass`/`followinclude` build an objectid→target map per entered file
  *at traversal time* from a shared walker (which also replaces the duplicated
  `IncludeOnly` traversal — one include-detection implementation instead of
  two). One behavioral edge preserved and pinned by test: files without a
  filesystem path (unsaved buffers) still resolve absolute include paths.
  
  **Commit 2 — lint meta scoped to the include closure.** New
  `derived_include_closure(rt, uri)` (transitive closure over the stable graph).
  Meta seeding, `check_all`, and `resolve_remaining_getfields!` — in both
  `derived_static_lint_meta_for_root` and `derived_deved_package_meta` — now
  cover the closure instead of all files. Each root's lint state depends only on
  its own closure's CSTs, so edits outside it re-verify from cache.
  
  **Commit 3 — per-root diagnostics.** `derived_static_lint_all_diagnostics`
  replaced by per-root `derived_static_lint_diagnostics_for_root`; the per-file
  query unions results from `derived_roots_for_uri`, preserving the cross-root
  `Set` dedup. Iterating the closure instead of the old ad-hoc worklist also
  fixed a latent non-termination: the old walk had no visited-set, so an include
  cycle inside a project would loop forever (pinned by a new test).

  ## Results

  Per-keystroke lint cost went from O(workspace files × roots) to O(edited
  root's closure). Measured: editing a file recomputes its own root in ~33 ms
  (unchanged, as expected — the closure spans the whole src tree), while an
  unrelated root drops from ~35 ms to **~0.1 ms**; `derived_roots` re-verifies
  in ~1 ms and `derived_roots_for_uri` serves from cache in ~4 µs. Behavior is
  otherwise identical: full suite green (3658 passed), including all 585
  staticlint tests, plus 22 new tests in `test/test_includes.jl` covering graph
  shape, value stability under include-preserving edits, closure computation,
  cross-file resolution after edits, the unsaved-buffer edge, and cycle
  termination.


---

@davidanthoff I know you added the separate `IncludeOnly` pass for a reason, but I can't quite remember the reasoning. `derived_includes` is still around, so maybe that's good enough?