### PR TITLE
feat(parser): add JuliaSyntax -> CSTParser compatibility layer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 TestItemDetection = "1.1"
-JuliaSyntax = "0.4, 1"
+JuliaSyntax = "1"
 SHA = "<0.0.1, 0.7, 1"
 REPL = "<0.0.1, 1"
 LibGit2 = "<0.0.1, 1"

--- a/docs/superpowers/plans/2026-07-06-juliasyntax-cst-converter.md
+++ b/docs/superpowers/plans/2026-07-06-juliasyntax-cst-converter.md
@@ -1,0 +1,1380 @@
+# JuliaSyntax → CSTParser.EXPR Converter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `CSTConversion.build_cst`, which produces CSTParser-compatible `EXPR` trees from a JuliaSyntax parse, so JuliaWorkspaces parses each buffer exactly once and CSTParser's parser (and eventually the dependency) can be dropped.
+
+**Architecture:** A two-pass converter over JuliaSyntax's lossless `GreenNode` tree: pass 1 flattens tokens and folds trailing trivia into per-token `fullspan`s (matching CSTParser's trivia model); pass 2 recursively assembles `EXPR` nodes, computing spans from absolute leaf positions and re-shaping each syntax form into CSTParser's arg/trivia layout. Correctness is defined by an oracle — `CSTParser.parse(src, true)` — via a structural diff function, first on targeted snippets (unit tests), then on a large corpus (differential harness). Finally the Salsa layer is restructured so *both* trees derive from one `ParseStream`, which is also the seam that lets analysis layers migrate to pure JuliaSyntax trees one query-call at a time.
+
+**Tech Stack:** Julia, JuliaSyntax 0.4.10 (`GreenNode`, `ParseStream`, `Kind`), CSTParser 3.5.0 (`EXPR` as target datastructure and oracle), Salsa derived queries, TestItemRunner.
+
+## Global Constraints
+
+- Working directory for ALL git commands: `/home/pfitzseb/git/julia-vscode/scripts/packages/JuliaWorkspaces` (this package is a git submodule; never run git from the julia-vscode root).
+- Run Julia code ONLY via the julia-mcp session (`mcp__julia__julia_eval`, session env=`environments/development`). Never spawn `julia` processes and never run `Pkg.test`.
+- Never write anything under `~/.julia`. Corpus files are copied to the scratchpad first.
+- Code comments: terse, only for non-obvious constraints. Never reference this plan or spec documents in code or comments.
+- `@testitem` bodies are module-scope: `return` does NOT skip the rest — gate with `if/else` only.
+- Edit files directly with Edit/Write; no bulk-rewrite scripts over repo files.
+- All new test items are named with prefix `cst-conv:` so `JW_TEST_FILTER="cst-conv"` scopes a run to this feature.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Oracle definition (used everywhere): `CSTParser.parse(src, true)` — top-level/file mode, matching `derived_julia_legacy_syntax_tree`.
+- JuliaSyntax pin: the API used is 0.4.10 (`~/.julia/packages/JuliaSyntax/DHdTk`). CSTParser source of truth: `~/.julia/packages/CSTParser/VyV0S/src`.
+
+## Standard run commands
+
+**Fast red/green loop** (per failing snippet), via `mcp__julia__julia_eval`:
+
+```julia
+import JuliaWorkspaces
+using JuliaWorkspaces: CSTConversion
+CSTConversion.oracle_diff("a + b")   # nothing == pass; otherwise a diff-path string
+```
+
+Note: the julia-mcp session runs Revise-style with the dev'd package; if a struct definition changed (not just methods), restart via `mcp__julia__julia_restart` first.
+
+**Test-suite run** (per task, and before every commit), via `mcp__julia__julia_eval`:
+
+```julia
+withenv("JW_TEST_FILTER" => "cst-conv") do
+    include("/home/pfitzseb/git/julia-vscode/scripts/packages/JuliaWorkspaces/test/runtests.jl")
+end
+```
+
+Expected: a TestItemRunner summary with 0 failures/errors. (For the final integration task, run once with the filter empty to execute the full package suite.)
+
+**Green-tree dump** (the "look at the actual shapes" tool used in every red step):
+
+```julia
+using JuliaSyntax
+stream = JuliaSyntax.ParseStream("a + b"); JuliaSyntax.parse!(stream; rule=:all)
+show(stdout, MIME"text/plain"(), JuliaSyntax.build_tree(JuliaSyntax.GreenNode, stream), "a + b")
+# oracle side:
+using CSTParser; dump(CSTParser.parse("a + b", true), maxdepth=6)
+```
+
+## File Structure
+
+```
+src/cst_conversion/CSTConversion.jl   # module: includes, ConvertCtx, build_cst entry points
+src/cst_conversion/compare.jl         # first_tree_diff / trees_equal / oracle_diff / check_spans
+src/cst_conversion/tokens.jl          # Leaf, flatten_leaves (pass 1: trivia folding)
+src/cst_conversion/terminals.jl       # Kind→head tables, terminal_expr
+src/cst_conversion/assembly.jl        # Cursor, assemble (pass 2 core), span bookkeeping, fallback
+src/cst_conversion/forms.jl           # assemble_form: per-kind arg/trivia layout rules (grows over burn-down tasks)
+src/layer_syntax_trees.jl             # (modified, final task) single-parse Salsa queries
+test/test_cst_conversion.jl           # @testitem oracle tests, grouped per task
+test/cst_corpus.jl                    # corpus differential runner (plain module, driven via julia-mcp)
+```
+
+Design rules locked in here:
+
+- `EXPR.fullspan`/`.span` are computed **only** from absolute leaf positions in `assemble` (never via `update_span!`), so span correctness is independent of per-form layout mistakes.
+- `assemble_form` receives children **in source order** with their kinds and must return the CSTParser layout; it never touches spans.
+- Unknown kinds hit a **generic fallback** (never throw), so the corpus runner always completes and reports "unhandled kind X" statistics.
+- Everything is pure functions over `(GreenNode, source::String)` — no Salsa, no URIs — so the module is testable in isolation and reusable by CSTParser upstream later if desired.
+
+### Migration-seam design (why the final tasks look the way they do)
+
+Analysis layers never parse; they obtain trees via Salsa queries. After this plan:
+
+- `derived_julia_green_tree(rt, uri) -> (GreenNode, diagnostics, content)` — the single parse.
+- `derived_julia_syntax_tree(rt, uri) -> SyntaxNode` — built from the green tree.
+- `derived_julia_legacy_syntax_tree(rt, uri) -> EXPR` — built from the *same* green tree via `build_cst`.
+
+Migrating a layer to pure JuliaSyntax later = changing its query call from `derived_julia_legacy_syntax_tree` to `derived_julia_syntax_tree`, per call site, with both trees guaranteed to describe the same parse. Byte offsets are the shared currency between trees: `JuliaWorkspaces.get_expr1(cst, offset)` (exists, `src/layer_hover.jl:32`) on the EXPR side, `syntax_node_at` (added in Task 12) on the SyntaxNode side.
+
+---
+
+### Task 1: Branch, module scaffold, structural tree diff
+
+**Files:**
+- Create: `src/cst_conversion/CSTConversion.jl`
+- Create: `src/cst_conversion/compare.jl`
+- Modify: `src/JuliaWorkspaces.jl` (add include; find the `include("layer_syntax_trees.jl")` line and add the module include immediately before it)
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:**
+- Produces: `CSTConversion.first_tree_diff(a::EXPR, b::EXPR; path="") -> Union{Nothing,String}`; `CSTConversion.trees_equal(a, b) -> Bool`. Every later task's tests consume these.
+
+- [ ] **Step 1: Create branch**
+
+```bash
+cd /home/pfitzseb/git/julia-vscode/scripts/packages/JuliaWorkspaces
+git checkout -b sp/juliasyntax-cst-converter
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: tree diff basics" begin
+    using CSTParser
+    using JuliaWorkspaces: CSTConversion
+
+    a = CSTParser.parse("f(x) = x + 1", true)
+    b = CSTParser.parse("f(x) = x + 1", true)
+    c = CSTParser.parse("f(x) = x + 2", true)
+    d = CSTParser.parse("f(x) = x +  1", true)   # same tree, different trivia width
+
+    @test CSTConversion.trees_equal(a, b)
+    @test CSTConversion.first_tree_diff(a, b) === nothing
+    @test !CSTConversion.trees_equal(a, c)
+    @test CSTConversion.first_tree_diff(a, c) isa String
+    @test !CSTConversion.trees_equal(a, d)      # fullspans must be compared
+end
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run the test-suite command (see "Standard run commands"). Expected: FAIL/ERROR — `CSTConversion` not defined.
+
+- [ ] **Step 4: Implement module + diff**
+
+Create `src/cst_conversion/CSTConversion.jl`:
+
+```julia
+module CSTConversion
+
+using CSTParser
+using CSTParser: EXPR
+using JuliaSyntax
+using JuliaSyntax: GreenNode, Kind, @K_str, kind, haschildren, children, span
+
+include("compare.jl")
+
+end
+```
+
+Create `src/cst_conversion/compare.jl`:
+
+```julia
+# Structural equality of EXPR trees ignoring parent/meta.
+# Returns nothing when equal, else a human-readable path to the first divergence.
+function first_tree_diff(a::EXPR, b::EXPR; path::String="□")
+    if typeof(a.head) != typeof(b.head)
+        return "$path: head type $(typeof(a.head)) vs $(typeof(b.head))"
+    end
+    if a.head isa Symbol
+        a.head === b.head || return "$path: head $(a.head) vs $(b.head)"
+    else
+        d = first_tree_diff(a.head, b.head; path="$path.head")
+        d === nothing || return d
+    end
+    a.val == b.val || return "$path: val $(repr(a.val)) vs $(repr(b.val))"
+    a.fullspan == b.fullspan || return "$path: fullspan $(a.fullspan) vs $(b.fullspan)"
+    a.span == b.span || return "$path: span $(a.span) vs $(b.span)"
+    for (field, fa, fb) in ((:args, a.args, b.args), (:trivia, a.trivia, b.trivia))
+        (fa === nothing) == (fb === nothing) || return "$path: $field nothing-ness differs"
+        fa === nothing && continue
+        length(fa) == length(fb) || return "$path: $field length $(length(fa)) vs $(length(fb))"
+        for i in eachindex(fa)
+            d = first_tree_diff(fa[i], fb[i]; path="$path.$field[$i]")
+            d === nothing || return d
+        end
+    end
+    return nothing
+end
+
+trees_equal(a::EXPR, b::EXPR) = first_tree_diff(a, b) === nothing
+```
+
+Modify `src/JuliaWorkspaces.jl`: directly above `include("layer_syntax_trees.jl")` add:
+
+```julia
+include("cst_conversion/CSTConversion.jl")
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run the test-suite command. Expected: PASS (the one new testitem, 5 assertions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cst_conversion src/JuliaWorkspaces.jl test/test_cst_conversion.jl
+git commit -m "feat: CSTConversion module with structural EXPR diff"
+```
+
+---
+
+### Task 2: Leaf pass — token flattening with trivia folding
+
+**Files:**
+- Create: `src/cst_conversion/tokens.jl`
+- Modify: `src/cst_conversion/CSTConversion.jl` (add `include("tokens.jl")` after `include("compare.jl")`)
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:**
+- Produces: `struct Leaf{kind::Kind, pos::Int, span::Int, fullspan::Int}` (pos is absolute, 1-based); `flatten_leaves(green::GreenNode, source::AbstractString) -> (Vector{Leaf}, Int)` where the `Int` is file-leading trivia bytes; `is_ws_trivia(k::Kind) -> Bool`. Task 4's `Cursor` consumes `Vector{Leaf}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: leaf flattening" begin
+    using JuliaSyntax
+    using JuliaSyntax: @K_str
+    using JuliaWorkspaces: CSTConversion
+
+    function leaves_of(src)
+        stream = JuliaSyntax.ParseStream(src)
+        JuliaSyntax.parse!(stream; rule=:all)
+        green = JuliaSyntax.build_tree(JuliaSyntax.GreenNode, stream)
+        CSTConversion.flatten_leaves(green, src)
+    end
+
+    # "x + 1" → tokens x,+,1 ; ws folded into preceding token's fullspan
+    ls, leading = leaves_of("x + 1")
+    @test leading == 0
+    @test [l.kind for l in ls] == [K"Identifier", K"+", K"Integer"]
+    @test [l.pos for l in ls] == [1, 3, 5]
+    @test [l.span for l in ls] == [1, 1, 1]
+    @test [l.fullspan for l in ls] == [2, 2, 1]
+
+    # comments are trivia too
+    ls, _ = leaves_of("x # hi\ny")
+    @test [l.kind for l in ls] == [K"Identifier", K"Identifier"]
+    @test ls[1].fullspan == 7     # "x # hi\n"
+    @test ls[2].pos == 8
+
+    # file-leading trivia is reported separately
+    ls, leading = leaves_of("  x")
+    @test leading == 2
+    @test ls[1].pos == 3
+
+    # invariant: leaves tile the file
+    for src in ["f(a; b=1) do x\n  x\nend", "\"str\\n\" * `cmd`", ""]
+        ls, lead = leaves_of(src)
+        @test lead + sum(l -> l.fullspan, ls; init=0) == sizeof(src)
+    end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the test-suite command. Expected: FAIL — `flatten_leaves` not defined.
+
+- [ ] **Step 3: Implement**
+
+Create `src/cst_conversion/tokens.jl`:
+
+```julia
+struct Leaf
+    kind::Kind
+    pos::Int       # absolute first byte, 1-based
+    span::Int      # bytes of the token itself
+    fullspan::Int  # span + trailing trivia bytes
+end
+
+is_ws_trivia(k::Kind) = k == K"Whitespace" || k == K"NewlineWs" || k == K"Comment"
+
+# Flattens the green tree into non-trivia tokens, folding each trivia token's
+# width into the preceding token's fullspan (CSTParser's trivia model).
+function flatten_leaves(green::GreenNode, source::AbstractString)
+    leaves = Leaf[]
+    leading = _flatten!(leaves, 0, green, 1)[2]
+    return leaves, leading
+end
+
+function _flatten!(leaves::Vector{Leaf}, leading::Int, node::GreenNode, pos::Int)
+    if !haschildren(node)
+        w = Int(span(node))
+        if is_ws_trivia(kind(node))
+            if isempty(leaves)
+                leading += w
+            else
+                l = leaves[end]
+                leaves[end] = Leaf(l.kind, l.pos, l.span, l.fullspan + w)
+            end
+        else
+            push!(leaves, Leaf(kind(node), pos, w, w))
+        end
+        return pos + w, leading
+    end
+    for c in children(node)
+        pos, leading = _flatten!(leaves, leading, c, pos)
+    end
+    return pos, leading
+end
+```
+
+Add `include("tokens.jl")` to `CSTConversion.jl` after the compare include.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the test-suite command. Expected: PASS. If the token kinds differ from the test's expectation (e.g. `K"+"` spelled differently in 0.4.10), use the green-tree dump command to see actual kinds and fix the *test* to match reality — the invariants (positions, tiling) are the contract.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cst_conversion test/test_cst_conversion.jl
+git commit -m "feat: green-tree leaf flattening with trivia folding"
+```
+
+---
+
+### Task 3: Terminal EXPR construction, `:file` assembly, `build_cst` entry
+
+**Files:**
+- Create: `src/cst_conversion/terminals.jl`
+- Modify: `src/cst_conversion/CSTConversion.jl` (include + export `build_cst`, add `oracle_diff` to compare.jl)
+- Modify: `src/cst_conversion/compare.jl` (add `oracle_diff`)
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:**
+- Consumes: `Leaf`, `flatten_leaves` (Task 2).
+- Produces: `terminal_expr(leaf::Leaf, source::String) -> EXPR`; `build_cst(source::AbstractString) -> EXPR` and `build_cst(green::GreenNode, source::AbstractString) -> EXPR` (temporary flat implementation, replaced by Task 4's recursion); `oracle_diff(src::AbstractString) -> Union{Nothing,String}` — THE assertion helper for all later tasks.
+
+- [ ] **Step 1: Read the authoritative head tables**
+
+Read `~/.julia/packages/CSTParser/VyV0S/src/spec.jl` — specifically `literalmap` (~line 287) and `tokenkindtoheadmap` — and note the exact Symbol each Tokenize kind maps to (`:IDENTIFIER`, `:INTEGER`, `:FLOAT`, `:STRING`, `:CHAR`, `:TRUE`, `:FALSE`, keyword and punctuation heads, `:OPERATOR`). The `TERMINAL_HEADS` table in Step 4 must mirror these, keyed by JuliaSyntax `Kind` instead of Tokenize kind.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: terminals via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in ["x", "1", "1.5", "0x1f", "0b101", "0o17", "true", "false",
+                "'a'", "\"str\"", "x ", "  x", "# only a comment", ""]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run the test-suite command. Expected: FAIL — `oracle_diff` not defined.
+
+- [ ] **Step 4: Implement**
+
+Append to `src/cst_conversion/compare.jl`:
+
+```julia
+# Compare converter output against CSTParser for the same source.
+oracle_diff(src::AbstractString) = first_tree_diff(build_cst(src), CSTParser.parse(src, true))
+```
+
+Create `src/cst_conversion/terminals.jl` (fill `TERMINAL_HEADS` from Step 1's reading; the entries below are the shape, not the complete table):
+
+```julia
+# Mirrors CSTParser's literalmap/tokenkindtoheadmap, keyed by JuliaSyntax kind.
+const TERMINAL_HEADS = Dict{Kind,Symbol}(
+    K"Identifier" => :IDENTIFIER,
+    K"Integer"    => :INTEGER,
+    K"Float"      => :FLOAT,
+    K"HexInt"     => :HEXINT,
+    K"BinInt"     => :BININT,
+    K"OctInt"     => :OCTINT,
+    K"Char"       => :CHAR,
+    K"String"     => :STRING,
+    K"true"       => :TRUE,
+    K"false"      => :FALSE,
+    # ... complete from CSTParser's tables during red/green iteration
+)
+
+token_text(leaf::Leaf, source::String) = source[leaf.pos:prevind(source, leaf.pos + leaf.span)]
+
+function terminal_expr(leaf::Leaf, source::String)
+    k = leaf.kind
+    if JuliaSyntax.is_operator(k)
+        return EXPR(:OPERATOR, leaf.fullspan, leaf.span, token_text(leaf, source))
+    elseif JuliaSyntax.is_keyword(k)
+        return EXPR(Symbol(uppercase(string(k))), leaf.fullspan, leaf.span, nothing)
+    elseif haskey(TERMINAL_HEADS, k)
+        return EXPR(TERMINAL_HEADS[k], leaf.fullspan, leaf.span, token_text(leaf, source))
+    else
+        return EXPR(punctuation_head(k), leaf.fullspan, leaf.span, nothing)
+    end
+end
+
+# Mirrors tokenkindtoheadmap's punctuation entries; extend as kinds show up
+# in oracle diffs (unmapped kinds fail loudly with a KeyError, which is wanted
+# during burn-down — the corpus runner catches and reports it).
+const PUNCTUATION_HEADS = Dict{Kind,Symbol}(
+    K"(" => :LPAREN,   K")" => :RPAREN,
+    K"[" => :LSQUARE,  K"]" => :RSQUARE,
+    K"{" => :LBRACE,   K"}" => :RBRACE,
+    K"," => :COMMA,    K";" => :SEMICOLON,
+    K"@" => :ATSIGN,   K"." => :DOT,
+)
+punctuation_head(k::Kind) = PUNCTUATION_HEADS[k]
+```
+
+Add a temporary `build_cst` to `CSTConversion.jl` (replaced in Task 4) that handles only single-token-or-empty files, plus the entry point:
+
+```julia
+function build_cst(source::AbstractString)
+    stream = JuliaSyntax.ParseStream(source; version=VERSION)
+    JuliaSyntax.parse!(stream; rule=:all)
+    build_cst(JuliaSyntax.build_tree(GreenNode, stream), source)
+end
+
+function build_cst(green::GreenNode, source::AbstractString)
+    leaves, leading = flatten_leaves(green, source)
+    file = EXPR(:file, EXPR[], nothing, 0, 0)
+    for leaf in leaves
+        push!(file, terminal_expr(leaf, String(source)))  # CSTParser extends Base.push! with span updates
+    end
+    attach_leading!(file, leading)
+    return file
+end
+
+# Default rule: leading file trivia widens the first token's fullspan.
+# Step 5's oracle dump decides whether this or a file-level attachment is
+# what CSTParser actually does — fix here if the "  x" oracle test diffs.
+function attach_leading!(file::EXPR, leading::Int)
+    leading == 0 && return file
+    if file.args !== nothing && !isempty(file.args)
+        file.args[1].fullspan += leading
+    end
+    file.fullspan += leading
+    return file
+end
+```
+
+- [ ] **Step 5: Pin the leading-trivia and val conventions against the oracle**
+
+The two conventions this task must discover empirically (do this BEFORE guessing at `attach_leading!`):
+
+```julia
+using CSTParser
+dump(CSTParser.parse("  x", true), maxdepth=3)              # where do 2 leading bytes go?
+dump(CSTParser.parse("# only a comment", true), maxdepth=3) # file with no tokens at all
+dump(CSTParser.parse("\"str\"", true), maxdepth=4)           # is val quoted source text or unescaped?
+dump(CSTParser.parse("0x1f", true), maxdepth=3)              # literal val formatting
+```
+
+Encode exactly what the oracle shows: `attach_leading!` implements the observed rule (wherever CSTParser puts leading bytes — typically widening the first child's fullspan or the file node itself); string/char/number `val`s match the observed convention (adjust `terminal_expr` for kinds whose val is not the raw token text).
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run the fast-loop `oracle_diff` on each snippet, then the test-suite command. Expected: PASS for all 14 snippets. Any remaining diff string tells you the exact path and field to fix.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cst_conversion test/test_cst_conversion.jl
+git commit -m "feat: terminal EXPR construction with oracle-pinned conventions"
+```
+
+---
+
+### Task 4: Recursive assembly core + first structural forms
+
+**Files:**
+- Create: `src/cst_conversion/assembly.jl`
+- Create: `src/cst_conversion/forms.jl`
+- Modify: `src/cst_conversion/CSTConversion.jl` (includes; replace temporary `build_cst(green, source)`)
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:**
+- Consumes: `Leaf`, `flatten_leaves`, `terminal_expr`, `is_ws_trivia`.
+- Produces: `mutable struct Cursor{leaves::Vector{Leaf}, i::Int, src::String}`; `assemble(node::GreenNode, cur::Cursor) -> EXPR` (spans computed here, universally); `assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vector{Kind}, cur::Cursor) -> EXPR` (layout only — every burn-down task adds branches here); `generic_form(k, kids, kkinds) -> EXPR` fallback. `UNHANDLED_KINDS::Set{Kind}` populated by the fallback (read by the corpus runner).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: core forms via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "a = 1",                 # binary syntax: op is the EXPR head
+        "a + b",                 # infix call: op moves to args[1]
+        "a + b + c",             # chained infix
+        "a * b",
+        "a == b",
+        "(a)",                   # brackets with paren trivia
+        "begin\na\nend",         # block with keyword trivia
+        "a\nb\nc",               # multi-expression file
+        "a; b",
+        "f(x)",                  # prefix call
+        "f()",
+        "f(x, y)",               # comma trivia
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the test-suite command. Expected: FAIL — multi-token sources hit the Task 3 flat `build_cst` (or `assemble` not defined once you start replacing it).
+
+- [ ] **Step 3: Implement the assembly core**
+
+Create `src/cst_conversion/assembly.jl`:
+
+```julia
+mutable struct Cursor
+    leaves::Vector{Leaf}
+    i::Int
+    src::String
+end
+
+const UNHANDLED_KINDS = Set{Kind}()
+
+function assemble(node::GreenNode, cur::Cursor)::EXPR
+    if !haschildren(node)
+        leaf = cur.leaves[cur.i]
+        cur.i += 1
+        return terminal_expr(leaf, cur.src)
+    end
+    first_i = cur.i
+    kids = EXPR[]
+    kkinds = Kind[]
+    for c in children(node)
+        is_ws_trivia(kind(c)) && continue
+        push!(kids, assemble(c, cur))
+        push!(kkinds, kind(c))
+    end
+    ex = assemble_form(kind(node), node, kids, kkinds, cur)
+    # Spans from absolute leaf positions: independent of per-form layout.
+    if cur.i > first_i
+        first_leaf = cur.leaves[first_i]
+        last_leaf = cur.leaves[cur.i - 1]
+        ex.fullspan = (last_leaf.pos + last_leaf.fullspan) - first_leaf.pos
+        ex.span = (last_leaf.pos + last_leaf.span) - first_leaf.pos
+    end
+    return ex
+end
+
+# Fallback: args = non-token children in source order, tokens into trivia.
+# Wrong layout for anything CSTParser consumers pattern-match, but keeps the
+# corpus runner alive and counts what still needs a real rule.
+function generic_form(k::Kind, kids::Vector{EXPR}, kkinds::Vector{Kind})
+    push!(UNHANDLED_KINDS, k)
+    args = EXPR[]
+    trivia = EXPR[]
+    for (ex, ck) in zip(kids, kkinds)
+        if JuliaSyntax.is_keyword(ck) || ex.head in (:LPAREN, :RPAREN, :COMMA,
+            :LBRACE, :RBRACE, :LSQUARE, :RSQUARE, :SEMICOLON, :AT_SIGN, :DOT)
+            push!(trivia, ex)
+        else
+            push!(args, ex)
+        end
+    end
+    EXPR(Symbol(lowercase(string(k))), args, trivia, 0, 0)
+end
+```
+
+Create `src/cst_conversion/forms.jl`:
+
+```julia
+function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vector{Kind}, cur::Cursor)::EXPR
+    if k == K"toplevel"
+        return EXPR(:file, kids, nothing, 0, 0)
+    elseif k == K"call" && JuliaSyntax.is_infix_op_call(JuliaSyntax.head(node))
+        # a + b (+ c ...) → (:call, [op, a, b, c...]); extra op tokens → trivia
+        op = kids[2]
+        args = EXPR[op, kids[1]]
+        trivia = EXPR[]
+        for j in 3:length(kids)
+            if isodd(j)
+                push!(args, kids[j])
+            else
+                push!(trivia, kids[j])   # repeated ops in chained calls
+            end
+        end
+        return EXPR(:call, args, isempty(trivia) ? nothing : trivia, 0, 0)
+    elseif k == K"call"
+        # f(x, y) → (:call, [f, x, y], trivia=[lparen, commas..., rparen])
+        args = EXPR[]
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"(" || ck == K")" || ck == K","
+                push!(trivia, ex)
+            else
+                push!(args, ex)
+            end
+        end
+        return EXPR(:call, args, trivia, 0, 0)
+    elseif k == K"=" && length(kids) == 3
+        # binary syntax: operator EXPR becomes the head
+        return EXPR(kids[2], EXPR[kids[1], kids[3]], nothing, 0, 0)
+    elseif k == K"block"
+        args = EXPR[]
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == K"begin" || ck == K"end" || ck == K";") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:block, args, isempty(trivia) ? nothing : trivia, 0, 0)
+    elseif k == K"parens"
+        trivia = EXPR[kids[1], kids[end]]
+        return EXPR(:brackets, kids[2:end-1], trivia, 0, 0)
+    end
+    return generic_form(k, kids, kkinds)
+end
+```
+
+Replace the Task 3 `build_cst(green, source)` in `CSTConversion.jl`:
+
+```julia
+function build_cst(green::GreenNode, source::AbstractString)
+    src = String(source)
+    leaves, leading = flatten_leaves(green, src)
+    cur = Cursor(leaves, 1, src)
+    ex = assemble(green, cur)
+    if headof(ex) !== :file
+        ex = EXPR(:file, EXPR[ex], nothing, ex.fullspan, ex.span)
+    end
+    attach_leading!(ex, leading)
+    return ex
+end
+```
+
+(`headof` comes from CSTParser; add `using CSTParser: headof` to the module.)
+
+- [ ] **Step 4: Iterate red/green per snippet**
+
+For each still-failing snippet, run the green-tree dump and oracle dump side by side, then fix the corresponding `assemble_form` branch. Expected end state: all 12 snippets return `nothing` from `oracle_diff`. Layout details this step is expected to correct against the oracle: whether `:file` wraps single expressions, exact trivia ordering in chained infix calls, where semicolons go in blocks, and the JuliaSyntax 0.4.10 kind for parenthesized expressions (dump `"(a)"` to see whether it is `K"parens"` or flag-based — adjust the branch to the real kind).
+
+- [ ] **Step 5: Run full cst-conv suite, verify Tasks 1–3 still pass**
+
+Run the test-suite command. Expected: PASS, 0 failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cst_conversion test/test_cst_conversion.jl
+git commit -m "feat: recursive EXPR assembly with core form layouts"
+```
+
+---
+
+### Task 5: Span invariant checker + corpus differential runner
+
+**Files:**
+- Modify: `src/cst_conversion/compare.jl` (add `check_spans`)
+- Create: `test/cst_corpus.jl`
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:**
+- Consumes: `build_cst`, `first_tree_diff`, `UNHANDLED_KINDS`.
+- Produces: `check_spans(x::EXPR) -> Union{Nothing,String}` (violated invariant description); `CSTCorpus.run_corpus(files::Vector{String}; report_path::String) -> NamedTuple{(:total,:passed,:failed,:errored)}` writing a markdown report grouped by diff signature. Tasks 6–11 consume the report format; Task 11 consumes `check_spans`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: span invariants and corpus smoke" begin
+    using JuliaWorkspaces: CSTConversion
+    include(joinpath(@__DIR__, "cst_corpus.jl"))
+
+    # invariants hold on converter output for valid and broken code
+    for src in ["f(x) = x + 1", "function f(", "a +", ""]
+        ex = CSTConversion.build_cst(src)
+        @test ex.fullspan == sizeof(src)
+        @test CSTConversion.check_spans(ex) === nothing
+    end
+
+    # corpus runner runs end to end on this package's own test file
+    report = joinpath(mktempdir(), "report.md")
+    stats = CSTCorpus.run_corpus([@__FILE__]; report_path=report)
+    @test stats.total == 1
+    @test stats.errored == 0
+    @test isfile(report)
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run the test-suite command. Expected: FAIL — `check_spans` / `cst_corpus.jl` missing.
+
+- [ ] **Step 3: Implement**
+
+Append to `src/cst_conversion/compare.jl`:
+
+```julia
+# EXPR span bookkeeping invariants; layout-independent sanity for broken code
+# where no oracle equality is possible.
+function check_spans(x::EXPR; path::String="□")
+    x.span <= x.fullspan || return "$path: span $(x.span) > fullspan $(x.fullspan)"
+    x.args === nothing && return nothing
+    childsum = sum(c -> c.fullspan, x.args; init=0) +
+               (x.trivia === nothing ? 0 : sum(c -> c.fullspan, x.trivia; init=0)) +
+               (x.head isa EXPR ? x.head.fullspan : 0)
+    childsum == x.fullspan || return "$path: children sum $childsum != fullspan $(x.fullspan)"
+    for (i, c) in enumerate(x.args)
+        d = check_spans(c; path="$path.args[$i]")
+        d === nothing || return d
+    end
+    if x.trivia !== nothing
+        for (i, c) in enumerate(x.trivia)
+            d = check_spans(c; path="$path.trivia[$i]")
+            d === nothing || return d
+        end
+    end
+    return nothing
+end
+```
+
+Create `test/cst_corpus.jl`:
+
+```julia
+module CSTCorpus
+
+using CSTParser
+using JuliaWorkspaces: CSTConversion
+
+# One corpus file's outcome: :pass, or a diff signature for grouping.
+function check_file(path::String)
+    src = read(path, String)
+    ours = try
+        CSTConversion.build_cst(src)
+    catch err
+        return (:errored, "converter threw: $(typeof(err))")
+    end
+    oracle = try
+        CSTParser.parse(src, true)
+    catch err
+        return (:pass, nothing)   # oracle itself fails: out of scope
+    end
+    d = CSTConversion.first_tree_diff(ours, oracle)
+    d === nothing && return (:pass, nothing)
+    # signature = diff with indices stripped, so identical shapes group together
+    return (:failed, replace(d, r"\[\d+\]" => "[]", r"\d+" => "N"))
+end
+
+function run_corpus(files::Vector{String}; report_path::String)
+    empty!(CSTConversion.UNHANDLED_KINDS)
+    passed = 0; failures = Dict{String,Vector{String}}(); errors = Dict{String,Vector{String}}()
+    for f in files
+        outcome, sig = check_file(f)
+        if outcome == :pass
+            passed += 1
+        elseif outcome == :failed
+            push!(get!(Vector{String}, failures, sig), f)
+        else
+            push!(get!(Vector{String}, errors, sig), f)
+        end
+    end
+    open(report_path, "w") do io
+        total = length(files)
+        println(io, "# CST conversion corpus report\n")
+        println(io, "$passed / $total files identical to oracle\n")
+        println(io, "## Unhandled kinds\n")
+        for k in sort!(string.(collect(CSTConversion.UNHANDLED_KINDS)))
+            println(io, "- `", k, "`")
+        end
+        for (title, group) in (("Diffs", failures), ("Converter errors", errors))
+            println(io, "\n## $title\n")
+            for (sig, fs) in sort!(collect(group); by=p -> -length(p.second))
+                println(io, "- **$(length(fs))×** `$sig`\n  - e.g. `$(first(fs))`")
+            end
+        end
+    end
+    return (total=length(files), passed=passed,
+            failed=sum(length, values(failures); init=0),
+            errored=sum(length, values(errors); init=0))
+end
+
+julia_files(dir::String) = String[joinpath(r, f) for (r, _, fs) in walkdir(dir) for f in fs if endswith(f, ".jl")]
+
+end
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run the test-suite command. Expected: PASS. Note: `stats.failed` for the smoke file may be 1 at this stage — the test only asserts `errored == 0`; that is intended.
+
+- [ ] **Step 5: Baseline corpus run over this package's own source**
+
+Via `mcp__julia__julia_eval`:
+
+```julia
+include("/home/pfitzseb/git/julia-vscode/scripts/packages/JuliaWorkspaces/test/cst_corpus.jl")
+files = CSTCorpus.julia_files("/home/pfitzseb/git/julia-vscode/scripts/packages/JuliaWorkspaces/src")
+CSTCorpus.run_corpus(files; report_path="/tmp/claude-13471954/-home-pfitzseb-git-julia-vscode-scripts-packages-JuliaWorkspaces/1b3c5b3f-4373-46ef-b6f2-294a49002962/scratchpad/corpus_report.md")
+```
+
+Record the pass count in the commit message body. This report drives Tasks 6–10.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cst_conversion/compare.jl test/cst_corpus.jl test/test_cst_conversion.jl
+git commit -m "feat: span invariant checker and corpus differential runner"
+```
+
+---
+
+### Task 6: Burn-down — definitions
+
+**Files:**
+- Modify: `src/cst_conversion/forms.jl`
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:**
+- Consumes/extends: `assemble_form` (adds branches). No new names.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: definitions via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "function f() end",
+        "function f(x, y=1; z) x end",
+        "function f(x::Int)::Int x end",
+        "f(x) = x",
+        "x -> x + 1",
+        "function (x) x end",
+        "struct A end",
+        "struct A{T} <: B\n    x::T\nend",
+        "mutable struct A x end",
+        "abstract type A end",
+        "abstract type A{T} <: B end",
+        "primitive type A 8 end",
+        "macro m(x) x end",
+        "module A\nf() = 1\nend",
+        "baremodule A end",
+        "f(x::T) where T = x",
+        "f(x::T) where {T <: Number} = x",
+        "const x = 1",
+        "global x = 1",
+        "local x = 1",
+        "mutable struct A\n    const x::Int\nend",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+```
+
+- [ ] **Step 2: Run to verify failures and capture shapes**
+
+Run the test-suite command; expect several failures. For each failing snippet run the green-tree dump + oracle dump pair to see both shapes.
+
+- [ ] **Step 3: Implement `assemble_form` branches**
+
+The uniform recipe for every branch (this is the same recipe every burn-down task uses):
+
+1. Dump both trees for the failing snippet.
+2. Identify which source-order children are CSTParser `args` vs `trivia`, and their order in each vector (CSTParser stores args in `Expr`-order, which for definitions is usually signature-then-body; keywords like `function`/`end` and punctuation are trivia in source order).
+3. Add an `elseif k == K"..."` branch mapping `kids`/`kkinds` accordingly, mirroring Task 4's `K"call"` branch style.
+4. Re-run `oracle_diff(snippet)`; the diff path pinpoints any remaining field.
+
+Representative branch to write first (function definitions), matching CSTParser's `(:function, [sig, block], trivia=[FUNCTION_kw, END_kw])` layout:
+
+```julia
+    elseif k == K"function"
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == K"function" || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:function, args, trivia, 0, 0)
+```
+
+Then `K"struct"` (check `mutable` handling — the oracle dump shows whether CSTParser uses `:struct`/`:mutable` heads or a trivia keyword), `K"abstract"`, `K"primitive"`, `K"macro"`, `K"module"`, `K"where"`, `K"::"` (declaration: binary-syntax head like `=`), `K"->"`, `K"const"`, `K"global"`, `K"local"`.
+
+- [ ] **Step 4: Run test to verify all 21 snippets pass**
+
+Run the test-suite command. Expected: PASS.
+
+- [ ] **Step 5: Re-run the src/ corpus, confirm pass count increased, commit**
+
+Re-run the Task 5 Step 5 corpus command; the pass count must be ≥ the recorded baseline.
+
+```bash
+git add src/cst_conversion/forms.jl test/test_cst_conversion.jl
+git commit -m "feat: cst conversion for definition forms"
+```
+
+---
+
+### Task 7: Burn-down — call syntax in full generality
+
+**Files:**
+- Modify: `src/cst_conversion/forms.jl`
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:** extends `assemble_form` only.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: call syntax via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "f(x; y=1)",             # parameters node
+        "f(x, y=1; z=2, w)",
+        "f(x...)",
+        "f(; x)",
+        "f.(x)",                 # dotcall
+        "a.b",                   # getfield with quotenode
+        "a.b.c",
+        "a.:b",
+        "A{T}",                  # curly
+        "A{T} where T",
+        "a[1]",                  # ref
+        "a[1, 2]",
+        "a[end]",
+        "@m x y",                # macrocall
+        "@m(x)",
+        "m\"str\"",              # string macro
+        "f(x) do y\n    y\nend", # do
+        "g(f, xs) do y; y; end",
+        "x |> f",
+        "a ∘ b",
+        "f(g(x))",
+        "(f)(x)",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+```
+
+- [ ] **Step 2–4: Red/green loop per snippet, same recipe as Task 6 Step 3**
+
+Branches to add: `K"parameters"`, `K"..."` (splat), `K"dotcall"`, `K"."` (getfield — oracle shows the `:quotenode` wrapper CSTParser builds around the field name; replicate it exactly, it is what `is_getfield_w_quotenode` pattern-matches), `K"curly"`, `K"ref"`, `K"macrocall"` (macro name representation differs between the parsers — the oracle dump for `"@m x"` shows CSTParser's `[@-sign, name]` vs JuliaSyntax's fused `MacroName`; split the fused token into the two EXPRs CSTParser expects, using source text offsets from the leaf), `K"do"`, `K"string_macro"`/`K"cmd_macro"` kinds as dumped.
+
+Expected: all 22 snippets pass `oracle_diff`.
+
+- [ ] **Step 5: Corpus re-run (count must increase) + commit**
+
+```bash
+git add src/cst_conversion/forms.jl test/test_cst_conversion.jl
+git commit -m "feat: cst conversion for call syntax"
+```
+
+---
+
+### Task 8: Burn-down — control flow and containers
+
+**Files:**
+- Modify: `src/cst_conversion/forms.jl`
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:** extends `assemble_form` only.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: control flow and containers via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "if a\nb\nend",
+        "if a\nb\nelse\nc\nend",
+        "if a\nb\nelseif c\nd\nelse\ne\nend",
+        "a ? b : c",
+        "while a\nb\nend",
+        "for i in xs\ni\nend",
+        "for i = 1:10, j in ys\nend",
+        "for (a, b) in xs end",
+        "try\na\ncatch\nend",
+        "try\na\ncatch err\nb\nfinally\nc\nend",
+        "try\na\ncatch e\nb\nelse\nc\nend",
+        "let x = 1\nx\nend",
+        "let\nend",
+        "return",
+        "return x",
+        "break",
+        "continue",
+        "(a, b)",
+        "(a,)",
+        "(;a=1)",
+        "[1, 2]",
+        "[1 2]",
+        "[1 2; 3 4]",
+        "[1; 2;; 3; 4]",
+        "Int[1, 2]",
+        "[x for x in xs]",
+        "[x for x in xs if x > 0]",
+        "(x for x in xs)",
+        "[x + y for x in xs, y in ys]",
+        "Dict(a => b)",
+        "a:b",
+        "a:b:c",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+```
+
+- [ ] **Step 2–4: Red/green loop, same recipe as Task 6 Step 3**
+
+Branches: `K"if"`/`K"elseif"` (CSTParser nests elseif as a child `:elseif` with specific trivia distribution — dump `"if a\nb\nelseif c\nd\nelse\ne\nend"` carefully), `K"?"` ternary, `K"while"`, `K"for"` + `K"iteration"`/`K"in"` (the iteration spec: oracle shows whether `in`/`=` becomes an operator-headed binary or `:iteration`), `K"try"` (all 4 clause combinations in the snippets), `K"let"`, `K"return"`, `K"break"`/`K"continue"`, `K"tuple"` (incl. trailing comma and named-tuple `(;a=1)`), `K"vect"`, `K"hcat"`, `K"vcat"`, `K"row"`, `K"ncat"`/`K"nrow"`, `K"typed_vect"`/`K"typed_hcat"`, `K"comprehension"`, `K"generator"`, `K"filter"`, and range colon-calls (these are infix `K"call"`; verify the Task 4 branch covers `a:b:c`'s 5 children).
+
+Expected: all 32 snippets pass.
+
+- [ ] **Step 5: Corpus re-run (count must increase) + commit**
+
+```bash
+git add src/cst_conversion/forms.jl test/test_cst_conversion.jl
+git commit -m "feat: cst conversion for control flow and containers"
+```
+
+---
+
+### Task 9: Burn-down — strings, operators, remaining expression forms
+
+**Files:**
+- Modify: `src/cst_conversion/forms.jl`, `src/cst_conversion/terminals.jl`
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:** extends `assemble_form` and terminal tables only.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: strings and operators via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "\"a\$b c\"",            # interpolation: CSTParser splits chunks differently
+        "\"a\$(b + c)d\"",
+        "\"\"\"\ntriple \$x\n\"\"\"",
+        "`cmd \$x`",
+        "```\ncmd\n```",
+        "raw\"no \$interp\"",
+        "'\\n'",
+        "\"esc\\\"aped\"",
+        "-x",                    # unary call
+        "!x",
+        "+x",
+        "x'",                    # postfix adjoint
+        "x''",
+        "a .+ b",                # broadcast infix
+        ".!x",
+        "a && b",
+        "a || b && c",
+        "a <: B",
+        "a >: B",
+        "a === b",
+        "x...",
+        "&x",
+        "::Int",
+        "2x",                    # juxtaposition
+        "2(x + 1)",
+        "a = b = c",             # right-assoc chained assignment
+        "a += 1",
+        "a .= b",
+        "x = \"\"\"\n a\n\"\"\"",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+```
+
+- [ ] **Step 2–4: Red/green loop, same recipe as Task 6 Step 3**
+
+This group's known hard spots, each pinned by dumping both sides:
+
+- **String nodes** (`K"string"`, `K"cmdstring"`): CSTParser and JuliaSyntax split interpolated strings into different chunk sequences and CSTParser keeps quote tokens as trivia. If chunk boundaries genuinely disagree (not just layout), rebuild CSTParser's chunking from the leaf byte ranges and source text inside the `K"string"` branch — the leaves carry exact positions, so CSTParser's chunk spans can be reconstituted by re-slicing the source between the quote tokens. If a case appears where that is impossible, record it in `docs/superpowers/plans/cst-converter-divergences.md` (created in this task) instead of forcing it, and move on.
+- **Unary/postfix** (`K"call"` with `PREFIX_OP_FLAG`/`POSTFIX_OP_FLAG`): extend the Task 4 call branch using `JuliaSyntax.is_prefix_op_call`/`is_postfix_op_call`; postfix `'` in CSTParser is an operator-headed EXPR (see `update_span!`'s `is_prime` special case — head EXPR, trailing).
+- **Short-circuit** `K"&&"`/`K"||"` and comparisons-as-syntax (`<:`, `>:`, `===`?): oracle dump decides operator-head-vs-call per operator; encode exactly that.
+- **Juxtaposition** (`K"juxtapose"`): CSTParser emits an implicit `*` call; the oracle dump shows whether the synthesized `*` EXPR has zero span — replicate.
+- **Dotted ops** (`K"dotcall"` infix, `.=` as dotted assignment): distinct CSTParser layouts; dump each.
+
+Expected: all 29 snippets pass, except any recorded in the divergence log (each such test line moves into a `@test_broken` with a comment-free reference by snippet only).
+
+- [ ] **Step 5: Corpus re-run + commit**
+
+```bash
+git add src/cst_conversion test/test_cst_conversion.jl docs/superpowers/plans/cst-converter-divergences.md
+git commit -m "feat: cst conversion for strings and operator forms"
+```
+
+---
+
+### Task 10: Burn-down — imports, docstrings, full-corpus loop to zero
+
+**Files:**
+- Modify: `src/cst_conversion/forms.jl`
+- Create: `docs/superpowers/plans/cst-converter-divergences.md` (if Task 9 didn't)
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:** extends `assemble_form`. Produces the divergence decision list (USER CHECKPOINT).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: imports and docstrings via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "using A",
+        "using A, B",
+        "using A: x, y",
+        "using A.B.C",
+        "import A",
+        "import A as B",
+        "import A: x as y",
+        "import ..A",
+        "export a, b",
+        "\"\"\"\ndoc\n\"\"\"\nf(x) = x",
+        "\"doc\"\nmodule A end",
+        "@doc \"x\" f",
+        "quote\nx\nend",
+        ":(x + y)",
+        ":x",
+        "\$x",
+        "\$(x)",
+        "x where {T, S}",
+        "GC.@preserve a f(a)",
+        "if VERSION > v\"1.6\" end",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+```
+
+- [ ] **Step 2–3: Red/green loop, same recipe as Task 6 Step 3**
+
+Branches: `K"using"`/`K"import"` (with `K"importpath"`, `K":"` selective-import layout, `K"as"`), `K"export"` (and `K"public"` if the pinned JuliaSyntax emits it), `K"doc"` (docstring macrocall — CSTParser represents it as a `:macrocall` with a synthesized `@doc` name; dump to replicate), `K"quote"` (block form and `:(...)` form differ), `K"$"` interpolation, `K"braces"`/`K"bracescat"`.
+
+- [ ] **Step 4: Build the big corpus (copied, never in-place) and loop to zero**
+
+```bash
+mkdir -p /tmp/claude-13471954/-home-pfitzseb-git-julia-vscode-scripts-packages-JuliaWorkspaces/1b3c5b3f-4373-46ef-b6f2-294a49002962/scratchpad/corpus
+cp -r ~/.julia/packages /tmp/claude-13471954/-home-pfitzseb-git-julia-vscode-scripts-packages-JuliaWorkspaces/1b3c5b3f-4373-46ef-b6f2-294a49002962/scratchpad/corpus/packages
+```
+
+Then via `mcp__julia__julia_eval`:
+
+```julia
+include("/home/pfitzseb/git/julia-vscode/scripts/packages/JuliaWorkspaces/test/cst_corpus.jl")
+files = CSTCorpus.julia_files("/tmp/claude-13471954/-home-pfitzseb-git-julia-vscode-scripts-packages-JuliaWorkspaces/1b3c5b3f-4373-46ef-b6f2-294a49002962/scratchpad/corpus/packages")
+CSTCorpus.run_corpus(files; report_path=".../scratchpad/corpus_report.md")  # same scratchpad dir
+```
+
+Loop: pick the highest-count diff signature from the report → reduce one example file to a minimal snippet → add it to the nearest-themed testitem above → fix the branch → re-run corpus. Repeat until the report shows either 100% pass or only signatures caused by **genuine parser divergence** (the two parsers disagree about structure, not layout).
+
+STOP criteria for this step: (a) zero non-divergence diffs remain, AND (b) every remaining signature is written into `docs/superpowers/plans/cst-converter-divergences.md` as: snippet, both tree dumps (truncated), and a proposed resolution (converter shims it / downstream adapts / accept drift).
+
+- [ ] **Step 5: USER CHECKPOINT — commit and pause**
+
+```bash
+git add src/cst_conversion test/test_cst_conversion.jl docs/superpowers/plans/cst-converter-divergences.md
+git commit -m "feat: cst conversion for imports and docstrings; corpus at parity
+
+Corpus: <N>/<M> files identical to oracle; remaining signatures documented
+in cst-converter-divergences.md"
+```
+
+Present `cst-converter-divergences.md` to the user for decisions before Task 12's backend flip. Task 11 can proceed meanwhile.
+
+---
+
+### Task 11: Error recovery mapping
+
+**Files:**
+- Modify: `src/cst_conversion/forms.jl`, `src/cst_conversion/terminals.jl`
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:** extends `assemble_form` with `K"error"`; no oracle equality here — the contract is: never throw, spans tile the source, error subtrees are traversable.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: broken code invariants" begin
+    using CSTParser
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "function f(",
+        "a +",
+        "f(x,",
+        "if a",
+        "struct",
+        "a.b.",
+        "\"unterminated",
+        "x = @",
+        "function f() en",
+        "a ? b",
+        "[1, 2",
+        "module A function g() end",
+    ]
+        ex = CSTConversion.build_cst(src)
+        @test ex isa CSTParser.EXPR
+        @test ex.fullspan == sizeof(src)
+        @test CSTConversion.check_spans(ex) === nothing
+        # error subtrees must be traversable by StaticLint-style recursion
+        count = Ref(0)
+        walk(x) = begin
+            count[] += 1
+            x.args === nothing || foreach(walk, x.args)
+        end
+        walk(ex)
+        @test count[] > 0
+    end
+end
+```
+
+- [ ] **Step 2: Run to verify failures** (converter throws or spans don't tile on some inputs).
+
+- [ ] **Step 3: Implement**
+
+Add to `assemble_form` (before the fallback):
+
+```julia
+    elseif k == K"error"
+        # CSTParser marks recovery with :errortoken; children stay reachable
+        # so downstream traversal and spans keep working.
+        return EXPR(:errortoken, kids, nothing, 0, 0)
+```
+
+And in `terminals.jl`, map error-kind leaves (`JuliaSyntax.is_error(k)`) to `EXPR(:errortoken, fullspan, span, token_text(...))`. Also handle `K"TOMBSTONE"`/zero-width leaves if they appear: emit zero-span `:errortoken` EXPRs rather than skipping, so span tiling holds.
+
+- [ ] **Step 4: Run test to verify it passes**, then also re-run the full cst-conv suite.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cst_conversion test/test_cst_conversion.jl
+git commit -m "feat: map JuliaSyntax error recovery to errortoken EXPRs"
+```
+
+---
+
+### Task 12: Salsa single-parse integration + backend flip
+
+**Files:**
+- Modify: `src/layer_syntax_trees.jl`
+- Modify: `src/public.jl` (add `syntax_node_at`; export next to the existing tree accessors around `public.jl:463`)
+- Test: `test/test_cst_conversion.jl`
+
+**Interfaces:**
+- Produces: `derived_julia_green_tree(rt, uri) -> Tuple{GreenNode, Vector{JuliaSyntax.Diagnostic}, String}`; `derived_julia_legacy_syntax_tree` now converter-backed with `CST_BACKEND` override; `JuliaWorkspaces.syntax_node_at(node::SyntaxNode, byte::Int) -> SyntaxNode` (deepest node containing byte — the SyntaxNode counterpart of `get_expr1` for cross-tree migration).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/test_cst_conversion.jl`:
+
+```julia
+@testitem "cst-conv: single-parse salsa integration" begin
+    using CSTParser, JuliaSyntax
+    using JuliaSyntax: kind, @K_str
+    using JuliaWorkspaces
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, URI
+
+    content = "f(x) = x + 1\n"
+    jw = JuliaWorkspace()
+    uri = URI("file:///a.jl")
+    add_file!(jw, TextFile(uri, SourceText(content, "julia")))
+
+    cst = JuliaWorkspaces.get_legacy_cst(jw, uri)
+    @test cst isa CSTParser.EXPR
+    @test JuliaWorkspaces.CSTConversion.trees_equal(cst, CSTParser.parse(content, true))
+
+    sn = JuliaWorkspaces.get_julia_syntax_tree(jw, uri)
+    @test JuliaWorkspaces.syntax_node_at(sn, 1) isa JuliaSyntax.SyntaxNode
+    @test kind(JuliaWorkspaces.syntax_node_at(sn, 8)) == K"Identifier"  # byte 8 = 'x'
+end
+```
+
+(Workspace-construction idiom copied from `test/test_documents.jl:3-8`; accessors are `get_julia_syntax_tree` at `public.jl:458` and `get_legacy_cst` at `public.jl:651`. If `URI`/`TextFile`/`SourceText` aren't importable exactly as written, mirror the imports at the top of `test/test_documents.jl`.)
+
+- [ ] **Step 2: Run to verify it fails** (`derived_julia_green_tree`, `syntax_node_at` undefined).
+
+- [ ] **Step 3: Implement**
+
+In `src/layer_syntax_trees.jl`, replace lines 1–54 (`derived_julia_parse_result` / `derived_julia_syntax_tree` / `derived_julia_legacy_syntax_tree`) with:
+
+```julia
+Salsa.@derived function derived_julia_green_tree(rt, uri)
+    @debug "derived_julia_green_tree" uri=uri
+    tf = derived_text_file_content(rt, uri)
+    content = tf.content.content
+    stream = JuliaSyntax.ParseStream(content; version=VERSION)
+    JuliaSyntax.parse!(stream; rule=:all)
+    green = JuliaSyntax.build_tree(JuliaSyntax.GreenNode, stream)
+    return green, stream.diagnostics, content
+end
+
+Salsa.@derived function derived_julia_parse_result(rt, uri)
+    green, diagnostics, content = derived_julia_green_tree(rt, uri)
+    tree = SyntaxNode(JuliaSyntax.SourceFile(content), green)
+    return tree, diagnostics
+end
+
+Salsa.@derived function derived_julia_syntax_tree(rt, uri)
+    return derived_julia_parse_result(rt, uri)[1]
+end
+
+# Backend escape hatch while the converter soaks; read once at load time.
+const CST_BACKEND = Ref(get(ENV, "JW_CST_BACKEND", "juliasyntax"))
+
+Salsa.@derived function derived_julia_legacy_syntax_tree(rt, uri)
+    @debug "derived_julia_legacy_syntax_tree" uri=uri
+    if CST_BACKEND[] == "cstparser"
+        tf = derived_text_file_content(rt, uri)
+        return CSTParser.parse(tf.content.content, true)
+    end
+    green, _, content = derived_julia_green_tree(rt, uri)
+    return CSTConversion.build_cst(green, content)
+end
+```
+
+(Verify the `SyntaxNode(::SourceFile, ::GreenNode)` constructor exists in the pinned 0.4.10 — `~/.julia/packages/JuliaSyntax/DHdTk/src/syntax_tree.jl`; if the signature differs, adapt to what `build_tree(SyntaxNode, ...)` does internally at `syntax_tree.jl:262`.)
+
+In `src/public.jl`, next to the existing syntax-tree accessor (`public.jl:463`):
+
+```julia
+function syntax_node_at(node::SyntaxNode, byte::Int)
+    while haschildren(node)
+        found = false
+        for c in children(node)
+            if first_byte(c) <= byte <= last_byte(c)
+                node = c
+                found = true
+                break
+            end
+        end
+        found || break
+    end
+    return node
+end
+```
+
+- [ ] **Step 4: Run the cst-conv suite** — expected PASS.
+
+- [ ] **Step 5: Run the FULL package suite, both backends**
+
+Via `mcp__julia__julia_eval` (empty filter = everything):
+
+```julia
+withenv("JW_TEST_FILTER" => "") do
+    include("/home/pfitzseb/git/julia-vscode/scripts/packages/JuliaWorkspaces/test/runtests.jl")
+end
+```
+
+Then set `JuliaWorkspaces.CST_BACKEND[] = "cstparser"` and repeat. Expected: identical results (0 failures both ways; if the pre-existing suite has known failures on main, the two runs must fail identically). Any test passing under `cstparser` but failing under `juliasyntax` is a converter bug: reduce to a snippet, add to the themed testitem, fix, re-run.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/layer_syntax_trees.jl src/public.jl test/test_cst_conversion.jl
+git commit -m "feat: single JuliaSyntax parse feeding both syntax trees
+
+derived_julia_legacy_syntax_tree now builds EXPR via CSTConversion from
+the shared green tree; JW_CST_BACKEND=cstparser restores the old parser."
+```
+
+---
+
+### Task 13: Soak gate + finish
+
+**Files:** none new.
+
+- [ ] **Step 1: Full-suite verification run** — both backends again from a fresh julia-mcp restart (`mcp__julia__julia_restart`), to rule out Revise artifacts. Record outputs.
+
+- [ ] **Step 2: Resolve the divergence list** — confirm the user has answered `cst-converter-divergences.md` (Task 10 checkpoint); implement any "converter shims it" decisions as new testitem snippets + `forms.jl` branches, same recipe as Task 6 Step 3.
+
+- [ ] **Step 3: Finish the branch** — use the superpowers:finishing-a-development-branch skill (merge vs PR decision belongs to the user). Note for the PR body: CSTParser remains a dependency (EXPR datastructure + predicates + oracle in tests); *parsing* now happens exactly once via JuliaSyntax. Dropping the dependency entirely (vendoring EXPR + predicates) and porting `layer_completions.jl`'s Tokenize usage are follow-up projects, deliberately out of scope here.

--- a/docs/superpowers/plans/cst-converter-divergences.md
+++ b/docs/superpowers/plans/cst-converter-divergences.md
@@ -52,3 +52,42 @@ input):
   still reports `args length 1 vs 2`. This input never occurs in real
   code (a source file cannot meaningfully start with `;`); zero corpus files
   hit it. Resolution: accept drift — downstream never sees leading-`;` files.
+
+- **Suffixed comparison operators in a chain** (e.g. `a ==ᵥ b == c`) — a
+  genuine parser disagreement. JuliaSyntax classifies the suffixed `==ᵥ` as
+  comparison-precedence and emits ONE flat `K"comparison"` node
+  (`comparison[a, ==ᵥ, b, ==, c]`), whereas CSTParser does not recognise the
+  suffixed operator as comparison-class and parses right-to-left into nested
+  binary `:call`s (`(==)((==ᵥ)(a,b), c)`). Reproducing CSTParser's shape would
+  require re-deriving its operator-precedence table for arbitrary suffixed
+  unicode operators — information absent from the green tree. 1 corpus file
+  (`BlockArrays/test/test_blockindices.jl`). `check_spans` passes.
+  Resolution: accept drift.
+
+- **CSTParser is stricter than JuliaSyntax on a few malformed/edge inputs and
+  emits `:errortoken`/`:error` where JuliaSyntax accepts (or vice versa).**
+  These are inputs no valid program contains; the converter follows
+  JuliaSyntax (it has no error node to mirror). Confirmed cases, all
+  `check_spans`-clean, each in 1 corpus test file:
+  - `@async try … finally … catch e … end` — a `finally` clause BEFORE
+    `catch` (invalid order). CSTParser wraps the stray `catch` in an
+    `:errortoken`; JuliaSyntax parses the clauses in the given order.
+    (`JSONRPC/test/test_json_serialization.jl`)
+  - `@SVector[…]'` — postfix adjoint applied to a `[...]`-macrocall. CSTParser
+    wraps the whole thing in an `:errortoken`; JuliaSyntax produces the plain
+    adjoint call. (`StaticArrays/test/linalg.jl`)
+  - `\b` as a bare expression — an invalid use of `\`. CSTParser emits an
+    `:errortoken`; JuliaSyntax makes a `:call`.
+    (`BlockBandedMatrices/examples/finitedifference_2d.jl`)
+  Resolution: accept drift.
+
+- **Deep context-dependent span/arg discrepancies** (3 corpus files:
+  `StaticArrays/src/blas.jl` — `@eval`-block RHS inside a nested cartesian
+  `for (a,b) in …, (c,d) in …`; `StaticArrays/test/broadcast.jl` — a nested
+  `@testset`/`@test`/`@inferred`/`SA[…]` stack; `CodeTracking/test/script.jl`
+  — a file-level statement count off by one around a `'\n'` char literal + `;`).
+  Each fails only when embedded in its full surrounding context; every minimal
+  extraction of the construct converts identically to the oracle, and all
+  three are `check_spans`-clean. Not reduced to a fixable rule within this
+  task's budget; documented as remaining loop state rather than a claimed
+  divergence.

--- a/docs/superpowers/plans/cst-converter-divergences.md
+++ b/docs/superpowers/plans/cst-converter-divergences.md
@@ -166,3 +166,11 @@ emits a `Placeholder` catch-var where CSTParser errortokens the stray
 `catch` — but the root causes are unchanged). No entry dissolved; no new
 divergence was introduced by the retarget. Depot corpus: 1154/1161, the
 same six accepted-drift files plus the StackOverflow file as before.
+
+## Task 11.5 (JuliaSyntax 1.x retarget) — reviewer addendum
+
+- The `(…;…) ->` brackets-vs-tuple heuristic is oracle-pinned for all corpus
+  and common spellings, with one degenerate gap: an EMPTY `;`-group after a
+  splat (`(a...;) -> a`) converts as `:tuple` where CSTParser says
+  `:brackets`. Here the converter matches real Julia (`Meta.parse` gives a
+  tuple LHS) and CSTParser is the deviant; corpus-clean. Accept drift.

--- a/docs/superpowers/plans/cst-converter-divergences.md
+++ b/docs/superpowers/plans/cst-converter-divergences.md
@@ -11,35 +11,28 @@ No gate snippet required a `@test_broken` entry — all 29 brief snippets plus
 the inherited concerns (cmd literals, triple-quoted strings, multi-chunk
 line-continuation strings, compound assignment/short-circuit, dotted
 macrocalls, comparison chains, juxtaposition, standalone braces) reached
-oracle equality with a real fix rather than a shim.
+oracle equality with a real fix rather than a shim. Two round-2 review
+findings (raw/regex string escape corruption; bare-string-literal `$(...)`
+losing its `:string` wrapper) were likewise FIXED, not logged: the raw case
+turned out to be flag-detectable (`RAW_STRING_FLAG` on the `K"string"` node
+mirrors CSTParser's `prefixed != false` path exactly), so no macro-name
+heuristic was needed.
 
-Two corpus-discovered items are **not** gate-blocking divergences but are
-worth flagging for later tasks:
+One approximation remains flagged (not gate-blocking, no known failing
+input):
 
 - **Cmd-literal `$(...)` interpolation is reconstructed by a best-effort
-  re-scan, not a real divergence but an approximation**: JuliaSyntax's green
-  tree never decomposes backtick-literal interpolation at all (a `CmdString`
-  leaf's raw text can contain a literal unescaped `$` with no child node —
-  real Julia defers `$`-splitting in cmd literals to the `@cmd` macro at
-  expansion time), unlike double-quoted strings where the green tree already
-  splits real children. The converter's `split_cmd_dollar` (terminals.jl)
-  manually re-scans the raw leaf text and recursively re-parses `$(...)`
-  groups via `build_cst`, verified correct against the oracle for the gate
-  snippet and for a real corpus example (`CloudIndex/driver.jl`'s
-  multi-interpolation `inner = \`...\`` cmd literal). The paren-matching is
-  naive (depth-counting only, no awareness of nested strings/comments
-  containing parens) — a `$(f("("))`-style case inside a cmd literal would
-  mis-scan. Not hit by the current corpus; flagged rather than hardened,
-  since fixing it generally requires the same tokenizer JuliaSyntax itself
-  uses for the inner re-parse boundary.
-- **Raw/regex string macros (`raw"..."`, `r"..."`) get the same unconditional
-  `_rm_escaped_newlines`/`_unescape_string_expr` pass as plain strings** —
-  pre-existing since Task 3/4's `merge_quoted`, unchanged by Task 9 (still
-  called on every simple/collapsed `K"string"` chunk regardless of which
-  macro wraps it). This is invisible when the literal has no backslashes
-  (the Task 9 gate's `raw"no $interp"` has none) but corrupts content for a
-  real corpus regex like `r"[/\\]+"` (`src/compat.jl`) and
-  `r"^(julia)?manifest(-v\d+...)?\.toml$"` (`src/fileio.jl`), both surfaced
-  once Task 9 removed the crashes that had been masking these files
-  entirely. Not fixed here (out of Task 9's scope — strings/cmd/operators,
-  not macro-name-conditional unescaping); handoff for Task 10/11.
+  re-scan**: JuliaSyntax's green tree never decomposes backtick-literal
+  interpolation at all (a `CmdString` leaf's raw text can contain a literal
+  unescaped `$` with no child node — real Julia defers `$`-splitting in cmd
+  literals to the `@cmd` macro at expansion time), unlike double-quoted
+  strings where the green tree already splits real children. The converter's
+  `split_cmd_dollar` (terminals.jl) manually re-scans the raw leaf text and
+  recursively re-parses `$(...)` groups via `build_cst`, verified correct
+  against the oracle for the gate snippets and for a real corpus example
+  (`CloudIndex/driver.jl`'s multi-interpolation `inner = \`...\`` cmd
+  literal). The paren-matching is naive (depth-counting only, no awareness
+  of nested strings/comments containing parens) — a `$(f("("))`-style case
+  inside a cmd literal would mis-scan. Not hit by the current corpus;
+  flagged rather than hardened, since fixing it generally requires the same
+  tokenizer JuliaSyntax itself uses for the inner re-parse boundary.

--- a/docs/superpowers/plans/cst-converter-divergences.md
+++ b/docs/superpowers/plans/cst-converter-divergences.md
@@ -81,13 +81,63 @@ input):
     (`BlockBandedMatrices/examples/finitedifference_2d.jl`)
   Resolution: accept drift.
 
-- **Deep context-dependent span/arg discrepancies** (3 corpus files:
-  `StaticArrays/src/blas.jl` — `@eval`-block RHS inside a nested cartesian
-  `for (a,b) in …, (c,d) in …`; `StaticArrays/test/broadcast.jl` — a nested
-  `@testset`/`@test`/`@inferred`/`SA[…]` stack; `CodeTracking/test/script.jl`
-  — a file-level statement count off by one around a `'\n'` char literal + `;`).
-  Each fails only when embedded in its full surrounding context; every minimal
-  extraction of the construct converts identically to the oracle, and all
-  three are `check_spans`-clean. Not reduced to a fixable rule within this
-  task's budget; documented as remaining loop state rather than a claimed
-  divergence.
+- **Statement group split at a mid-file `;` after a block form** — same
+  structural family as the leading-`;` entry above. `CodeTracking/test/
+  script.jl` reduces to:
+
+  ```julia
+  struct S
+  end;1
+  ```
+
+  Oracle (CSTParser) hoists the post-`;` statement to a FILE-level sibling,
+  wrapping only the pre-`;` group in a nested toplevel:
+
+  ```
+  file
+    toplevel            fs=13 s=12
+      struct …end
+    INTEGER "1"         fs=1 s=1
+  ```
+
+  Ours (from the single flat green `toplevel[struct, ;, 1]` node):
+
+  ```
+  file
+    toplevel            fs=14 s=14
+      struct …end
+      INTEGER "1"
+  ```
+
+  Reproducing the split would require re-deriving CSTParser's file-level
+  statement-grouping pass (which decides per-`;` whether the run continues
+  the group or starts a file sibling) — information not represented in the
+  green tree. `check_spans` passes. Resolution: accept drift.
+  (Task-10 round-2 note: this was initially misfiled as "context-dependent /
+  resists reduction"; the reviewer reduced it to the two-liner above.)
+
+- **JuliaSyntax's parser overflows on a file CSTParser parses fine** —
+  `JuliaSyntax/src/tokenize_utils.jl` (a deeply-nested chained-`||`
+  expression): `CSTParser.parse(src, true)` succeeds, but our pipeline's
+  `JuliaSyntax.parse!` throws `StackOverflowError` before the converter ever
+  runs. This is NOT a tree-shape divergence — it is a **pipeline availability
+  gap and a Task 12 backend-flip liability**: after the flip, any file whose
+  nesting depth overflows JuliaSyntax's recursive-descent parser regresses
+  from "parsed" to "unparseable", a regression surface CSTParser's parser
+  does not have (or hits at a different depth). Needs either a bigger parse
+  stack (e.g. parsing on a dedicated task with an enlarged stack) or an
+  upstream JuliaSyntax fix before the flip. Resolution: converter cannot shim
+  it; flag for Task 12.
+
+- **One genuinely context-dependent case** — `StaticArrays/test/broadcast.jl`
+  (an `::`/`==` binding inside a macro arg that diverges only in the full
+  nested `@testset`/`@test`/`@inferred`/`SA[…]` context; every minimal
+  extraction converts identically). Reviewer-confirmed as genuinely
+  context-dependent in the round-2 review. `check_spans`-clean. Left as
+  remaining loop state.
+  (Round-2 correction: the earlier claim that a "trio" of files shared this
+  character was wrong for 2 of 3 — `StaticArrays/src/blas.jl` was a real
+  converter bug, fixed in round 2 [qualified-macrocall span quirk not
+  propagating through a nesting macrocall, `x = @eval M.@m(a)`], and
+  `CodeTracking/test/script.jl` reduced to the statement-group split logged
+  above.)

--- a/docs/superpowers/plans/cst-converter-divergences.md
+++ b/docs/superpowers/plans/cst-converter-divergences.md
@@ -174,3 +174,63 @@ same six accepted-drift files plus the StackOverflow file as before.
   splat (`(a...;) -> a`) converts as `:tuple` where CSTParser says
   `:brackets`. Here the converter matches real Julia (`Meta.parse` gives a
   tuple LHS) and CSTParser is the deviant; corpus-clean. Accept drift.
+
+## Task 12 (Salsa single-parse integration + backend flip)
+
+Backend-flip regression sweep (full package test suite, both
+`JW_CST_BACKEND` values) surfaced two real converter bugs, both fixed, plus
+two genuine parser-level (not converter) divergences left as accepted drift.
+
+- **Fixed**: `a.end`/`a.begin` as a dot-getfield field name converted to the
+  `:END`/`:BEGIN` index-context literal instead of plain `:IDENTIFIER`.
+  `terminal_expr` maps any Identifier-kinded `end`/`begin` leaf to the index
+  literal head unconditionally; the getfield/quotenode forms already demoted
+  `:BEGIN` back to `:IDENTIFIER` for quoted-field context (`wrap_field_atom`,
+  the `K"quote"` form) but were missing the matching `:END` demotion. Fixed
+  by adding the same demotion for `:END` in both spots
+  (`src/cst_conversion/forms.jl`).
+- **Fixed**: a `module`/`baremodule` whose closing `end` is missing entirely
+  (e.g. mid-edit `module M\nBase.\nend\n` where the dangling `Base.` consumes
+  the literal `end` as its field name, autocompletion's classic trigger
+  shape) produced a 4th `:module` arg (the raw green error-recovery leaf)
+  instead of CSTParser's own convention: an `:errortoken` wrapping a
+  zero-width, val-less `:END` placeholder filed as `trivia[2]`. The stray
+  4th arg broke CSTParser's own `_module` iterate accessor (`x.args[2]`
+  assumed a 3-slot arg list), crashing any StaticLint/completions code that
+  walks the module via CSTParser's iteration protocol (not just `.args`
+  directly) with a `BoundsError`. Fixed by synthesizing the oracle-shaped
+  `errortoken`/`:END` placeholder in `trivia` instead of appending to `args`
+  (`src/cst_conversion/forms.jl`, the `K"module"` form). Two more
+  truncated-module edge cases (`"module A\n"` with an entirely empty body,
+  and an unterminated call before a stray `end`) still show narrow arg-shape
+  diffs; both are `check_spans`-clean and not exercised by any real test —
+  left as further loop state rather than chased with no failing test to
+  pin them.
+- **Accept drift**: `if x = 1 end` / `if a || x = 1 end` / `if x = 1 && b
+  end` (assignment used directly as an `if` condition) parses as a genuine
+  syntax error under JuliaSyntax 1.x — this vendored fork's parser rejects
+  bare `=` in condition position (`"unexpected \`=\`"` diagnostic, then
+  cascading error recovery), whereas CSTParser accepts it leniently as a
+  normal assignment expression. Confirmed via green-tree inspection: the
+  divergence originates in the parse itself, not the conversion — the
+  converter faithfully mirrors JuliaSyntax's error-recovery shape. Surfaces
+  as 3 failing StaticLint `check_if_conds` tests
+  (`test/staticlint/test_staticlint.jl`) that assert the (pre-flip) lenient
+  parse; out of converter scope.
+- **Accept drift**: `[i for i in length(1) end]` (a test fixture with a
+  stray, syntactically-invalid `end` inside a list-comprehension literal)
+  recovers differently between parsers — CSTParser folds the stray `end`
+  into an `hcat` alongside the comprehension; JuliaSyntax closes the
+  comprehension cleanly and leaves the `end`+`]` as trailing errortokens one
+  level up. Again a parser-level error-recovery difference, not a converter
+  bug. Surfaces as 2 erroring StaticLint tests
+  (`test/staticlint/test_inference.jl`,
+  `error_list_comp_incorrect_iter_specs`); out of converter scope.
+
+Full-suite backend-flip regression (custom broad run excluding vendored
+`packages/*` subpackage suites and `testdata/` fixtures, both backends):
+2195 total both ways; identical except for exactly the 5 tests above
+(2178/10/1/6 under `cstparser` vs 2173/13/3/6 under `juliasyntax`). All
+other non-identical-seeming counts (Runic package missing, cache-infra
+rclone sandbox gate, `test_uris2.jl` broken markers) are pre-existing
+environment gaps, confirmed identical between backends.

--- a/docs/superpowers/plans/cst-converter-divergences.md
+++ b/docs/superpowers/plans/cst-converter-divergences.md
@@ -128,6 +128,12 @@ input):
   stack (e.g. parsing on a dedicated task with an enlarged stack) or an
   upstream JuliaSyntax fix before the flip. Resolution: converter cannot shim
   it; flag for Task 12.
+  (Task-11.5 re-check under the vendored 1.0.2 fork: `parse!` STILL
+  overflows at the default task stack — the fork does not change this. On
+  an enlarged-stack task (`Task(f, 512*1024*1024)`) the file both parses
+  AND converts to full oracle equality (`first_tree_diff === nothing`), so
+  no tree-shape issue hides behind the overflow; an enlarged-stack parse
+  task is a verified-workable Task 12 integration fix. Entry stays open.)
 
 - **One genuinely context-dependent case** — `StaticArrays/test/broadcast.jl`
   (an `::`/`==` binding inside a macro arg that diverges only in the full
@@ -141,3 +147,22 @@ input):
   propagating through a nesting macrocall, `x = @eval M.@m(a)`], and
   `CodeTracking/test/script.jl` reduced to the statement-group split logged
   above.)
+  (Task-11.5 update: under JuliaSyntax 1.x this is no longer
+  context-dependent — it reduces to `@test @inferred(f(x))   ::T == y`
+  (whitespace before the `::`). CSTParser splits the space-separated
+  `::T == y` off as a SECOND macro arg (a prefix-`::` expression), while
+  JuliaSyntax binds the `::` to the preceding macrocall result —
+  and `Meta.parse` agrees with JuliaSyntax, so CSTParser deviates from
+  real Julia here. Genuine parser disagreement; accept drift. Without the
+  whitespace the two parsers agree and the converter matches.)
+
+## Task 11.5 (retarget to JuliaSyntax 1.x)
+
+All Task-10 entries above were re-verified under the vendored JuliaSyntax
+1.0.2 fork with the vendored CSTParser 3.5.1-DEV oracle; every reduction
+still reproduces (some corpus diff signatures shifted — e.g. the
+catch-after-finally file now surfaces as `IDENTIFIER vs FALSE` because 1.x
+emits a `Placeholder` catch-var where CSTParser errortokens the stray
+`catch` — but the root causes are unchanged). No entry dissolved; no new
+divergence was introduced by the retarget. Depot corpus: 1154/1161, the
+same six accepted-drift files plus the StackOverflow file as before.

--- a/docs/superpowers/plans/cst-converter-divergences.md
+++ b/docs/superpowers/plans/cst-converter-divergences.md
@@ -36,3 +36,19 @@ input):
   inside a cmd literal would mis-scan. Not hit by the current corpus;
   flagged rather than hardened, since fixing it generally requires the same
   tokenizer JuliaSyntax itself uses for the inner re-parse boundary.
+
+## Task 10
+
+- **A file that begins with a `;` before any statement** (e.g. `"; a"`) — a
+  genuine structural disagreement, not a layout gap. JuliaSyntax nests the
+  leading `;` and the following statement in ONE `K"toplevel"` green node
+  (`toplevel[;, a]`), whereas CSTParser splits them across two file-level
+  slots: an empty leading statement wrapped in its own nested toplevel, then
+  the real statement as a sibling — `file[ toplevel[NOTHING], a ]`. The
+  converter cannot produce that split from the single flat green node without
+  re-deriving CSTParser's statement-grouping pass. It DOES synthesize the
+  leading `NOTHING` placeholder (so widths balance and `check_spans` passes,
+  and the pure-`;` degenerate `;;` matches the oracle exactly), but `"; a"`
+  still reports `args length 1 vs 2`. This input never occurs in real
+  code (a source file cannot meaningfully start with `;`); zero corpus files
+  hit it. Resolution: accept drift — downstream never sees leading-`;` files.

--- a/docs/superpowers/plans/cst-converter-divergences.md
+++ b/docs/superpowers/plans/cst-converter-divergences.md
@@ -200,12 +200,19 @@ two genuine parser-level (not converter) divergences left as accepted drift.
   walks the module via CSTParser's iteration protocol (not just `.args`
   directly) with a `BoundsError`. Fixed by synthesizing the oracle-shaped
   `errortoken`/`:END` placeholder in `trivia` instead of appending to `args`
-  (`src/cst_conversion/forms.jl`, the `K"module"` form). Two more
-  truncated-module edge cases (`"module A\n"` with an entirely empty body,
-  and an unterminated call before a stray `end`) still show narrow arg-shape
-  diffs; both are `check_spans`-clean and not exercised by any real test —
-  left as further loop state rather than chased with no failing test to
-  pin them.
+  (`src/cst_conversion/forms.jl`, the `K"module"` form).
+- **Fixed**: `"module A\n"` (an entirely empty, unterminated module body) leaked
+  a phantom zero-width `:errortoken` into the module body block's `args` where
+  the oracle keeps an empty body. The zero-width error-leaf recovery marker is
+  now dropped from block `args` (a `begin`/`quote` block keeps it as an `:END`
+  placeholder in trivia instead); `oracle_diff("module A\n")` is now `nothing`.
+  The same class of bug for the other end-keyword forms — an unterminated
+  `for`/`while`/`try`/`function`/`macro` leaked the missing-`end` error node
+  into `args`, breaking CSTParser's `taat`/`_function`/`_try` iterate accessors
+  with a `BoundsError` (which killed `get_diagnostics_blocking` for the whole
+  workspace) — is fixed the same way: the marker becomes a trivia `:END`
+  placeholder (and a degenerate unterminated `try` synthesizes an empty catch so
+  its fixed iterate arity holds). All spans stay `check_spans`-clean.
 - **Accept drift**: `if x = 1 end` / `if a || x = 1 end` / `if x = 1 && b
   end` (assignment used directly as an `if` condition) parses as a genuine
   syntax error under JuliaSyntax 1.x — this vendored fork's parser rejects

--- a/docs/superpowers/plans/cst-converter-divergences.md
+++ b/docs/superpowers/plans/cst-converter-divergences.md
@@ -1,0 +1,45 @@
+# CST converter: JuliaSyntax/CSTParser divergence log
+
+Cases where the converter cannot (or does not yet) reproduce CSTParser's
+output because the two parsers genuinely disagree at the structural level,
+not just in layout. Used sparingly — most oracle diffs are layout gaps in
+the converter, fixed directly rather than logged here.
+
+## Task 9
+
+No gate snippet required a `@test_broken` entry — all 29 brief snippets plus
+the inherited concerns (cmd literals, triple-quoted strings, multi-chunk
+line-continuation strings, compound assignment/short-circuit, dotted
+macrocalls, comparison chains, juxtaposition, standalone braces) reached
+oracle equality with a real fix rather than a shim.
+
+Two corpus-discovered items are **not** gate-blocking divergences but are
+worth flagging for later tasks:
+
+- **Cmd-literal `$(...)` interpolation is reconstructed by a best-effort
+  re-scan, not a real divergence but an approximation**: JuliaSyntax's green
+  tree never decomposes backtick-literal interpolation at all (a `CmdString`
+  leaf's raw text can contain a literal unescaped `$` with no child node —
+  real Julia defers `$`-splitting in cmd literals to the `@cmd` macro at
+  expansion time), unlike double-quoted strings where the green tree already
+  splits real children. The converter's `split_cmd_dollar` (terminals.jl)
+  manually re-scans the raw leaf text and recursively re-parses `$(...)`
+  groups via `build_cst`, verified correct against the oracle for the gate
+  snippet and for a real corpus example (`CloudIndex/driver.jl`'s
+  multi-interpolation `inner = \`...\`` cmd literal). The paren-matching is
+  naive (depth-counting only, no awareness of nested strings/comments
+  containing parens) — a `$(f("("))`-style case inside a cmd literal would
+  mis-scan. Not hit by the current corpus; flagged rather than hardened,
+  since fixing it generally requires the same tokenizer JuliaSyntax itself
+  uses for the inner re-parse boundary.
+- **Raw/regex string macros (`raw"..."`, `r"..."`) get the same unconditional
+  `_rm_escaped_newlines`/`_unescape_string_expr` pass as plain strings** —
+  pre-existing since Task 3/4's `merge_quoted`, unchanged by Task 9 (still
+  called on every simple/collapsed `K"string"` chunk regardless of which
+  macro wraps it). This is invisible when the literal has no backslashes
+  (the Task 9 gate's `raw"no $interp"` has none) but corrupts content for a
+  real corpus regex like `r"[/\\]+"` (`src/compat.jl`) and
+  `r"^(julia)?manifest(-v\d+...)?\.toml$"` (`src/fileio.jl`), both surfaced
+  once Task 9 removed the crashes that had been masking these files
+  entirely. Not fixed here (out of Task 9's scope — strings/cmd/operators,
+  not macro-name-conditional unescaping); handoff for Task 10/11.

--- a/src/cst_conversion/CSTConversion.jl
+++ b/src/cst_conversion/CSTConversion.jl
@@ -8,6 +8,8 @@ using JuliaSyntax: GreenNode, Kind, @K_str, kind, haschildren, children, span
 include("compare.jl")
 include("tokens.jl")
 include("terminals.jl")
+include("assembly.jl")
+include("forms.jl")
 
 export first_tree_diff, trees_equal, Leaf, flatten_leaves, is_ws_trivia, build_cst, oracle_diff
 
@@ -21,21 +23,26 @@ function build_cst(green::GreenNode, source::AbstractString)
     src = String(source)
     isempty(src) && return EXPR(:file, EXPR[], EXPR[], 0, 0)
     leaves, leading = flatten_leaves(green, src)
-    file = EXPR(:file, EXPR[], nothing, 0, 0)
-    attach_leading!(file, leading)
-    for expr in terminal_exprs(leaves, src)
-        push!(file, expr)  # CSTParser extends Base.push! with span updates
-    end
-    return file
+    cur = Cursor(leaves, 1, src)
+    ex = assemble(green, cur)   # root green node is always kind K"toplevel"
+    ex.head = :file
+    ex.trivia = nothing
+    attach_leading!(ex, leading)
+    return ex
 end
 
 # Oracle-pinned: leading file trivia (whitespace/comments before the first
 # token, or the whole file when there is no token at all) becomes its own
 # :NOTHING leaf at the front of file.args — it does not widen the first
-# token's fullspan.
+# token's fullspan. Prepended (not pushed) since assemble() already filled
+# in the real args before this runs; span/fullspan grow by leading's width.
 function attach_leading!(file::EXPR, leading::Int)
     leading == 0 && return file
-    push!(file, EXPR(:NOTHING, leading, leading, ""))
+    node = EXPR(:NOTHING, leading, leading, "")
+    CSTParser.setparent!(node, file)
+    pushfirst!(file.args, node)
+    file.fullspan += leading
+    file.span += leading
     return file
 end
 

--- a/src/cst_conversion/CSTConversion.jl
+++ b/src/cst_conversion/CSTConversion.jl
@@ -7,8 +7,8 @@ using JuliaSyntax: GreenNode, Kind, @K_str, kind, haschildren, children, span
 
 include("compare.jl")
 include("tokens.jl")
+include("assembly.jl")    # defines Cursor (used in terminals.jl signatures)
 include("terminals.jl")
-include("assembly.jl")
 include("forms.jl")
 
 export first_tree_diff, trees_equal, Leaf, flatten_leaves, is_ws_trivia, build_cst, oracle_diff

--- a/src/cst_conversion/CSTConversion.jl
+++ b/src/cst_conversion/CSTConversion.jl
@@ -6,7 +6,8 @@ using JuliaSyntax
 using JuliaSyntax: GreenNode, Kind, @K_str, kind, haschildren, children, span
 
 include("compare.jl")
+include("tokens.jl")
 
-export first_tree_diff, trees_equal
+export first_tree_diff, trees_equal, Leaf, flatten_leaves, is_ws_trivia
 
 end

--- a/src/cst_conversion/CSTConversion.jl
+++ b/src/cst_conversion/CSTConversion.jl
@@ -1,0 +1,12 @@
+module CSTConversion
+
+using CSTParser
+using CSTParser: EXPR
+using JuliaSyntax
+using JuliaSyntax: GreenNode, Kind, @K_str, kind, haschildren, children, span
+
+include("compare.jl")
+
+export first_tree_diff, trees_equal
+
+end

--- a/src/cst_conversion/CSTConversion.jl
+++ b/src/cst_conversion/CSTConversion.jl
@@ -7,7 +7,36 @@ using JuliaSyntax: GreenNode, Kind, @K_str, kind, haschildren, children, span
 
 include("compare.jl")
 include("tokens.jl")
+include("terminals.jl")
 
-export first_tree_diff, trees_equal, Leaf, flatten_leaves, is_ws_trivia
+export first_tree_diff, trees_equal, Leaf, flatten_leaves, is_ws_trivia, build_cst, oracle_diff
+
+function build_cst(source::AbstractString)
+    stream = JuliaSyntax.ParseStream(source; version=VERSION)
+    JuliaSyntax.parse!(stream; rule=:all)
+    build_cst(JuliaSyntax.build_tree(GreenNode, stream), source)
+end
+
+function build_cst(green::GreenNode, source::AbstractString)
+    src = String(source)
+    isempty(src) && return EXPR(:file, EXPR[], EXPR[], 0, 0)
+    leaves, leading = flatten_leaves(green, src)
+    file = EXPR(:file, EXPR[], nothing, 0, 0)
+    attach_leading!(file, leading)
+    for expr in terminal_exprs(leaves, src)
+        push!(file, expr)  # CSTParser extends Base.push! with span updates
+    end
+    return file
+end
+
+# Oracle-pinned: leading file trivia (whitespace/comments before the first
+# token, or the whole file when there is no token at all) becomes its own
+# :NOTHING leaf at the front of file.args — it does not widen the first
+# token's fullspan.
+function attach_leading!(file::EXPR, leading::Int)
+    leading == 0 && return file
+    push!(file, EXPR(:NOTHING, leading, leading, ""))
+    return file
+end
 
 end

--- a/src/cst_conversion/CSTConversion.jl
+++ b/src/cst_conversion/CSTConversion.jl
@@ -23,7 +23,7 @@ function build_cst(green::GreenNode, source::AbstractString)
     src = String(source)
     isempty(src) && return EXPR(:file, EXPR[], EXPR[], 0, 0)
     leaves, leading = flatten_leaves(green, src)
-    cur = Cursor(leaves, 1, src)
+    cur = Cursor(leaves, 1, src, green)
     ex = assemble(green, cur)   # root green node is always kind K"toplevel"
     ex.head = :file
     ex.trivia = nothing

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -37,9 +37,13 @@ const UNHANDLED_KINDS = Set{Kind}()
 # — silently dropping that kid's width from the node's own children instead
 # of just losing the kid itself. Mirrors check_spans' own childsum rule; when
 # it would report a shortfall, pad it with a zero-content filler so spans
-# stay tiled instead of desyncing. Never fires for valid code (childsum
-# always matches there) or for genuinely childless nodes (matrix cells).
-function patch_dropped_width!(ex::EXPR)
+# stay tiled instead of desyncing. Gated on the green subtree actually
+# containing an error node, so a childsum bug on VALID code still surfaces
+# via check_spans instead of being silently padded over; the subtree-walking
+# gate only runs when a gap exists, which never happens on valid code, so
+# the non-error path pays nothing. Skips genuinely childless nodes (matrix
+# cells), same rule as check_spans itself.
+function patch_dropped_width!(ex::EXPR, node::GreenNode)
     ex.args === nothing && return ex
     has_children = !isempty(ex.args) ||
                    (ex.trivia !== nothing && !isempty(ex.trivia)) ||
@@ -49,12 +53,18 @@ function patch_dropped_width!(ex::EXPR)
                (ex.trivia === nothing ? 0 : sum(c -> c.fullspan, ex.trivia; init=0)) +
                (ex.head isa EXPR ? ex.head.fullspan : 0)
     gap = ex.fullspan - childsum
-    if gap > 0
+    if gap > 0 && has_error_descendant(node)
         filler = EXPR(:errortoken, gap, 0, nothing)
         push!(ex.args, filler)
         CSTParser.setparent!(filler, ex)
     end
     return ex
+end
+
+function has_error_descendant(node::GreenNode)
+    JuliaSyntax.is_error(kind(node)) && return true
+    haschildren(node) || return false
+    return any(has_error_descendant, children(node))
 end
 
 function assemble(node::GreenNode, cur::Cursor)::EXPR
@@ -86,7 +96,7 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         # trailing chunk for interpolated strings, the whole literal
         # otherwise) so a `;`-fold widens the right node.
         expr = assemble_quoted(node, cur, k0 == K"cmdstring")
-        return patch_dropped_width!(expr)
+        return patch_dropped_width!(expr, node)
     end
     first_i = cur.i
     kids = EXPR[]
@@ -118,7 +128,7 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         ex.span = min(ex.span + cur.grow_span, ex.fullspan)
         cur.grow_span = 0
     end
-    patch_dropped_width!(ex)
+    patch_dropped_width!(ex, node)
     return ex
 end
 

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -7,10 +7,13 @@ mutable struct Cursor
     terminals::Vector{Union{Nothing,EXPR}}
     # leaf range consumed by each kid of the node currently in assemble_form
     kid_ranges::Vector{UnitRange{Int}}
+    # width the current form excluded from its own leading edge (folded onto
+    # a preceding leaf instead); assemble subtracts it from the node's spans
+    trim::Int
 end
 
 Cursor(leaves::Vector{Leaf}, i::Int, src::String) =
-    Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)), UnitRange{Int}[])
+    Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)), UnitRange{Int}[], 0)
 
 const UNHANDLED_KINDS = Set{Kind}()
 
@@ -51,6 +54,11 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         last_leaf = cur.leaves[cur.i - 1]
         ex.fullspan = (last_leaf.pos + last_leaf.fullspan) - first_leaf.pos
         ex.span = (last_leaf.pos + last_leaf.span) - first_leaf.pos
+    end
+    if cur.trim != 0
+        ex.fullspan -= cur.trim
+        ex.span = max(ex.span - cur.trim, 0)
+        cur.trim = 0
     end
     return ex
 end

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -31,6 +31,32 @@ Cursor(leaves::Vector{Leaf}, i::Int, src::String) =
 
 const UNHANDLED_KINDS = Set{Kind}()
 
+# Error-recovery safety net: a per-form branch's kid-dispatch loop can, on
+# broken input, route an unexpected extra kid (e.g. a trailing marker for a
+# missing `end`) into overwriting a single-slot field instead of keeping it
+# — silently dropping that kid's width from the node's own children instead
+# of just losing the kid itself. Mirrors check_spans' own childsum rule; when
+# it would report a shortfall, pad it with a zero-content filler so spans
+# stay tiled instead of desyncing. Never fires for valid code (childsum
+# always matches there) or for genuinely childless nodes (matrix cells).
+function patch_dropped_width!(ex::EXPR)
+    ex.args === nothing && return ex
+    has_children = !isempty(ex.args) ||
+                   (ex.trivia !== nothing && !isempty(ex.trivia)) ||
+                   ex.head isa EXPR
+    has_children || return ex
+    childsum = sum(c -> c.fullspan, ex.args; init=0) +
+               (ex.trivia === nothing ? 0 : sum(c -> c.fullspan, ex.trivia; init=0)) +
+               (ex.head isa EXPR ? ex.head.fullspan : 0)
+    gap = ex.fullspan - childsum
+    if gap > 0
+        filler = EXPR(:errortoken, gap, 0, nothing)
+        push!(ex.args, filler)
+        CSTParser.setparent!(filler, ex)
+    end
+    return ex
+end
+
 function assemble(node::GreenNode, cur::Cursor)::EXPR
     if !haschildren(node)
         leaf = cur.leaves[cur.i]
@@ -44,12 +70,12 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         # Quoted literals are open-quote/content/close-quote leaf triples in
         # the green tree, but CSTParser sees one CHAR token; consume the
         # whole run via the cursor instead of descending into children.
-        expr, next_i = merge_quoted(cur.leaves, cur.i, cur.src)
+        expr, next_i = merge_quoted(cur.leaves, cur.i, cur.src, cur.i + leaf_count(node) - 1)
         cur.terminals[next_i - 1] = expr
         cur.i = next_i
         return expr
     elseif k0 == K"var"
-        expr, next_i = merge_var(cur.leaves, cur.i, cur.src)
+        expr, next_i = merge_var(cur.leaves, cur.i, cur.src, cur.i + leaf_count(node) - 1)
         cur.terminals[next_i - 1] = expr
         cur.i = next_i
         return expr
@@ -60,7 +86,7 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         # trailing chunk for interpolated strings, the whole literal
         # otherwise) so a `;`-fold widens the right node.
         expr = assemble_quoted(node, cur, k0 == K"cmdstring")
-        return expr
+        return patch_dropped_width!(expr)
     end
     first_i = cur.i
     kids = EXPR[]
@@ -92,6 +118,7 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         ex.span = min(ex.span + cur.grow_span, ex.fullspan)
         cur.grow_span = 0
     end
+    patch_dropped_width!(ex)
     return ex
 end
 

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -1,0 +1,59 @@
+mutable struct Cursor
+    leaves::Vector{Leaf}
+    i::Int
+    src::String
+end
+
+const UNHANDLED_KINDS = Set{Kind}()
+
+function assemble(node::GreenNode, cur::Cursor)::EXPR
+    if !haschildren(node)
+        leaf = cur.leaves[cur.i]
+        cur.i += 1
+        return terminal_expr(leaf, cur.src)
+    end
+    k0 = kind(node)
+    if k0 == K"string" || k0 == K"char"
+        # Quoted literals are open-quote/content/close-quote leaf triples in
+        # the green tree, but CSTParser sees one STRING/CHAR token; consume
+        # the whole run via the cursor instead of descending into children.
+        expr, next_i = merge_quoted(cur.leaves, cur.i, cur.src)
+        cur.i = next_i
+        return expr
+    end
+    first_i = cur.i
+    kids = EXPR[]
+    kkinds = Kind[]
+    for c in children(node)
+        is_ws_trivia(kind(c)) && continue
+        push!(kids, assemble(c, cur))
+        push!(kkinds, kind(c))
+    end
+    ex = assemble_form(kind(node), node, kids, kkinds, cur)
+    # Spans from absolute leaf positions: independent of per-form layout.
+    if cur.i > first_i
+        first_leaf = cur.leaves[first_i]
+        last_leaf = cur.leaves[cur.i - 1]
+        ex.fullspan = (last_leaf.pos + last_leaf.fullspan) - first_leaf.pos
+        ex.span = (last_leaf.pos + last_leaf.span) - first_leaf.pos
+    end
+    return ex
+end
+
+# Fallback: args = non-token children in source order, tokens into trivia.
+# Wrong layout for anything CSTParser consumers pattern-match, but keeps the
+# corpus runner alive and counts what still needs a real rule.
+function generic_form(k::Kind, kids::Vector{EXPR}, kkinds::Vector{Kind})
+    push!(UNHANDLED_KINDS, k)
+    args = EXPR[]
+    trivia = EXPR[]
+    for (ex, ck) in zip(kids, kkinds)
+        if JuliaSyntax.is_keyword(ck) || ex.head in (:LPAREN, :RPAREN, :COMMA,
+            :LBRACE, :RBRACE, :LSQUARE, :RSQUARE, :SEMICOLON, :AT_SIGN, :DOT)
+            push!(trivia, ex)
+        else
+            push!(args, ex)
+        end
+    end
+    EXPR(Symbol(lowercase(string(k))), args, trivia, 0, 0)
+end

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -40,13 +40,19 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         return ex
     end
     k0 = kind(node)
-    if k0 == K"string" || k0 == K"char"
+    if k0 == K"char"
         # Quoted literals are open-quote/content/close-quote leaf triples in
-        # the green tree, but CSTParser sees one STRING/CHAR token; consume
-        # the whole run via the cursor instead of descending into children.
+        # the green tree, but CSTParser sees one CHAR token; consume the
+        # whole run via the cursor instead of descending into children.
         expr, next_i = merge_quoted(cur.leaves, cur.i, cur.src)
         cur.terminals[next_i - 1] = expr
         cur.i = next_i
+        return expr
+    elseif k0 == K"string" || k0 == K"cmdstring"
+        # Interpolation/triple-quote dedent/cmd-literal reconstruction; see
+        # assemble_quoted for why this can't be a simple leaf-run merge.
+        expr = assemble_quoted(node, cur, k0 == K"cmdstring")
+        cur.terminals[cur.i - 1] = expr
         return expr
     end
     first_i = cur.i

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -17,10 +17,17 @@ mutable struct Cursor
     # node's span even though the separator was folded away entirely; its
     # fullspan is already correctly included via the raw leaf range).
     trim_span::Int
+    # extra width to ADD to span ONLY (never past fullspan) — trim_span's
+    # symmetric counterpart, for forms whose oracle span extends past the
+    # last real leaf's own span. Only known case: bare `return`, whose
+    # synthetic zero-width NOTHING arg makes CSTParser measure span all the
+    # way to fullspan, covering the keyword's trailing trivia. Same
+    # lifecycle as trim/trim_span: set by a form, applied+reset by assemble.
+    grow_span::Int
 end
 
 Cursor(leaves::Vector{Leaf}, i::Int, src::String) =
-    Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)), UnitRange{Int}[], 0, 0)
+    Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)), UnitRange{Int}[], 0, 0, 0)
 
 const UNHANDLED_KINDS = Set{Kind}()
 
@@ -67,6 +74,10 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         ex.span = max(ex.span - cur.trim - cur.trim_span, 0)
         cur.trim = 0
         cur.trim_span = 0
+    end
+    if cur.grow_span != 0
+        ex.span = min(ex.span + cur.grow_span, ex.fullspan)
+        cur.grow_span = 0
     end
     return ex
 end

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -2,15 +2,25 @@ mutable struct Cursor
     leaves::Vector{Leaf}
     i::Int
     src::String
+    # EXPR built for each consumed leaf (last leaf only for merged quotes);
+    # lets forms locate the rightmost leaf of an already-assembled sibling.
+    terminals::Vector{Union{Nothing,EXPR}}
+    # leaf range consumed by each kid of the node currently in assemble_form
+    kid_ranges::Vector{UnitRange{Int}}
 end
+
+Cursor(leaves::Vector{Leaf}, i::Int, src::String) =
+    Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)), UnitRange{Int}[])
 
 const UNHANDLED_KINDS = Set{Kind}()
 
 function assemble(node::GreenNode, cur::Cursor)::EXPR
     if !haschildren(node)
         leaf = cur.leaves[cur.i]
+        ex = terminal_expr(leaf, cur.src)
+        cur.terminals[cur.i] = ex
         cur.i += 1
-        return terminal_expr(leaf, cur.src)
+        return ex
     end
     k0 = kind(node)
     if k0 == K"string" || k0 == K"char"
@@ -18,17 +28,22 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         # the green tree, but CSTParser sees one STRING/CHAR token; consume
         # the whole run via the cursor instead of descending into children.
         expr, next_i = merge_quoted(cur.leaves, cur.i, cur.src)
+        cur.terminals[next_i - 1] = expr
         cur.i = next_i
         return expr
     end
     first_i = cur.i
     kids = EXPR[]
     kkinds = Kind[]
+    ranges = UnitRange{Int}[]
     for c in children(node)
         is_ws_trivia(kind(c)) && continue
+        s = cur.i
         push!(kids, assemble(c, cur))
         push!(kkinds, kind(c))
+        push!(ranges, s:cur.i-1)
     end
+    cur.kid_ranges = ranges   # inner assemble calls are done; safe to publish
     ex = assemble_form(kind(node), node, kids, kkinds, cur)
     # Spans from absolute leaf positions: independent of per-form layout.
     if cur.i > first_i

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -30,6 +30,8 @@ Cursor(leaves::Vector{Leaf}, i::Int, src::String) =
     Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)), UnitRange{Int}[], 0, 0, 0)
 
 const UNHANDLED_KINDS = Set{Kind}()
+# Salsa runs derived queries concurrently; no live race today, but harden anyway.
+const UNHANDLED_LOCK = ReentrantLock()
 
 # Error-recovery safety net: a per-form branch's kid-dispatch loop can, on
 # broken input, route an unexpected extra kid (e.g. a trailing marker for a
@@ -151,7 +153,9 @@ end
 # Wrong layout for anything CSTParser consumers pattern-match, but keeps the
 # corpus runner alive and counts what still needs a real rule.
 function generic_form(k::Kind, kids::Vector{EXPR}, kkinds::Vector{Kind})
-    push!(UNHANDLED_KINDS, k)
+    lock(UNHANDLED_LOCK) do
+        push!(UNHANDLED_KINDS, k)
+    end
     args = EXPR[]
     trivia = EXPR[]
     for (ex, ck) in zip(kids, kkinds)

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -8,12 +8,19 @@ mutable struct Cursor
     # leaf range consumed by each kid of the node currently in assemble_form
     kid_ranges::Vector{UnitRange{Int}}
     # width the current form excluded from its own leading edge (folded onto
-    # a preceding leaf instead); assemble subtracts it from the node's spans
+    # a preceding leaf instead); assemble subtracts it from fullspan AND span
+    # (a leading exclusion shifts both boundaries by the same amount).
     trim::Int
+    # extra width to exclude from span ONLY, beyond `trim` — needed when a
+    # dropped separator is the LAST leaf this node consumed (its own
+    # meaningful width, `leaf.span`, would otherwise still count toward the
+    # node's span even though the separator was folded away entirely; its
+    # fullspan is already correctly included via the raw leaf range).
+    trim_span::Int
 end
 
 Cursor(leaves::Vector{Leaf}, i::Int, src::String) =
-    Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)), UnitRange{Int}[], 0)
+    Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)), UnitRange{Int}[], 0, 0)
 
 const UNHANDLED_KINDS = Set{Kind}()
 
@@ -55,10 +62,11 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         ex.fullspan = (last_leaf.pos + last_leaf.fullspan) - first_leaf.pos
         ex.span = (last_leaf.pos + last_leaf.span) - first_leaf.pos
     end
-    if cur.trim != 0
+    if cur.trim != 0 || cur.trim_span != 0
         ex.fullspan -= cur.trim
-        ex.span = max(ex.span - cur.trim, 0)
+        ex.span = max(ex.span - cur.trim - cur.trim_span, 0)
         cur.trim = 0
+        cur.trim_span = 0
     end
     return ex
 end

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -160,6 +160,33 @@ function assemble(node::GreenNode, cur::Cursor, is_cmdmacro_body::Bool=false)::E
         push!(ranges, s:cur.i-1)
         prev_kind = kind(c)
     end
+    # Stray statement-continuation errors (`1 x` juxtaposition and friends):
+    # JuliaSyntax closes the enclosing body block and emits the leftover
+    # tokens as an error SIBLING right after it, giving terminated containers
+    # (function/let/module/struct/while/...) an extra kid that breaks
+    # CSTParser's fixed iterate arities. Absorb such a width-bearing error kid
+    # into the preceding block as a trailing statement — blocks iterate args
+    # positionally, so any arg count is safe. Zero-SPAN markers (missing-`end`
+    # recovery) keep their per-form handling.
+    for j in length(kids):-1:2
+        if JuliaSyntax.is_error(kkinds[j]) && kids[j].span > 0
+            # look back past zero-span recovery markers for the body block
+            p = j - 1
+            while p >= 1 && JuliaSyntax.is_error(kkinds[p]) && kids[p].span == 0
+                p -= 1
+            end
+            if p >= 1 && kkinds[p] == K"block" && kids[p].head === :block &&
+               kids[p].args !== nothing
+                blk, err = kids[p], kids[j]
+                push!(blk.args, err)
+                CSTParser.setparent!(err, blk)
+                blk.fullspan += err.fullspan
+                blk.span = blk.fullspan - (err.fullspan - err.span)
+                ranges[p] = first(ranges[p]):last(ranges[j])
+                deleteat!(kids, j); deleteat!(kkinds, j); deleteat!(ranges, j)
+            end
+        end
+    end
     cur.kid_ranges = ranges   # inner assemble calls are done; safe to publish
     ex = assemble_form(kind(node), node, kids, kkinds, cur)
     # Spans from absolute leaf positions: independent of per-form layout.

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -56,8 +56,10 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
     elseif k0 == K"string" || k0 == K"cmdstring"
         # Interpolation/triple-quote dedent/cmd-literal reconstruction; see
         # assemble_quoted for why this can't be a simple leaf-run merge.
+        # assemble_quoted registers the close leaf's terminal itself (the
+        # trailing chunk for interpolated strings, the whole literal
+        # otherwise) so a `;`-fold widens the right node.
         expr = assemble_quoted(node, cur, k0 == K"cmdstring")
-        cur.terminals[cur.i - 1] = expr
         return expr
     end
     first_i = cur.i

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -49,7 +49,7 @@ function generic_form(k::Kind, kids::Vector{EXPR}, kkinds::Vector{Kind})
     trivia = EXPR[]
     for (ex, ck) in zip(kids, kkinds)
         if JuliaSyntax.is_keyword(ck) || ex.head in (:LPAREN, :RPAREN, :COMMA,
-            :LBRACE, :RBRACE, :LSQUARE, :RSQUARE, :SEMICOLON, :AT_SIGN, :DOT)
+            :LBRACE, :RBRACE, :LSQUARE, :RSQUARE, :SEMICOLON, :ATSIGN, :DOT)
             push!(trivia, ex)
         else
             push!(args, ex)

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -48,6 +48,11 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         cur.terminals[next_i - 1] = expr
         cur.i = next_i
         return expr
+    elseif k0 == K"var"
+        expr, next_i = merge_var(cur.leaves, cur.i, cur.src)
+        cur.terminals[next_i - 1] = expr
+        cur.i = next_i
+        return expr
     elseif k0 == K"string" || k0 == K"cmdstring"
         # Interpolation/triple-quote dedent/cmd-literal reconstruction; see
         # assemble_quoted for why this can't be a simple leaf-run merge.

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -67,7 +67,7 @@ function has_error_descendant(node::GreenNode)
     return any(has_error_descendant, children(node))
 end
 
-function assemble(node::GreenNode, cur::Cursor)::EXPR
+function assemble(node::GreenNode, cur::Cursor, is_cmdmacro_body::Bool=false)::EXPR
     if !haschildren(node)
         leaf = cur.leaves[cur.i]
         ex = terminal_expr(leaf, cur.src)
@@ -96,18 +96,33 @@ function assemble(node::GreenNode, cur::Cursor)::EXPR
         # trailing chunk for interpolated strings, the whole literal
         # otherwise) so a `;`-fold widens the right node.
         expr = assemble_quoted(node, cur, k0 == K"cmdstring")
-        return patch_dropped_width!(expr, node)
+        expr = patch_dropped_width!(expr, node)
+        if k0 == K"cmdstring" && !is_cmdmacro_body
+            # Unprefixed backtick literal: 1.x emits the bare cmdstring node
+            # with no wrapping macrocall at all (0.4 wrapped it in
+            # macrocall[core_@cmd, cmdstring]); synthesize CSTParser's
+            # :globalrefcmd macrocall wrapper ourselves. A prefixed literal
+            # (`m\`c\``) is the cmdstring DIRECTLY following its
+            # CmdMacroName sibling — already inside its own macrocall, no
+            # extra wrap; a bare cmd used as a macro ARG still wraps.
+            name = EXPR(:globalrefcmd, 0, 0, nothing)
+            return EXPR(:macrocall, EXPR[name, EXPR(:NOTHING, 0, 0, nothing), expr],
+                        EXPR[], expr.fullspan, expr.span)
+        end
+        return expr
     end
     first_i = cur.i
     kids = EXPR[]
     kkinds = Kind[]
     ranges = UnitRange{Int}[]
+    prev_kind = K"TOMBSTONE"
     for c in children(node)
         is_ws_trivia(kind(c)) && continue
         s = cur.i
-        push!(kids, assemble(c, cur))
+        push!(kids, assemble(c, cur, k0 == K"macrocall" && prev_kind == K"CmdMacroName"))
         push!(kkinds, kind(c))
         push!(ranges, s:cur.i-1)
+        prev_kind = kind(c)
     end
     cur.kid_ranges = ranges   # inner assemble calls are done; safe to publish
     ex = assemble_form(kind(node), node, kids, kkinds, cur)

--- a/src/cst_conversion/assembly.jl
+++ b/src/cst_conversion/assembly.jl
@@ -24,10 +24,40 @@ mutable struct Cursor
     # way to fullspan, covering the keyword's trailing trivia. Same
     # lifecycle as trim/trim_span: set by a form, applied+reset by assemble.
     grow_span::Int
+    # Prefix count of error-covered leaves: error_prefix[k+1] = number of the
+    # first k leaves that lie inside (or are) a green error node
+    # (error_prefix[1] = 0). Lets patch_dropped_width! test "does leaf range
+    # i:j overlap an error" in O(1) instead of re-walking the green subtree at
+    # every dropped-width site. Coverage (not just error-KIND leaves) is
+    # needed because a non-terminal K"error" can wrap ordinary tokens.
+    error_prefix::Vector{Int}
 end
 
-Cursor(leaves::Vector{Leaf}, i::Int, src::String) =
-    Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)), UnitRange{Int}[], 0, 0, 0)
+function Cursor(leaves::Vector{Leaf}, i::Int, src::String, green::GreenNode)
+    covered = Bool[]
+    _mark_error_covered!(covered, green, false)
+    error_prefix = Vector{Int}(undef, length(covered) + 1)
+    error_prefix[1] = 0
+    for k in eachindex(covered)
+        error_prefix[k+1] = error_prefix[k] + (covered[k] ? 1 : 0)
+    end
+    return Cursor(leaves, i, src, Vector{Union{Nothing,EXPR}}(nothing, length(leaves)),
+                  UnitRange{Int}[], 0, 0, 0, error_prefix)
+end
+
+# One non-ws leaf per entry, in flatten_leaves order; true when the leaf is
+# inside or is a green error node.
+function _mark_error_covered!(covered::Vector{Bool}, node::GreenNode, in_error::Bool)
+    e = in_error || JuliaSyntax.is_error(kind(node))
+    if !haschildren(node)
+        is_ws_trivia(kind(node)) || push!(covered, e)
+        return
+    end
+    for c in children(node)
+        _mark_error_covered!(covered, c, e)
+    end
+    return
+end
 
 const UNHANDLED_KINDS = Set{Kind}()
 # Salsa runs derived queries concurrently; no live race today, but harden anyway.
@@ -45,7 +75,7 @@ const UNHANDLED_LOCK = ReentrantLock()
 # gate only runs when a gap exists, which never happens on valid code, so
 # the non-error path pays nothing. Skips genuinely childless nodes (matrix
 # cells), same rule as check_spans itself.
-function patch_dropped_width!(ex::EXPR, node::GreenNode)
+function patch_dropped_width!(ex::EXPR, node::GreenNode, cur::Cursor, lo::Int, hi::Int)
     ex.args === nothing && return ex
     has_children = !isempty(ex.args) ||
                    (ex.trivia !== nothing && !isempty(ex.trivia)) ||
@@ -55,7 +85,7 @@ function patch_dropped_width!(ex::EXPR, node::GreenNode)
                (ex.trivia === nothing ? 0 : sum(c -> c.fullspan, ex.trivia; init=0)) +
                (ex.head isa EXPR ? ex.head.fullspan : 0)
     gap = ex.fullspan - childsum
-    if gap > 0 && has_error_descendant(node)
+    if gap > 0 && has_error_in_range(cur, node, lo, hi)
         filler = EXPR(:errortoken, gap, 0, nothing)
         push!(ex.args, filler)
         CSTParser.setparent!(filler, ex)
@@ -63,10 +93,13 @@ function patch_dropped_width!(ex::EXPR, node::GreenNode)
     return ex
 end
 
-function has_error_descendant(node::GreenNode)
+# O(1) error presence over a node's consumed leaf range via the prefix count,
+# plus the node's own kind (a childless/zero-width K"error" non-terminal
+# consumes no leaf, so it wouldn't show up in the leaf range).
+function has_error_in_range(cur::Cursor, node::GreenNode, lo::Int, hi::Int)
     JuliaSyntax.is_error(kind(node)) && return true
-    haschildren(node) || return false
-    return any(has_error_descendant, children(node))
+    hi >= lo || return false
+    return cur.error_prefix[hi+1] - cur.error_prefix[lo] > 0
 end
 
 function assemble(node::GreenNode, cur::Cursor, is_cmdmacro_body::Bool=false)::EXPR
@@ -97,8 +130,9 @@ function assemble(node::GreenNode, cur::Cursor, is_cmdmacro_body::Bool=false)::E
         # assemble_quoted registers the close leaf's terminal itself (the
         # trailing chunk for interpolated strings, the whole literal
         # otherwise) so a `;`-fold widens the right node.
+        str_lo = cur.i
         expr = assemble_quoted(node, cur, k0 == K"cmdstring")
-        expr = patch_dropped_width!(expr, node)
+        expr = patch_dropped_width!(expr, node, cur, str_lo, cur.i - 1)
         if k0 == K"cmdstring" && !is_cmdmacro_body
             # Unprefixed backtick literal: 1.x emits the bare cmdstring node
             # with no wrapping macrocall at all (0.4 wrapped it in
@@ -145,7 +179,7 @@ function assemble(node::GreenNode, cur::Cursor, is_cmdmacro_body::Bool=false)::E
         ex.span = min(ex.span + cur.grow_span, ex.fullspan)
         cur.grow_span = 0
     end
-    patch_dropped_width!(ex, node)
+    patch_dropped_width!(ex, node, cur, first_i, cur.i - 1)
     return ex
 end
 

--- a/src/cst_conversion/compare.jl
+++ b/src/cst_conversion/compare.jl
@@ -29,3 +29,25 @@ trees_equal(a::EXPR, b::EXPR) = first_tree_diff(a, b) === nothing
 
 # Compare converter output against CSTParser for the same source.
 oracle_diff(src::AbstractString) = first_tree_diff(build_cst(src), CSTParser.parse(src, true))
+
+# EXPR span bookkeeping invariants; layout-independent sanity for broken code
+# where no oracle equality is possible.
+function check_spans(x::EXPR; path::String="□")
+    x.span <= x.fullspan || return "$path: span $(x.span) > fullspan $(x.fullspan)"
+    x.args === nothing && return nothing
+    childsum = sum(c -> c.fullspan, x.args; init=0) +
+               (x.trivia === nothing ? 0 : sum(c -> c.fullspan, x.trivia; init=0)) +
+               (x.head isa EXPR ? x.head.fullspan : 0)
+    childsum == x.fullspan || return "$path: children sum $childsum != fullspan $(x.fullspan)"
+    for (i, c) in enumerate(x.args)
+        d = check_spans(c; path="$path.args[$i]")
+        d === nothing || return d
+    end
+    if x.trivia !== nothing
+        for (i, c) in enumerate(x.trivia)
+            d = check_spans(c; path="$path.trivia[$i]")
+            d === nothing || return d
+        end
+    end
+    return nothing
+end

--- a/src/cst_conversion/compare.jl
+++ b/src/cst_conversion/compare.jl
@@ -35,6 +35,13 @@ oracle_diff(src::AbstractString) = first_tree_diff(build_cst(src), CSTParser.par
 function check_spans(x::EXPR; path::String="□")
     x.span <= x.fullspan || return "$path: span $(x.span) > fullspan $(x.fullspan)"
     x.args === nothing && return nothing
+    # The childsum invariant is only meaningful when children exist: terminal
+    # nodes carrying empty (not nothing) args/trivia — CSTParser's bare
+    # matrix cells — have real width but nothing to sum against it.
+    has_children = !isempty(x.args) ||
+                   (x.trivia !== nothing && !isempty(x.trivia)) ||
+                   x.head isa EXPR
+    has_children || return nothing
     childsum = sum(c -> c.fullspan, x.args; init=0) +
                (x.trivia === nothing ? 0 : sum(c -> c.fullspan, x.trivia; init=0)) +
                (x.head isa EXPR ? x.head.fullspan : 0)

--- a/src/cst_conversion/compare.jl
+++ b/src/cst_conversion/compare.jl
@@ -39,6 +39,10 @@ function check_spans(x::EXPR; path::String="□")
                (x.trivia === nothing ? 0 : sum(c -> c.fullspan, x.trivia; init=0)) +
                (x.head isa EXPR ? x.head.fullspan : 0)
     childsum == x.fullspan || return "$path: children sum $childsum != fullspan $(x.fullspan)"
+    if x.head isa EXPR
+        d = check_spans(x.head; path="$path.head")
+        d === nothing || return d
+    end
     for (i, c) in enumerate(x.args)
         d = check_spans(c; path="$path.args[$i]")
         d === nothing || return d

--- a/src/cst_conversion/compare.jl
+++ b/src/cst_conversion/compare.jl
@@ -26,3 +26,6 @@ function first_tree_diff(a::EXPR, b::EXPR; path::String="□")
 end
 
 trees_equal(a::EXPR, b::EXPR) = first_tree_diff(a, b) === nothing
+
+# Compare converter output against CSTParser for the same source.
+oracle_diff(src::AbstractString) = first_tree_diff(build_cst(src), CSTParser.parse(src, true))

--- a/src/cst_conversion/compare.jl
+++ b/src/cst_conversion/compare.jl
@@ -1,0 +1,28 @@
+# Structural equality of EXPR trees ignoring parent/meta.
+# Returns nothing when equal, else a human-readable path to the first divergence.
+function first_tree_diff(a::EXPR, b::EXPR; path::String="□")
+    if typeof(a.head) != typeof(b.head)
+        return "$path: head type $(typeof(a.head)) vs $(typeof(b.head))"
+    end
+    if a.head isa Symbol
+        a.head === b.head || return "$path: head $(a.head) vs $(b.head)"
+    else
+        d = first_tree_diff(a.head, b.head; path="$path.head")
+        d === nothing || return d
+    end
+    a.val == b.val || return "$path: val $(repr(a.val)) vs $(repr(b.val))"
+    a.fullspan == b.fullspan || return "$path: fullspan $(a.fullspan) vs $(b.fullspan)"
+    a.span == b.span || return "$path: span $(a.span) vs $(b.span)"
+    for (field, fa, fb) in ((:args, a.args, b.args), (:trivia, a.trivia, b.trivia))
+        (fa === nothing) == (fb === nothing) || return "$path: $field nothing-ness differs"
+        fa === nothing && continue
+        length(fa) == length(fb) || return "$path: $field length $(length(fa)) vs $(length(fb))"
+        for i in eachindex(fa)
+            d = first_tree_diff(fa[i], fb[i]; path="$path.$field[$i]")
+            d === nothing || return d
+        end
+    end
+    return nothing
+end
+
+trees_equal(a::EXPR, b::EXPR) = first_tree_diff(a, b) === nothing

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -340,8 +340,15 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # as the K"quote" branch below does for the A.@m x case where the
         # `@` sits on the RHS instead).
         atex, nameex, dotex, rhs = kids
-        lhs = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
-                   atex.span + nameex.span, "@" * nameex.val)
+        lhs = if nameex.val isa String
+            EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
+                 atex.span + nameex.span, "@" * nameex.val)
+        else
+            # Broken macro name (missing/errored) — can't fuse into one
+            # IDENTIFIER; keep both pieces reachable instead.
+            EXPR(:errortoken, EXPR[atex, nameex], nothing,
+                 atex.fullspan + nameex.fullspan, atex.span + nameex.span)
+        end
         return EXPR(dotex, EXPR[lhs, rhs], nothing, 0, 0)
     elseif k == K"quote"
         # Three shapes share this kind:
@@ -369,11 +376,18 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         end
         if kkinds[1] == K"@"
             atex, nameex = kids
-            fused = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
-                        atex.span + nameex.span, "@" * nameex.val)
-            # Register the fused name at its leaf slot so a `;`-fold onto a
-            # qualified macrocall (`(Base.@m; x)`) widens THIS EXPR.
-            cur.terminals[first(cur.kid_ranges[2])] = fused
+            if nameex.val isa String
+                fused = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
+                            atex.span + nameex.span, "@" * nameex.val)
+                # Register the fused name at its leaf slot so a `;`-fold onto
+                # a qualified macrocall (`(Base.@m; x)`) widens THIS EXPR.
+                cur.terminals[first(cur.kid_ranges[2])] = fused
+                return EXPR(:quotenode, EXPR[fused], nothing, 0, 0)
+            end
+            # Broken macro name (missing/errored) — can't fuse into one
+            # IDENTIFIER; keep both pieces reachable instead.
+            fused = EXPR(:errortoken, EXPR[atex, nameex], nothing,
+                         atex.fullspan + nameex.fullspan, atex.span + nameex.span)
             return EXPR(:quotenode, EXPR[fused], nothing, 0, 0)
         end
         args = EXPR[]
@@ -526,11 +540,19 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # after it (args[3]).
         if kkinds[1] == K"@"
             atex, nameex = kids[1], kids[2]
-            name = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
-                        atex.span + nameex.span, "@" * nameex.val)
-            # Register the fused name at its leaf slot so a later `;`-fold
-            # (e.g. `:(@m; x)`) widens THIS EXPR, not the orphaned MacroName.
-            cur.terminals[first(cur.kid_ranges[2])] = name
+            if nameex.val isa String
+                name = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
+                            atex.span + nameex.span, "@" * nameex.val)
+                # Register the fused name at its leaf slot so a later `;`-fold
+                # (e.g. `:(@m; x)`) widens THIS EXPR, not the orphaned MacroName.
+                cur.terminals[first(cur.kid_ranges[2])] = name
+            else
+                # Broken macro name (missing/errored, e.g. `x = @`): can't
+                # fuse `@`+name into one IDENTIFIER — keep both pieces so
+                # spans still tile and the error stays traversable.
+                name = EXPR(:errortoken, EXPR[atex, nameex], nothing,
+                             atex.fullspan + nameex.fullspan, atex.span + nameex.span)
+            end
             rest, restk = kids[3:end], kkinds[3:end]
         else
             name = kids[1]
@@ -586,8 +608,16 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             if ck == K"@" && i < length(kids)
                 # `A.@m` path component: fuse `@`+MacroName into one IDENTIFIER.
                 nm = kids[i+1]
-                push!(args, EXPR(:IDENTIFIER, ex.fullspan + nm.fullspan,
-                                 ex.span + nm.span, "@" * nm.val))
+                if nm.val isa String
+                    push!(args, EXPR(:IDENTIFIER, ex.fullspan + nm.fullspan,
+                                     ex.span + nm.span, "@" * nm.val))
+                else
+                    # Broken macro name (missing/errored, e.g. a bare `@` at
+                    # EOF) — can't fuse into one IDENTIFIER; keep both pieces
+                    # reachable instead.
+                    push!(args, EXPR(:errortoken, EXPR[ex, nm], nothing,
+                                      ex.fullspan + nm.fullspan, ex.span + nm.span))
+                end
                 seen = true
                 i += 2
             elseif ck == K"."
@@ -662,8 +692,15 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(trivia, ex)
             elseif ck == K"@" && i < length(kids)
                 nm = kids[i+1]
-                push!(args, EXPR(:IDENTIFIER, ex.fullspan + nm.fullspan,
-                                 ex.span + nm.span, "@" * nm.val))
+                if nm.val isa String
+                    push!(args, EXPR(:IDENTIFIER, ex.fullspan + nm.fullspan,
+                                     ex.span + nm.span, "@" * nm.val))
+                else
+                    # Broken macro name (missing/errored) — can't fuse into
+                    # one IDENTIFIER; keep both pieces reachable instead.
+                    push!(args, EXPR(:errortoken, EXPR[ex, nm], nothing,
+                                      ex.fullspan + nm.fullspan, ex.span + nm.span))
+                end
                 i += 1
             else
                 push!(args, ex)
@@ -1264,6 +1301,12 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             grow_span_to_last_arg!(cur, args)
         return EXPR(:block, args, isempty(trivia) ? nothing : trivia, 0, 0)
     elseif k == K"parens"
+        if length(kids) < 2
+            # Broken input: missing open and/or close paren (e.g. an
+            # unterminated `$(` at EOF) collapses to a single error kid —
+            # no open/close pair to split off as trivia.
+            return EXPR(:brackets, EXPR[], kids, 0, 0)
+        end
         trivia = EXPR[kids[1], kids[end]]
         return EXPR(:brackets, kids[2:end-1], trivia, 0, 0)
     elseif k == K"function"
@@ -1281,6 +1324,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         is_mutable = false
         sig = nothing
         body = nothing
+        errs = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
             if ck == K"mutable"
                 is_mutable = true
@@ -1289,12 +1333,17 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(trivia, ex)
             elseif ck == K"block"
                 body = ex
-            else
+            elseif sig === nothing
                 sig = ex
+            else
+                # A further unclassified kid (e.g. broken input's trailing
+                # error marker for a missing `end`) — never overwrite the
+                # real signature; keep it reachable instead of dropping it.
+                push!(errs, ex)
             end
         end
         marker = EXPR(is_mutable ? :TRUE : :FALSE, 0, 0, nothing)
-        return EXPR(:struct, EXPR[marker, sig, body], trivia, 0, 0)
+        return EXPR(:struct, EXPR[marker, sig, body, errs...], trivia, 0, 0)
     elseif k == K"abstract"
         trivia = EXPR[]
         args = EXPR[]
@@ -1324,6 +1373,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         is_bare = false
         name = nothing
         body = nothing
+        errs = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
             if ck == K"baremodule"
                 is_bare = true
@@ -1332,15 +1382,20 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(trivia, ex)
             elseif ck == K"block"
                 body = ex
-            else
+            elseif name === nothing
                 name = ex
+            else
+                # A further unclassified kid (e.g. broken input's trailing
+                # error marker for a missing `end`) — never overwrite the
+                # real name; keep it reachable instead of dropping it.
+                push!(errs, ex)
             end
         end
         # A var"..." module name keeps trivia = EXPR[] (oracle-pinned; a
         # standalone var"..." value keeps nothing).
         name.head === :NONSTDIDENTIFIER && (name.trivia = EXPR[])
         marker = EXPR(is_bare ? :FALSE : :TRUE, 0, 0, nothing)
-        return EXPR(:module, EXPR[marker, name, body], trivia, 0, 0)
+        return EXPR(:module, EXPR[marker, name, body, errs...], trivia, 0, 0)
     elseif k == K"const" || k == K"global" || k == K"local"
         # `global a, b` / `local x, y` → names in args, keyword+commas trivia.
         sym = Symbol(lowercase(string(k)))
@@ -1380,6 +1435,12 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # Remaining prefix-unary-syntax-head kinds (e.g. `&x`), same shape
         # as bare `::T` above; same last-resort placement rationale.
         return EXPR(kids[1], EXPR[kids[2]], nothing, 0, 0)
+    elseif k == K"error"
+        # A non-leaf error node (e.g. wraps an unexpected token, or is
+        # entirely childless — a missing-token marker). CSTParser has no
+        # equivalent shape for this; mirror the leaf errortoken so the
+        # subtree stays traversable and spans still tile.
+        return EXPR(:errortoken, kids, nothing, 0, 0)
     end
     return generic_form(k, kids, kkinds)
 end

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -222,8 +222,14 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
     elseif k == K"juxtapose"
         # 2x / 2(x+1) → implicit multiplication; CSTParser synthesizes a
         # zero-width `*` operator since juxtaposition has no real op leaf.
-        op = EXPR(:OPERATOR, 0, 0, "*")
-        return EXPR(:call, EXPR[op, kids[1], kids[2]], nothing, 0, 0)
+        # 3+ factors (`4A'B'`) nest right: `4 * (A' * B')`.
+        acc = kids[end]
+        for i in length(kids)-1:-1:1
+            fs = kids[i].fullspan + acc.fullspan
+            acc = EXPR(:call, EXPR[EXPR(:OPERATOR, 0, 0, "*"), kids[i], acc],
+                       nothing, fs, fs - (acc.fullspan - acc.span))
+        end
+        return acc
     elseif k == K"comparison"
         # a < b < c → flat (:comparison, [a, op, b, op, c, ...]) — kids are
         # already in this exact order/shape. Dotted comparison operators
@@ -357,6 +363,11 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             args[1] = EXPR(:OPERATOR, di.fullspan, di.span, di.head.val * di.args[1].val)
         end
         inner = args[1]
+        # A quoted string field name (`a."prop"`) is used directly as the
+        # getfield RHS — no :quotenode wrapper.
+        if isempty(trivia) && inner.head in (:STRING, :TRIPLESTRING)
+            return inner
+        end
         # Word operators (`:where`/`:in`/`:isa`) tokenize as Identifier after
         # a quote colon, but CSTParser labels them OPERATOR. Only when the
         # quote is colon-prefixed — a bare getfield field name (`p.in`) stays
@@ -700,6 +711,13 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # reaches its fullspan (bare `return`, qualified-macrocall RHS).
         grow_span_to_last_arg!(cur, EXPR[lhs, body])
         return EXPR(op, EXPR[lhs, body], nothing, 0, 0)
+    elseif (k == K"::" || k == K"<:" || k == K">:") && length(kids) >= 2 &&
+           kkinds[1] == k && kkinds[2] == K"("
+        # operator-as-function-call: `<:(a, b)` → operator-headed with the
+        # parenthesized args, parens/commas as trivia.
+        op = kids[1]
+        args, trivia, groups = collect_arglist(kids[2:end], kkinds[2:end], K"(", K")")
+        return EXPR(op, args, trivia, 0, 0)
     elseif (k == K"::" || k == K"<:") && length(kids) == 3
         # binary syntax: operator EXPR becomes the head (type declarations,
         # supertype clauses)
@@ -1229,12 +1247,23 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         return EXPR(:module, EXPR[marker, name, body], trivia, 0, 0)
     elseif k == K"const" || k == K"global" || k == K"local"
         # `global a, b` / `local x, y` → names in args, keyword+commas trivia.
+        sym = Symbol(lowercase(string(k)))
         trivia = EXPR[]
         args = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
             (ck == k || ck == K",") ? push!(trivia, ex) : push!(args, ex)
         end
-        return EXPR(Symbol(lowercase(string(k))), args, trivia, 0, 0)
+        # `global const x = 1`: green nests const inside the modifier, but
+        # CSTParser puts const outermost — swap (spans are logical, not
+        # positional; childsums still balance).
+        if sym != :const && length(args) == 1 && args[1].head === :const
+            inner = args[1]
+            gkw = trivia[1]
+            mfs = gkw.fullspan + sum(a -> a.fullspan, inner.args; init=0)
+            modifier = EXPR(sym, inner.args, EXPR[gkw], mfs, mfs)
+            return EXPR(:const, EXPR[modifier], inner.trivia, 0, 0)
+        end
+        return EXPR(sym, args, trivia, 0, 0)
     elseif length(kids) == 3 && kkinds[2] == k && JuliaSyntax.is_operator(k)
         # Remaining binary-syntax-head kinds that use the operator's own
         # Kind as the NODE's kind (not K"call"): compound assignment

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -166,6 +166,20 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             end
         end
         return EXPR(:call, args, isempty(trivia) ? nothing : trivia, 0, 0)
+    elseif k == K"call" && JuliaSyntax.is_postfix_op_call(JuliaSyntax.head(node)) && length(kids) == 2
+        # x' (postfix adjoint) → operator-headed EXPR (kids=[operand, op]),
+        # unlike prefix calls (-x/!x) which stay :call-symbol-headed with the
+        # operator as a plain leading arg.
+        return EXPR(kids[2], EXPR[kids[1]], nothing, 0, 0)
+    elseif k == K"juxtapose"
+        # 2x / 2(x+1) → implicit multiplication; CSTParser synthesizes a
+        # zero-width `*` operator since juxtaposition has no real op leaf.
+        op = EXPR(:OPERATOR, 0, 0, "*")
+        return EXPR(:call, EXPR[op, kids[1], kids[2]], nothing, 0, 0)
+    elseif k == K"comparison"
+        # a < b < c → flat (:comparison, [a, op, b, op, c, ...]) — kids are
+        # already in this exact order/shape, just need the right head/trivia.
+        return EXPR(:comparison, kids, nothing, 0, 0)
     elseif k == K"call"
         # f(x, y) → (:call, [f, x, y], trivia=[lparen, commas..., rparen]).
         # `;`-separated keyword args nest under a `parameters` child at their
@@ -179,6 +193,37 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         args, trivia, groups = collect_arglist(kids, kkinds, K"(", K")")
         isempty(groups) || insert!(args, 2, merge_params!(groups))
         return EXPR(:call, args, isempty(trivia) ? nothing : trivia, 0, 0)
+    elseif k == K"dotcall" && JuliaSyntax.is_infix_op_call(JuliaSyntax.head(node))
+        # a .+ b (.+ c ...) → dotted infix broadcast; JuliaSyntax keeps `.`
+        # and the operator as TWO separate leaves (unlike macrocall's `@name`
+        # fusion precedent, but the same fold: sum fullspan/span, concat
+        # val), then reuses the plain infix-call shape (:call, [op, a, b,...]).
+        lhs = kids[1]
+        args = EXPR[]
+        trivia = EXPR[]
+        j = 2
+        first_op = true
+        while j < length(kids)
+            dotex, opex = kids[j], kids[j+1]
+            fused = EXPR(:OPERATOR, dotex.fullspan + opex.fullspan,
+                        dotex.span + opex.span, dotex.val * opex.val)
+            if first_op
+                args = EXPR[fused, lhs]
+                first_op = false
+            else
+                push!(trivia, fused)
+            end
+            j += 2
+            push!(args, kids[j])
+            j += 1
+        end
+        return EXPR(:call, args, isempty(trivia) ? nothing : trivia, 0, 0)
+    elseif k == K"dotcall" && JuliaSyntax.is_prefix_op_call(JuliaSyntax.head(node))
+        # .!x → dotted prefix broadcast; same `.`+op fusion, single operand.
+        dotex, opex, operand = kids[1], kids[2], kids[3]
+        fused = EXPR(:OPERATOR, dotex.fullspan + opex.fullspan,
+                    dotex.span + opex.span, dotex.val * opex.val)
+        return EXPR(:call, EXPR[fused, operand], nothing, 0, 0)
     elseif k == K"dotcall"
         # f.(x, y) → (:., [f, tuple(x, y)]); the parenthesized arg list packs
         # into a :tuple the same way a call's does (parameters relocate to
@@ -200,9 +245,25 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # ::/<:/->. The field-name side is always a K"quote" child (see the
         # branch below), already packaged as :quotenode by the time we see it.
         return EXPR(kids[2], EXPR[kids[1], kids[3]], nothing, 0, 0)
+    elseif k == K"." && length(kids) == 4 && kkinds[1] == K"@"
+        # @m.n x: a dotted/qualified macro name — the LHS itself is an
+        # unfused `@`+name pair (same fusion as macrocall's own @+name, and
+        # as the K"quote" branch below does for the A.@m x case where the
+        # `@` sits on the RHS instead).
+        atex, nameex, dotex, rhs = kids
+        lhs = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
+                   atex.span + nameex.span, "@" * nameex.val)
+        return EXPR(dotex, EXPR[lhs, rhs], nothing, 0, 0)
     elseif k == K"quote" && length(kids) <= 2
-        # Field-name wrapper under getfield's `.`: bare `b`, or `:b` with an
-        # explicit-quote colon kept as trivia.
+        # Field-name wrapper under getfield's `.`: bare `b`, `:b` with an
+        # explicit-quote colon kept as trivia, or (A.@m x) an unfused `@`+
+        # name pair fused into a single "@name" IDENTIFIER.
+        if !isempty(kkinds) && kkinds[1] == K"@"
+            atex, nameex = kids
+            fused = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
+                        atex.span + nameex.span, "@" * nameex.val)
+            return EXPR(:quotenode, EXPR[fused], nothing, 0, 0)
+        end
         args = EXPR[]
         trivia = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
@@ -234,7 +295,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         args, trivia, groups = collect_arglist(rest, restk, K"(", K")")
         args = EXPR[name, EXPR(:NOTHING, 0, 0, nothing), args...]
         isempty(groups) || insert!(args, 3, merge_params!(groups))
-        return EXPR(:macrocall, args, isempty(trivia) ? nothing : trivia, 0, 0)
+        # Unprefixed cmd literals (name.head == :globalrefcmd) always keep
+        # trivia = EXPR[], oracle-pinned, unlike every other macrocall shape.
+        macro_trivia = name.head === :globalrefcmd ? EXPR[] : (isempty(trivia) ? nothing : trivia)
+        return EXPR(:macrocall, args, macro_trivia, 0, 0)
     elseif k == K"do"
         # `f(x) do y ... end` desugars to a call plus a synthetic zero-width
         # `->` operator wrapping the (params-tuple, body-block) pair — no
@@ -296,7 +360,13 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # their RHS in an implicit block; plain assignment does not, and an
         # explicit `begin ... end` RHS is never wrapped a second time.
         lhs, op, rhs = kids
-        if k == K"=" && op.val != "="
+        if k == K"=" && JuliaSyntax.is_dotted(JuliaSyntax.head(node))
+            # a .= b: dotted assignment reuses base K"=" plus a DOTTED flag
+            # instead of a distinct Kind (unlike +=/-=/etc, which get their
+            # own Kind and are handled by the generic operator branch below)
+            # — op.val is already the real ".=" text, no fusion needed.
+            return EXPR(op, EXPR[lhs, rhs], nothing, 0, 0)
+        elseif k == K"=" && op.val != "="
             # for-loop/comprehension iteration spec (`i in xs`/`i ∈ xs`):
             # JuliaSyntax reuses K"=" regardless of the actual keyword; the
             # oracle always synthesizes a zero-width "=" head and relocates
@@ -815,6 +885,20 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             ck == k ? push!(trivia, ex) : push!(args, ex)
         end
         return EXPR(Symbol(lowercase(string(k))), args, trivia, 0, 0)
+    elseif length(kids) == 3 && kkinds[2] == k && JuliaSyntax.is_operator(k)
+        # Remaining binary-syntax-head kinds that use the operator's own
+        # Kind as the NODE's kind (not K"call"): compound assignment
+        # (+=/.=/...), short-circuit (&&/||), and remaining comparison-as-
+        # syntax ops (>:) — same shape as =/->/::/<:` above, just not
+        # special-cased per-operator since none of them need block-wrapping.
+        # Placed last: `where`/`in`/`isa` are also JuliaSyntax "operators"
+        # by precedence but have their own dedicated non-operator-headed
+        # branches earlier, which must win first.
+        return EXPR(kids[2], EXPR[kids[1], kids[3]], nothing, 0, 0)
+    elseif length(kids) == 2 && kkinds[1] == k && JuliaSyntax.is_operator(k)
+        # Remaining prefix-unary-syntax-head kinds (e.g. `&x`), same shape
+        # as bare `::T` above; same last-resort placement rationale.
+        return EXPR(kids[1], EXPR[kids[2]], nothing, 0, 0)
     end
     return generic_form(k, kids, kkinds)
 end

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -14,11 +14,13 @@ function widen_at_leaf!(cur::Cursor, i::Int, width::Int)
     node === nothing && return false
     while node !== nothing
         # A node whose LAST arg is a zero-width marker (e.g. a bare `@m`
-        # macrocall's NOTHING) measures span to fullspan; a `;` folded onto
-        # it extends span too. Every other node keeps the `;` as excluded
-        # trailing width (span measures to the last real leaf/arg).
+        # macrocall's NOTHING) AND which has no trailing trivia measures span
+        # to fullspan; a `;` folded onto it extends span too. A node ending in
+        # trailing trivia (e.g. a `try ... end`, span measured to END) keeps
+        # the `;` as excluded trailing width even with an empty last arg.
         grow = node.args !== nothing && !isempty(node.args) &&
-               node.args[end].fullspan == 0 && node.span == node.fullspan
+               node.args[end].fullspan == 0 && node.span == node.fullspan &&
+               (node.trivia === nothing || isempty(node.trivia))
         node.fullspan += width
         grow && (node.span += width)
         node = node.parent
@@ -1282,6 +1284,9 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 name = ex
             end
         end
+        # A var"..." module name keeps trivia = EXPR[] (oracle-pinned; a
+        # standalone var"..." value keeps nothing).
+        name.head === :NONSTDIDENTIFIER && (name.trivia = EXPR[])
         marker = EXPR(is_bare ? :FALSE : :TRUE, 0, 0, nothing)
         return EXPR(:module, EXPR[marker, name, body], trivia, 0, 0)
     elseif k == K"const" || k == K"global" || k == K"local"

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -1081,13 +1081,25 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         trivia = EXPR[]
         args = EXPR[]
         haserr = false
-        for (ex, ck) in zip(kids, kkinds)
+        orphan = 0
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ex.args === nothing && (ck == K"?" || ck == K":")
                 push!(trivia, ex)
             elseif JuliaSyntax.is_error(ck)
                 # Broken ternary emits zero-width error markers; drop them and
-                # rebuild the fixed cond?then:else arity below.
+                # rebuild the fixed cond?then:else arity below. A marker can
+                # carry folded trailing trivia (`a ? b\n`): fold that width
+                # onto the preceding real leaf (skipping earlier markers) so
+                # patch_dropped_width! never materializes a filler arg that
+                # breaks the arity.
                 haserr = true
+                if ex.fullspan > 0
+                    i = first(cur.kid_ranges[j]) - 1
+                    while i >= 1 && JuliaSyntax.is_error(cur.leaves[i].kind)
+                        i -= 1
+                    end
+                    widen_at_leaf!(cur, i, ex.fullspan) || (orphan += ex.fullspan)
+                end
             else
                 push!(args, ex)
             end
@@ -1095,11 +1107,15 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         if haserr
             # Pad to CSTParser's 3-arg/2-trivia ternary shape so its iterate
             # accessor stays in bounds (recovery differs from the oracle).
+            # `orphan` (no real leaf preceded the marker) rides on the first
+            # pad so childsums stay balanced.
             while length(args) < 3
-                push!(args, EXPR(:errortoken, 0, 0, nothing))
+                push!(args, EXPR(:errortoken, orphan, 0, nothing))
+                orphan = 0
             end
             while length(trivia) < 2
-                push!(trivia, EXPR(:errortoken, 0, 0, nothing))
+                push!(trivia, EXPR(:errortoken, orphan, 0, nothing))
+                orphan = 0
             end
         end
         return EXPR(:if, args, trivia, 0, 0)

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -13,7 +13,14 @@ function widen_at_leaf!(cur::Cursor, i::Int, width::Int)
     node = i >= 1 ? cur.terminals[i] : nothing
     node === nothing && return false
     while node !== nothing
+        # A node whose LAST arg is a zero-width marker (e.g. a bare `@m`
+        # macrocall's NOTHING) measures span to fullspan; a `;` folded onto
+        # it extends span too. Every other node keeps the `;` as excluded
+        # trailing width (span measures to the last real leaf/arg).
+        grow = node.args !== nothing && !isempty(node.args) &&
+               node.args[end].fullspan == 0 && node.span == node.fullspan
         node.fullspan += width
+        grow && (node.span += width)
         node = node.parent
     end
     return true
@@ -341,9 +348,15 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
            inner.val in ("where", "in", "isa")
             inner.head = :OPERATOR
         end
+        # `begin` maps to BEGIN in index context (terminal_expr), but as a
+        # quoted field/symbol (`a.begin`, `:begin`) it is an IDENTIFIER.
+        inner.head === :BEGIN && (inner.head = :IDENTIFIER)
         target = (inner.head === :brackets && inner.args !== nothing &&
                   length(inner.args) == 1) ? inner.args[1] : inner
-        head = target.args === nothing ? :quotenode : :quote
+        # atoms → :quotenode, composites → :quote; a var"..." nonstandard
+        # identifier counts as an atom.
+        head = (target.args === nothing || target.head === :NONSTDIDENTIFIER) ?
+               :quotenode : :quote
         return EXPR(head, args, isempty(trivia) ? nothing : trivia, 0, 0)
     elseif k == K"curly"
         # A{T; S} → (:curly, [A, parameters, T]) — parameters relocates to
@@ -450,6 +463,9 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             atex, nameex = kids[1], kids[2]
             name = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
                         atex.span + nameex.span, "@" * nameex.val)
+            # Register the fused name at its leaf slot so a later `;`-fold
+            # (e.g. `:(@m; x)`) widens THIS EXPR, not the orphaned MacroName.
+            cur.terminals[first(cur.kid_ranges[2])] = name
             rest, restk = kids[3:end], kkinds[3:end]
         else
             name = kids[1]
@@ -655,8 +671,13 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             head = EXPR(:OPERATOR, 0, 0, "=")
             return EXPR(head, EXPR[lhs, rhs], EXPR[op], 0, 0)
         end
-        needs_block = (k == K"->" || kkinds[1] == K"call" || kkinds[1] == K"where") &&
-                      kkinds[3] != K"block"
+        # A short-form definition (block-wrapped body) is keyed by the LHS
+        # being a call / where-clause / return-type-annotated call
+        # (`f()::T = ...`) — but NOT a plain typed assignment (`x::T = 5`).
+        typed_def = kkinds[1] == K"::" && lhs.args !== nothing &&
+                    !isempty(lhs.args) && lhs.args[1].head === :call
+        needs_block = (k == K"->" || kkinds[1] == K"call" || kkinds[1] == K"where" ||
+                       typed_def) && kkinds[3] != K"block"
         body = needs_block ? EXPR(:block, EXPR[rhs], nothing, rhs.fullspan, rhs.span) : rhs
         # Span is measured to the last arg; grow when that arg's span already
         # reaches its fullspan (bare `return`, qualified-macrocall RHS).
@@ -859,6 +880,18 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         end
         length(bindings.args) == 1 && (bindings = bindings.args[1])
         return EXPR(:let, EXPR[bindings, body], trivia, 0, 0)
+    elseif k == K"while" || k == K"for"
+        # `while cond body end` / `for spec body end` → args=[cond/spec, body],
+        # trivia=[keyword, END]. A real branch (not generic_form) is needed
+        # because the condition/spec can itself be keyword-kinded (e.g. a
+        # `while let ... end`), which generic_form would misfile as trivia.
+        sym = k == K"while" ? :while : :for
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == k || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(sym, args, trivia, 0, 0)
     elseif k == K"cartesian_iterator"
         # Multi-spec `for`/generator iteration (`i = 1:10, j in ys`) → a
         # synthetic :block of iteration specs with comma trivia.
@@ -959,8 +992,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             end
         end
         length(cells) >= 2 && foreach(matrix_cell!, cells)
-        !isempty(kkinds) && kkinds[end] == K";" &&
-            (cur.trim_span += trailing_semi_span(kids, kkinds))
+        # Span is measured to the last cell, not the trailing `;` run (which
+        # folds into that cell's fullspan) — this also excludes whitespace
+        # between the last cell and the `;`.
+        trim_span_to_last_arg!(cur, cells)
         return EXPR(:row, cells, EXPR[], 0, 0)
     elseif k == K"vcat"
         # Either wraps nested :row children (2D matrices) or holds bare cells
@@ -1003,8 +1038,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             end
         end
         length(cells) >= 2 && foreach(matrix_cell!, cells)
-        !isempty(kkinds) && kkinds[end] == K";" &&
-            (cur.trim_span += trailing_semi_span(kids, kkinds))
+        # Span is measured to the last cell, not the trailing `;` run (which
+        # folds into that cell's fullspan) — this also excludes whitespace
+        # between the last cell and the `;`.
+        trim_span_to_last_arg!(cur, cells)
         args = EXPR[EXPR(Symbol(string(dim)), 0, 0, "")]
         append!(args, cells)
         return EXPR(:nrow, args, EXPR[], 0, 0)

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -1322,7 +1322,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             inner = args[1]
             gkw = trivia[1]
             mfs = gkw.fullspan + sum(a -> a.fullspan, inner.args; init=0)
-            modifier = EXPR(sym, inner.args, EXPR[gkw], mfs, mfs)
+            # span measured to the last inner arg (e.g. `= if … end` excludes
+            # its own trailing).
+            la = inner.args[end]
+            modifier = EXPR(sym, inner.args, EXPR[gkw], mfs, mfs - (la.fullspan - la.span))
             return EXPR(:const, EXPR[modifier], inner.trivia, 0, 0)
         end
         return EXPR(sym, args, trivia, 0, 0)

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -279,7 +279,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # (`a .== b`) arrive as a K"." composite (dot+op leaves); fuse each
         # into one OPERATOR leaf (val ".==") like CSTParser does.
         args = EXPR[]
-        for (ex, ck) in zip(kids, kkinds)
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ck == K"." && ex.head isa EXPR && ex.args !== nothing &&
                length(ex.args) == 1 && ex.args[1].head === :OPERATOR
                 # dotted comparison operator (`.==`); NOT a getfield `.x`
@@ -287,6 +287,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(args, EXPR(:OPERATOR, ex.fullspan, ex.span,
                                  ex.head.val * ex.args[1].val))
             else
+                # Word operators (`isa`/`in`/`where`) in an operator slot
+                # (even position) tokenize as Identifier but label OPERATOR.
+                iseven(j) && ex.head === :IDENTIFIER &&
+                    ex.val in ("where", "in", "isa") && (ex.head = :OPERATOR)
                 push!(args, ex)
             end
         end
@@ -810,6 +814,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 end
                 i += 1
             else
+                # A word-operator name (`export isa`) tokenizes as Identifier
+                # but is labelled OPERATOR, same as importpath's own path.
+                ex.head === :IDENTIFIER && ex.val in ("where", "in", "isa") &&
+                    (ex.head = :OPERATOR)
                 push!(args, ex)
             end
             i += 1
@@ -914,7 +922,9 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         end
         return EXPR(:block, args, trivia, 0, 0)
     elseif (k == K"=" || k == K"->" ||
-            (k == K"function" && K"function" ∉ kkinds)) && length(kids) == 3
+            (k == K"function" &&
+             !any(j -> kkinds[j] == K"function" && kids[j].args === nothing,
+                  eachindex(kids)))) && length(kids) == 3
         # binary syntax: operator EXPR becomes the head. Short-form function
         # defs (`f(x) = ...`, `f(x::T) where T = ...`) and `->` bodies wrap
         # their RHS in an implicit block; plain assignment does not, and an
@@ -997,7 +1007,11 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                      !isempty(lhs.args) && lhs.args[1].head in (:call, :where)
         needs_block = (k == K"->" || kkinds[1] == K"call" || kkinds[1] == K"where" ||
                        typed_def || parens_def) && kkinds[3] != K"block"
-        body = needs_block ? EXPR(:block, EXPR[rhs], nothing, rhs.fullspan, rhs.span) : rhs
+        # A bare unary `::T` signature (`::typeof(x) = x` kwarg default) keeps
+        # the wrapped body's trivia as EXPR[]; a binary `::` return-type def
+        # (`f()::T = x`) and every other wrapped body use `nothing`.
+        body_trivia = (typed_def && length(lhs.args) == 1) ? EXPR[] : nothing
+        body = needs_block ? EXPR(:block, EXPR[rhs], body_trivia, rhs.fullspan, rhs.span) : rhs
         # Span is measured to the last arg; grow when that arg's span already
         # reaches its fullspan (bare `return`, qualified-macrocall RHS).
         grow_span_to_last_arg!(cur, EXPR[lhs, body])
@@ -1039,9 +1053,15 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # the only reliable way to tell "keyword to drop" from "child node".
         trivia = EXPR[]
         args = EXPR[]
+        has_end = K"end" in kkinds
         for (ex, ck) in zip(kids, kkinds)
             if ex.args === nothing && JuliaSyntax.is_keyword(ck)
                 push!(trivia, ex)
+            elseif JuliaSyntax.is_error(ck) && !has_end && !isempty(args)
+                # Unterminated `if`: the missing-`end` marker becomes a trivia
+                # END-placeholder (not a spurious extra arg) so iterate holds.
+                push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)],
+                                   nothing, ex.fullspan, ex.span))
             else
                 push!(args, ex)
             end
@@ -1060,11 +1080,26 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # may be filed into trivia.
         trivia = EXPR[]
         args = EXPR[]
+        haserr = false
         for (ex, ck) in zip(kids, kkinds)
             if ex.args === nothing && (ck == K"?" || ck == K":")
                 push!(trivia, ex)
+            elseif JuliaSyntax.is_error(ck)
+                # Broken ternary emits zero-width error markers; drop them and
+                # rebuild the fixed cond?then:else arity below.
+                haserr = true
             else
                 push!(args, ex)
+            end
+        end
+        if haserr
+            # Pad to CSTParser's 3-arg/2-trivia ternary shape so its iterate
+            # accessor stays in bounds (recovery differs from the oracle).
+            while length(args) < 3
+                push!(args, EXPR(:errortoken, 0, 0, nothing))
+            end
+            while length(trivia) < 2
+                push!(trivia, EXPR(:errortoken, 0, 0, nothing))
             end
         end
         return EXPR(:if, args, trivia, 0, 0)
@@ -1147,7 +1182,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # placeholder instead. Same trim-from-the-tail rule applies to the
         # keyword trivia (CATCH is unconditional — a try always has catch or
         # finally, so CATCH is never the trailing item).
-        try_kw = end_kw = try_block = nothing
+        try_kw = end_kw = try_block = missing_end = nothing
         catch_kw = catch_var = catch_block = nothing
         finally_kw = finally_block = nothing
         else_kw = else_block = nothing
@@ -1166,9 +1201,21 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             elseif ck == K"else"
                 has_else = true
                 else_kw, else_block = ex.trivia[1], ex.args[1]
+            elseif JuliaSyntax.is_error(ck) && try_block !== nothing
+                # Unterminated try (missing `end`); keep as the trailing
+                # END-placeholder instead of clobbering the try body.
+                missing_end = ex
             else
                 try_block = ex
             end
+        end
+        if !has_catch && !has_finally && !has_else
+            # Broken input (no catch/finally/else at all): synthesize an empty
+            # catch so the node matches CSTParser iterate's fixed try arity.
+            has_catch = true
+            catch_kw = EXPR(:CATCH, 0, 0, nothing)
+            catch_var = false_arg()
+            catch_block = EXPR(:block, EXPR[], nothing, 0, 0)
         end
         # An empty catch body followed by a finally/else clause is degenerate
         # in CSTParser: a FALSE marker before `finally`, an args=nothing
@@ -1203,8 +1250,15 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             push!(trivia, present ? v : false_arg())
         end
         # end_kw can be absent when malformed input (e.g. `try catch finally
-        # else`) buries the `end` inside a JuliaSyntax error node — don't crash.
-        end_kw === nothing || push!(trivia, end_kw)
+        # else`) buries the `end` inside a JuliaSyntax error node. Keep the
+        # missing-`end` marker as a trailing END-placeholder so iterate's
+        # arity holds; otherwise drop the slot entirely.
+        if end_kw !== nothing
+            push!(trivia, end_kw)
+        elseif missing_end !== nothing
+            push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)],
+                               nothing, missing_end.fullspan, missing_end.span))
+        end
         return EXPR(:try, filter(!isnothing, args), trivia, 0, 0)
     elseif k == K"let"
         # bindings block collapses to its single item when there's exactly
@@ -1235,8 +1289,19 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         sym = k == K"while" ? :while : :for
         trivia = EXPR[]
         args = EXPR[]
+        has_end = K"end" in kkinds
         for (ex, ck) in zip(kids, kkinds)
-            (ck == k || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+            if ck == k || ck == K"end"
+                push!(trivia, ex)
+            elseif JuliaSyntax.is_error(ck) && !has_end && !isempty(args)
+                # Unterminated body: the missing-`end` marker becomes an
+                # END-placeholder in trivia (not a spurious extra arg) so
+                # CSTParser's iterate finds the expected arity.
+                push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)],
+                                   nothing, ex.fullspan, ex.span))
+            else
+                push!(args, ex)
+            end
         end
         return EXPR(sym, args, trivia, 0, 0)
     elseif k == K"comprehension"
@@ -1451,6 +1516,16 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 # `let`'s bindings list reuses K"block" for its comma-joined
                 # `=` items; a plain statement block never has raw commas.
                 push!(trivia, ex)
+            elseif JuliaSyntax.is_error(ck) && ex.fullspan == 0
+                # Unterminated block: JuliaSyntax emits a zero-width error
+                # recovery marker for the missing terminator. A `begin`/`quote`
+                # block carries END in its trivia, so keep an END-placeholder
+                # there (iterate expects trivia[2]); a plain statement block's
+                # oracle keeps an empty body, so drop it (no width to fold).
+                if !isempty(trivia) && trivia[1].head in (:BEGIN, :QUOTE)
+                    push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)],
+                                       nothing, ex.fullspan, ex.span))
+                end
             elseif ck == K";"
                 semi_i = first(cur.kid_ranges[j])
                 if fold_semi!(cur, semi_i, ex.fullspan)
@@ -1498,8 +1573,16 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
     elseif k == K"function"
         trivia = EXPR[]
         args = EXPR[]
+        has_end = K"end" in kkinds
         for (ex, ck) in zip(kids, kkinds)
-            (ck == K"function" || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+            if ck == K"function" || ck == K"end"
+                push!(trivia, ex)
+            elseif JuliaSyntax.is_error(ck) && !has_end && !isempty(args)
+                push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)],
+                                   nothing, ex.fullspan, ex.span))
+            else
+                push!(args, ex)
+            end
         end
         return EXPR(:function, args, trivia, 0, 0)
     elseif k == K"struct"
@@ -1511,6 +1594,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         sig = nothing
         body = nothing
         errs = EXPR[]
+        has_end = K"end" in kkinds
         for (ex, ck) in zip(kids, kkinds)
             if ck == K"mutable"
                 is_mutable = true
@@ -1519,12 +1603,16 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(trivia, ex)
             elseif ck == K"block"
                 body = ex
+            elseif JuliaSyntax.is_error(ck) && !has_end && body !== nothing
+                # Unterminated struct: the missing-`end` marker (after the body)
+                # becomes a trivia END-placeholder so iterate's arity holds.
+                push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)],
+                                   nothing, ex.fullspan, ex.span))
             elseif sig === nothing
                 sig = ex
             else
-                # A further unclassified kid (e.g. broken input's trailing
-                # error marker for a missing `end`) — never overwrite the
-                # real signature; keep it reachable instead of dropping it.
+                # A further unclassified kid — never overwrite the real
+                # signature; keep it reachable instead of dropping it.
                 push!(errs, ex)
             end
         end
@@ -1551,22 +1639,44 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
     elseif k == K"abstract"
         trivia = EXPR[]
         args = EXPR[]
-        for (ex, ck) in zip(kids, kkinds)
-            (ck == K"abstract" || ck == K"type" || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if ck == K"abstract" || ck == K"type" || ck == K"end"
+                push!(trivia, ex)
+            elseif ck == K";"
+                # `abstract type A; end` — the `;` before `end` drops, folding
+                # onto the preceding leaf (no block body to hold it).
+                fold_semi!(cur, first(cur.kid_ranges[j]), ex.fullspan)
+            else
+                push!(args, ex)
+            end
         end
         return EXPR(:abstract, args, trivia, 0, 0)
     elseif k == K"primitive"
         trivia = EXPR[]
         args = EXPR[]
-        for (ex, ck) in zip(kids, kkinds)
-            (ck == K"primitive" || ck == K"type" || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if ck == K"primitive" || ck == K"type" || ck == K"end"
+                push!(trivia, ex)
+            elseif ck == K";"
+                fold_semi!(cur, first(cur.kid_ranges[j]), ex.fullspan)
+            else
+                push!(args, ex)
+            end
         end
         return EXPR(:primitive, args, trivia, 0, 0)
     elseif k == K"macro"
         trivia = EXPR[]
         args = EXPR[]
+        has_end = K"end" in kkinds
         for (ex, ck) in zip(kids, kkinds)
-            (ck == K"macro" || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+            if ck == K"macro" || ck == K"end"
+                push!(trivia, ex)
+            elseif JuliaSyntax.is_error(ck) && !has_end && !isempty(args)
+                push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)],
+                                   nothing, ex.fullspan, ex.span))
+            else
+                push!(args, ex)
+            end
         end
         return EXPR(:macro, args, trivia, 0, 0)
     elseif k == K"module"

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -346,7 +346,9 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             fs = sum(a -> a.fullspan, blk.args; init=0)
             sp = isempty(blk.args) ? 0 : fs - (blk.args[end].fullspan - blk.args[end].span)
             inner = EXPR(:block, blk.args, nothing, fs, sp)
-            return EXPR(:quote, EXPR[inner], EXPR[qkw, ekw], 0, 0)
+            # qkw/ekw can be absent for malformed input; filter out nothings.
+            qtriv = EXPR[t for t in (qkw, ekw) if t !== nothing]
+            return EXPR(:quote, EXPR[inner], qtriv, 0, 0)
         end
         if kkinds[1] == K"@"
             atex, nameex = kids
@@ -912,14 +914,19 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 try_block = ex
             end
         end
-        # An empty catch body followed by an else clause is a degenerate
-        # block in CSTParser (args = nothing, val = "").
-        if has_catch && has_else && catch_block !== nothing &&
-           (catch_block.args === nothing || isempty(catch_block.args)) &&
-           catch_block.fullspan == 0
-            catch_block.args = nothing
-            catch_block.trivia = nothing
-            catch_block.val = ""
+        # An empty catch body followed by a finally/else clause is degenerate
+        # in CSTParser: a FALSE marker before `finally`, an args=nothing
+        # `:block` (val "") before `else`.
+        if has_catch && catch_block !== nothing && catch_block.fullspan == 0 &&
+           (catch_block.args === nothing || isempty(catch_block.args))
+            if has_else
+                catch_block.args = nothing
+                catch_block.trivia = nothing
+                catch_block.val = ""
+            elseif has_finally && catch_var !== nothing && catch_var.head === :FALSE
+                # only a var-less empty catch collapses to FALSE before finally
+                catch_block = false_arg()
+            end
         end
         raw = [(catch_var, has_catch), (catch_block, has_catch),
                (finally_block, has_finally), (else_block, has_else)]

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -355,12 +355,21 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         for (ex, ck) in zip(kids, kkinds)
             ck == K":" ? push!(trivia, ex) : push!(args, ex)
         end
-        # A quoted dotted operator (`:.&`) arrives as a K"." composite (dot+op
-        # leaves); fuse it into one OPERATOR leaf, same as comparison does.
-        if args[1].head isa EXPR && args[1].head.val == "." && args[1].args !== nothing &&
-           length(args[1].args) == 1 && args[1].args[1].head === :OPERATOR
-            di = args[1]
-            args[1] = EXPR(:OPERATOR, di.fullspan, di.span, di.head.val * di.args[1].val)
+        # A quoted dotted operator (`:.&`, `:(.=)`) arrives as a K"." composite
+        # (dot+op leaves); fuse it into one OPERATOR leaf, either directly or
+        # inside a single-item brackets.
+        fuse_dotop(ex) = (ex.head isa EXPR && ex.head.val == "." && ex.args !== nothing &&
+                          length(ex.args) == 1 && ex.args[1].head === :OPERATOR) ?
+            EXPR(:OPERATOR, ex.fullspan, ex.span, ex.head.val * ex.args[1].val) : ex
+        args[1] = fuse_dotop(args[1])
+        # Inside parens, only a dotted assignment (`:(.=)`) fuses to an
+        # OPERATOR atom; a dotted broadcast operator (`:(.+)`) stays a
+        # composite (a broadcast call), so it remains a :quote.
+        if args[1].head === :brackets && args[1].args !== nothing &&
+           length(args[1].args) == 1 && args[1].args[1].head isa EXPR &&
+           args[1].args[1].args !== nothing && !isempty(args[1].args[1].args) &&
+           args[1].args[1].args[1].head === :OPERATOR && args[1].args[1].args[1].val == "="
+            args[1].args[1] = fuse_dotop(args[1].args[1])
         end
         inner = args[1]
         # A quoted string field name (`a."prop"`) is used directly as the
@@ -506,10 +515,12 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # Unprefixed cmd literals (name.head == :globalrefcmd) always keep
         # trivia = EXPR[], oracle-pinned, unlike every other macrocall shape.
         macro_trivia = name.head === :globalrefcmd ? EXPR[] : (isempty(trivia) ? nothing : trivia)
-        # Oracle quirk: a qualified (dotted-name) macrocall WITH a paren arg
-        # list has span == fullspan (its closing paren's trailing trivia is
-        # kept), unlike the unqualified or parenless forms.
-        if name.head isa EXPR && !isempty(kkinds) && kkinds[end] == K")"
+        # Oracle quirk: a qualified (dotted-name) macrocall's span reaches its
+        # fullspan (keeping trailing trivia) when it ends in a paren arg list
+        # (`M.@m(a)`) or has no real args at all (`Base.@_inline_meta`, whose
+        # last arg is the zero-width NOTHING). A qualified macrocall with a
+        # trailing real arg (`M.@m a`) keeps a normal span.
+        if name.head isa EXPR && (kkinds[end] == K")" || last(args).fullspan == 0)
             ll = cur.leaves[cur.i-1]
             cur.grow_span += ll.fullspan - ll.span
         end

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -132,6 +132,7 @@ end
 # CSTParser still expects, mirroring the K"quote" branch's own atom path.
 function wrap_field_atom(inner::EXPR)::EXPR
     inner.head === :BEGIN && (inner.head = :IDENTIFIER)
+    inner.head === :END && (inner.head = :IDENTIFIER)
     inner.head in (:STRING, :TRIPLESTRING) && return inner
     head = (inner.args === nothing || inner.head === :NONSTDIDENTIFIER) ? :quotenode : :quote
     # Transparent width: this wrapper adds no source characters of its own,
@@ -500,9 +501,11 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
            inner.val in ("where", "in", "isa")
             inner.head = :OPERATOR
         end
-        # `begin` maps to BEGIN in index context (terminal_expr), but as a
-        # quoted field/symbol (`a.begin`, `:begin`) it is an IDENTIFIER.
+        # `begin`/`end` map to BEGIN/END in index context (terminal_expr),
+        # but as a quoted field/symbol (`a.begin`, `a.end`, `:begin`) they
+        # are IDENTIFIER.
         inner.head === :BEGIN && (inner.head = :IDENTIFIER)
+        inner.head === :END && (inner.head = :IDENTIFIER)
         target = (inner.head === :brackets && inner.args !== nothing &&
                   length(inner.args) == 1) ? inner.args[1] : inner
         # atoms → :quotenode, composites → :quote; a var"..." nonstandard
@@ -1574,7 +1577,6 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         is_bare = false
         name = nothing
         body = nothing
-        errs = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
             if ck == K"baremodule"
                 is_bare = true
@@ -1586,17 +1588,19 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             elseif name === nothing
                 name = ex
             else
-                # A further unclassified kid (e.g. broken input's trailing
-                # error marker for a missing `end`) — never overwrite the
-                # real name; keep it reachable instead of dropping it.
-                push!(errs, ex)
+                # A further unclassified kid (broken input's trailing marker
+                # for a missing `end`) — oracle-pinned: CSTParser represents
+                # a missing expected token as errortoken wrapping a
+                # zero-width, val-less placeholder of that token's kind, kept
+                # in trivia[2], never a 4th arg; never overwrite the name.
+                push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)], nothing, ex.fullspan, ex.span))
             end
         end
         # A var"..." module name keeps trivia = EXPR[] (oracle-pinned; a
         # standalone var"..." value keeps nothing).
         name.head === :NONSTDIDENTIFIER && (name.trivia = EXPR[])
         marker = EXPR(is_bare ? :FALSE : :TRUE, 0, 0, nothing)
-        return EXPR(:module, EXPR[marker, name, body, errs...], trivia, 0, 0)
+        return EXPR(:module, EXPR[marker, name, body], trivia, 0, 0)
     elseif k == K"const" || k == K"global" || k == K"local"
         # `global a, b` / `local x, y` → names in args, keyword+commas trivia.
         sym = Symbol(lowercase(string(k)))

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -912,6 +912,15 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 try_block = ex
             end
         end
+        # An empty catch body followed by an else clause is a degenerate
+        # block in CSTParser (args = nothing, val = "").
+        if has_catch && has_else && catch_block !== nothing &&
+           (catch_block.args === nothing || isempty(catch_block.args)) &&
+           catch_block.fullspan == 0
+            catch_block.args = nothing
+            catch_block.trivia = nothing
+            catch_block.val = ""
+        end
         raw = [(catch_var, has_catch), (catch_block, has_catch),
                (finally_block, has_finally), (else_block, has_else)]
         while !isempty(raw) && !raw[end][2]
@@ -930,8 +939,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         for (v, present) in raw_t
             push!(trivia, present ? v : false_arg())
         end
-        push!(trivia, end_kw)
-        return EXPR(:try, args, trivia, 0, 0)
+        # end_kw can be absent when malformed input (e.g. `try catch finally
+        # else`) buries the `end` inside a JuliaSyntax error node — don't crash.
+        end_kw === nothing || push!(trivia, end_kw)
+        return EXPR(:try, filter(!isnothing, args), trivia, 0, 0)
     elseif k == K"let"
         # bindings block collapses to its single item when there's exactly
         # one binding (`let x = 1` / `let x`); stays a :block for 0 or 2+.

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -1,0 +1,56 @@
+function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vector{Kind}, cur::Cursor)::EXPR
+    if k == K"toplevel"
+        # Both the file root and semicolon-joined statement sequences share
+        # this kind (build_cst renames the root's head to :file afterward).
+        # Bare `;` separators are dropped entirely; their width is folded
+        # into the preceding statement's fullspan, oracle-style.
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K";"
+                isempty(args) || (args[end].fullspan += ex.fullspan)
+            else
+                push!(args, ex)
+            end
+        end
+        return EXPR(:toplevel, args, EXPR[], 0, 0)
+    elseif k == K"call" && JuliaSyntax.is_infix_op_call(JuliaSyntax.head(node))
+        # a + b (+ c ...) → (:call, [op, a, b, c...]); extra op tokens → trivia
+        op = kids[2]
+        args = EXPR[op, kids[1]]
+        trivia = EXPR[]
+        for j in 3:length(kids)
+            if isodd(j)
+                push!(args, kids[j])
+            else
+                push!(trivia, kids[j])   # repeated ops in chained calls
+            end
+        end
+        return EXPR(:call, args, isempty(trivia) ? nothing : trivia, 0, 0)
+    elseif k == K"call"
+        # f(x, y) → (:call, [f, x, y], trivia=[lparen, commas..., rparen])
+        args = EXPR[]
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"(" || ck == K")" || ck == K","
+                push!(trivia, ex)
+            else
+                push!(args, ex)
+            end
+        end
+        return EXPR(:call, args, trivia, 0, 0)
+    elseif k == K"=" && length(kids) == 3
+        # binary syntax: operator EXPR becomes the head
+        return EXPR(kids[2], EXPR[kids[1], kids[3]], nothing, 0, 0)
+    elseif k == K"block"
+        args = EXPR[]
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == K"begin" || ck == K"end" || ck == K";") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:block, args, isempty(trivia) ? nothing : trivia, 0, 0)
+    elseif k == K"parens"
+        trivia = EXPR[kids[1], kids[end]]
+        return EXPR(:brackets, kids[2:end-1], trivia, 0, 0)
+    end
+    return generic_form(k, kids, kkinds)
+end

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -348,6 +348,9 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             atex, nameex = kids
             fused = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
                         atex.span + nameex.span, "@" * nameex.val)
+            # Register the fused name at its leaf slot so a `;`-fold onto a
+            # qualified macrocall (`(Base.@m; x)`) widens THIS EXPR.
+            cur.terminals[first(cur.kid_ranges[2])] = fused
             return EXPR(:quotenode, EXPR[fused], nothing, 0, 0)
         end
         args = EXPR[]
@@ -915,9 +918,14 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # one binding (`let x = 1` / `let x`); stays a :block for 0 or 2+.
         trivia = EXPR[]
         bindings = body = nothing
-        for (ex, ck) in zip(kids, kkinds)
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ck == K"let" || ck == K"end"
                 push!(trivia, ex)
+            elseif ck == K";"
+                # `let x=1; y end` — the `;` separating bindings from body is
+                # dropped; its width folds onto the bindings' last leaf.
+                semi_i = first(cur.kid_ranges[j])
+                fold_semi!(cur, semi_i, ex.fullspan)
             elseif bindings === nothing
                 bindings = ex
             else

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -71,6 +71,22 @@ function trim_span_to_last_arg!(cur::Cursor, args::Vector{EXPR})
     cur.trim_span += (a.fullspan - a.span) - (last_leaf.fullspan - last_leaf.span)
 end
 
+# Symmetric counterpart of trim_span_to_last_arg! for the grow direction:
+# CSTParser measures a keyword-trivia-less node's span to its last stored
+# arg, so when that arg's trailing exclusion is SMALLER than the raw last
+# leaf's (only known case: a bare `return`, whose span was grown to its
+# fullspan), the node's span must grow by the difference. delta can never
+# be negative here (an arg's trailing can only shrink relative to its own
+# raw leaves, never grow).
+function grow_span_to_last_arg!(cur::Cursor, args::Vector{EXPR})
+    isempty(args) && return
+    last_leaf = cur.leaves[cur.i-1]
+    a = args[end]
+    delta = (last_leaf.fullspan - last_leaf.span) - (a.fullspan - a.span)
+    delta > 0 && (cur.grow_span += delta)
+    return
+end
+
 # Sum of the OWN spans of a maximal trailing run of `;`-kind kids (e.g. the
 # double `;;` promoting to the next ncat dimension) — every one of them
 # folds away via fold_semi!, but assemble()'s automatic span calc still
@@ -329,11 +345,18 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         end
         return EXPR(k == K"if" ? :if : :elseif, args, trivia, 0, 0)
     elseif k == K"?"
-        # ternary a ? b : c → (:if, [a, b, c], trivia=[?, :]) — reuses if's head.
+        # ternary a ? b : c → (:if, [a, b, c], trivia=[?, :]) — reuses if's
+        # head. Same kind-reuse trap as if/elseif: a NESTED ternary is a
+        # composite K"?" kid, so only genuine leaves (`args === nothing`)
+        # may be filed into trivia.
         trivia = EXPR[]
         args = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
-            (ck == K"?" || ck == K":") ? push!(trivia, ex) : push!(args, ex)
+            if ex.args === nothing && (ck == K"?" || ck == K":")
+                push!(trivia, ex)
+            else
+                push!(args, ex)
+            end
         end
         return EXPR(:if, args, trivia, 0, 0)
     elseif (k == K"break" || k == K"continue") && length(kids) == 1
@@ -342,13 +365,20 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         return kids[1]
     elseif k == K"return"
         # `return` (no value) gets a synthetic zero-width NOTHING arg; `return
-        # x` already has a real value kid, no synthesis needed.
+        # x` already has a real value kid, no synthesis needed. With the
+        # NOTHING arg stored last, CSTParser measures span = fullspan (zero
+        # trailing exclusion), so the keyword's trailing trivia must be
+        # grown back into the span (the auto leaf-range calc excludes it).
         trivia = EXPR[]
         args = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
             ck == K"return" ? push!(trivia, ex) : push!(args, ex)
         end
-        isempty(args) && push!(args, EXPR(:NOTHING, 0, 0, ""))
+        if isempty(args)
+            push!(args, EXPR(:NOTHING, 0, 0, ""))
+            kw = trivia[1]
+            cur.grow_span += kw.fullspan - kw.span
+        end
         return EXPR(:return, args, trivia, 0, 0)
     elseif k == K"catch"
         # Flattened into try's own args/trivia by the K"try" branch below;
@@ -484,27 +514,46 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # multi-spec cartesian_iterator FLATTENS its args/trivia directly
         # into generator's own (unlike `for`, which keeps it as a nested
         # :block) — confirmed via dump: comma lands in generator's trivia.
-        trivia = EXPR[]
-        expr = spec = nothing
-        speck = K"None"
-        for (ex, ck) in zip(kids, kkinds)
-            if ck == K"for"
-                push!(trivia, ex)
-            elseif expr === nothing
-                expr = ex
+        # Multiple `for` clauses (`[x for a in as for b in bs]`) are ONE
+        # flat green node, but the oracle nests them INVERTED — innermost
+        # generator holds the body + LAST clause, each enclosing level adds
+        # the next-earlier clause, and every multi-clause generator gets a
+        # :flatten wrapper (child levels included, the innermost single-
+        # clause one excluded). Nested levels are discontiguous in source,
+        # so their spans are hand-built from child fullspan sums.
+        body = kids[1]
+        groups = Tuple{EXPR,EXPR,Kind}[]   # (for_kw, spec, spec_kind)
+        j = 2
+        while j <= length(kids)
+            push!(groups, (kids[j], kids[j+1], kkinds[j+1]))
+            j += 2
+        end
+        function gen_level(child::EXPR, kw::EXPR, spec::EXPR, sk::Kind)
+            args = EXPR[child]
+            trivia = EXPR[kw]
+            if sk == K"cartesian_iterator"
+                append!(args, spec.args)
+                append!(trivia, spec.trivia)
             else
-                spec, speck = ex, ck
+                push!(args, spec)
             end
+            fs = child.fullspan + kw.fullspan + spec.fullspan
+            return EXPR(:generator, args, trivia, fs,
+                        fs - (args[end].fullspan - args[end].span)), args
         end
-        args = EXPR[expr]
-        if speck == K"cartesian_iterator"
-            append!(args, spec.args)
-            append!(trivia, spec.trivia)
-        else
-            push!(args, spec)
+        if length(groups) == 1
+            gen, args = gen_level(body, groups[1]...)
+            trim_span_to_last_arg!(cur, args)
+            return EXPR(:generator, gen.args, gen.trivia, 0, 0)
         end
-        trim_span_to_last_arg!(cur, args)
-        return EXPR(:generator, args, trivia, 0, 0)
+        gen, _ = gen_level(body, groups[end]...)
+        for gi in length(groups)-1:-1:1
+            child = gi == length(groups) - 1 ? gen :
+                    EXPR(:flatten, EXPR[gen], nothing, gen.fullspan, gen.span)
+            gen, _ = gen_level(child, groups[gi]...)
+        end
+        trim_span_to_last_arg!(cur, EXPR[gen])
+        return EXPR(:flatten, EXPR[gen], nothing, 0, 0)
     elseif k == K"filter"
         # `... if cond` clause → (:filter, [cond, spec], trivia=[if]) — args
         # order is COND-then-SPEC, reversed from source order (spec if cond),
@@ -678,6 +727,11 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(args, ex)
             end
         end
+        # A trivia-less block's span is measured to its last stored arg;
+        # grow when that arg's trailing exclusion shrank (bare `return`).
+        # Skip when the last kid was a dropped `;` (trim_span owns that).
+        isempty(trivia) && !isempty(args) && kkinds[end] != K";" &&
+            grow_span_to_last_arg!(cur, args)
         return EXPR(:block, args, isempty(trivia) ? nothing : trivia, 0, 0)
     elseif k == K"parens"
         trivia = EXPR[kids[1], kids[end]]

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -107,17 +107,18 @@ end
 # (vect/ref/call arguments keep the normal `nothing`). Composite cells
 # (already carrying real args/trivia) are untouched.
 function matrix_cell!(ex::EXPR)
-    if ex.args === nothing
-        ex.args = EXPR[]
-        ex.trivia = EXPR[]
-    end
+    # Bare terminals get empty args; every cell (bare or composite) whose
+    # trivia is `nothing` gets an empty trivia vector — a cell that already
+    # carries real trivia (e.g. `f(x)`'s parens) is left as-is.
+    ex.args === nothing && (ex.args = EXPR[])
+    ex.trivia === nothing && (ex.trivia = EXPR[])
     return ex
 end
 
 # Shared by call/dotcall/curly/macrocall arg lists: split into positional
 # args, bracket/comma trivia, and `;`-groups (still unmerged/unrelocated —
 # each caller decides where the merged group lands); `a=b` becomes `:kw`.
-function collect_arglist(kids::Vector{EXPR}, kkinds::Vector{Kind}, open::Kind, close::Kind)
+function collect_arglist(kids::Vector{EXPR}, kkinds::Vector{Kind}, open::Kind, close::Kind; kw::Bool=true)
     args = EXPR[]
     trivia = EXPR[]
     groups = EXPR[]
@@ -126,7 +127,7 @@ function collect_arglist(kids::Vector{EXPR}, kkinds::Vector{Kind}, open::Kind, c
             push!(trivia, ex)
         elseif ck == K"parameters"
             push!(groups, ex)
-        elseif ck == K"="
+        elseif ck == K"=" && kw
             push!(args, to_kw(ex))
         else
             push!(args, ex)
@@ -143,15 +144,34 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # the rightmost leaf of the preceding statement (and that leaf's
         # ancestors), oracle-style.
         args = EXPR[]
+        lead = 0
         for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ck == K";"
                 semi_i = first(cur.kid_ranges[j])
-                fold_semi!(cur, semi_i, ex.fullspan) ||
-                    (isempty(args) || (args[end].fullspan += ex.fullspan))
+                if fold_semi!(cur, semi_i, ex.fullspan)
+                    # Same span bookkeeping as a block: a leading `;` widens a
+                    # leaf outside this node; a trailing `;` widens this node's
+                    # own last leaf but was folded away, so drop it from span.
+                    j == 1 && (cur.trim += ex.fullspan)
+                    j == length(kids) && (cur.trim_span += ex.span)
+                elseif isempty(args)
+                    # A `;` at the very start of the file has no preceding
+                    # statement: CSTParser materializes an empty NOTHING one.
+                    lead += ex.fullspan
+                else
+                    args[end].fullspan += ex.fullspan
+                end
             else
                 push!(args, ex)
             end
         end
+        lead > 0 && pushfirst!(args, EXPR(:NOTHING, lead, lead, ""))
+        # File/toplevel span is measured to the last stored arg (the outer
+        # file root wraps an inner toplevel, so a trailing `;` or bare
+        # `return` shows up as a span mismatch here); reconcile both
+        # directions. Skip when the last kid was a dropped `;` (its own
+        # trim_span above already owns that case).
+        !isempty(args) && kkinds[end] != K";" && trim_span_to_last_arg!(cur, args)
         return EXPR(:toplevel, args, EXPR[], 0, 0)
     elseif k == K"call" && JuliaSyntax.is_infix_op_call(JuliaSyntax.head(node))
         # a + b (+ c ...) → (:call, [op, a, b, c...]); extra op tokens → trivia
@@ -178,8 +198,22 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         return EXPR(:call, EXPR[op, kids[1], kids[2]], nothing, 0, 0)
     elseif k == K"comparison"
         # a < b < c → flat (:comparison, [a, op, b, op, c, ...]) — kids are
-        # already in this exact order/shape, just need the right head/trivia.
-        return EXPR(:comparison, kids, nothing, 0, 0)
+        # already in this exact order/shape. Dotted comparison operators
+        # (`a .== b`) arrive as a K"." composite (dot+op leaves); fuse each
+        # into one OPERATOR leaf (val ".==") like CSTParser does.
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"." && ex.head isa EXPR && ex.args !== nothing &&
+               length(ex.args) == 1 && ex.args[1].head === :OPERATOR
+                # dotted comparison operator (`.==`); NOT a getfield `.x`
+                # (which has two args ending in a quotenode).
+                push!(args, EXPR(:OPERATOR, ex.fullspan, ex.span,
+                                 ex.head.val * ex.args[1].val))
+            else
+                push!(args, ex)
+            end
+        end
+        return EXPR(:comparison, args, nothing, 0, 0)
     elseif k == K"call"
         # f(x, y) → (:call, [f, x, y], trivia=[lparen, commas..., rparen]).
         # `;`-separated keyword args nest under a `parameters` child at their
@@ -254,11 +288,29 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         lhs = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
                    atex.span + nameex.span, "@" * nameex.val)
         return EXPR(dotex, EXPR[lhs, rhs], nothing, 0, 0)
-    elseif k == K"quote" && length(kids) <= 2
-        # Field-name wrapper under getfield's `.`: bare `b`, `:b` with an
-        # explicit-quote colon kept as trivia, or (A.@m x) an unfused `@`+
-        # name pair fused into a single "@name" IDENTIFIER.
-        if !isempty(kkinds) && kkinds[1] == K"@"
+    elseif k == K"quote"
+        # Three shapes share this kind:
+        #  (a) block form `quote ... end` → :quote wrapping the body block;
+        #      quote/end keywords are held in the block's trivia (block
+        #      branch) and lift up to the :quote node, the inner block keeps
+        #      only its statements.
+        #  (b) getfield field-name (`.b`, `.:b`, `.@m`) → :quotenode.
+        #  (c) `:x`/`:(expr)` → :quotenode for a quoted atom (incl. a
+        #      single-atom `:(x)`), :quote for a quoted composite —
+        #      CSTParser's parse_quote split.
+        if length(kids) == 1 && kkinds[1] == K"block"
+            blk = kids[1]
+            qkw = ekw = nothing
+            for t in (blk.trivia === nothing ? EXPR[] : blk.trivia)
+                t.head === :QUOTE && (qkw = t)
+                t.head === :END && (ekw = t)
+            end
+            fs = sum(a -> a.fullspan, blk.args; init=0)
+            sp = isempty(blk.args) ? 0 : fs - (blk.args[end].fullspan - blk.args[end].span)
+            inner = EXPR(:block, blk.args, nothing, fs, sp)
+            return EXPR(:quote, EXPR[inner], EXPR[qkw, ekw], 0, 0)
+        end
+        if kkinds[1] == K"@"
             atex, nameex = kids
             fused = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
                         atex.span + nameex.span, "@" * nameex.val)
@@ -269,13 +321,112 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         for (ex, ck) in zip(kids, kkinds)
             ck == K":" ? push!(trivia, ex) : push!(args, ex)
         end
-        return EXPR(:quotenode, args, isempty(trivia) ? nothing : trivia, 0, 0)
+        inner = args[1]
+        # Word operators (`:where`/`:in`/`:isa`) tokenize as Identifier after
+        # a quote colon, but CSTParser labels them OPERATOR. Only when the
+        # quote is colon-prefixed — a bare getfield field name (`p.in`) stays
+        # an IDENTIFIER.
+        if K":" in kkinds && inner.head === :IDENTIFIER &&
+           inner.val in ("where", "in", "isa")
+            inner.head = :OPERATOR
+        end
+        target = (inner.head === :brackets && inner.args !== nothing &&
+                  length(inner.args) == 1) ? inner.args[1] : inner
+        head = target.args === nothing ? :quotenode : :quote
+        return EXPR(head, args, isempty(trivia) ? nothing : trivia, 0, 0)
     elseif k == K"curly"
         # A{T; S} → (:curly, [A, parameters, T]) — parameters relocates to
         # args[2] exactly like call's.
         args, trivia, groups = collect_arglist(kids, kkinds, K"{", K"}")
         isempty(groups) || insert!(args, 2, merge_params!(groups))
         return EXPR(:curly, args, trivia, 0, 0)
+    elseif k == K"tuple"
+        # `(a, :b)` → (:tuple, [args], trivia=[parens, commas]); a named-tuple
+        # field (`(a=b,)`) keeps `=` as assignment (not `:kw`); `;`-parameters
+        # (`(; a=1)`) relocate to the front and keep their own `:kw` shape.
+        args, trivia, groups = collect_arglist(kids, kkinds, K"(", K")"; kw=false)
+        isempty(groups) || insert!(args, 1, merge_params!(groups))
+        return EXPR(:tuple, args, trivia, 0, 0)
+    elseif k == K"vect"
+        args, trivia, groups = collect_arglist(kids, kkinds, K"[", K"]")
+        isempty(groups) || insert!(args, 1, merge_params!(groups))
+        return EXPR(:vect, args, trivia, 0, 0)
+    elseif k == K"braces"
+        args, trivia, groups = collect_arglist(kids, kkinds, K"{", K"}")
+        isempty(groups) || insert!(args, 1, merge_params!(groups))
+        return EXPR(:braces, args, trivia, 0, 0)
+    elseif k == K"ref"
+        # `a[i, j]` → (:ref, [callee, indices...], trivia=[brackets, commas]).
+        callee = kids[1]
+        args, trivia, groups = collect_arglist(kids[2:end], kkinds[2:end], K"[", K"]")
+        isempty(groups) || insert!(args, 1, merge_params!(groups))
+        return EXPR(:ref, EXPR[callee, args...], trivia, 0, 0)
+    elseif k == K"typed_comprehension"
+        # `T[gen]` → (:typed_comprehension, [T, generator], trivia=[brackets]).
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == K"[" || ck == K"]") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:typed_comprehension, args, trivia, 0, 0)
+    elseif k == K"typed_hcat"
+        # `T[a b]` → (:typed_hcat, [T, cells...], trivia=[brackets]).
+        typ = kids[1]
+        trivia = EXPR[kids[2], kids[end]]
+        cells = kids[3:end-1]
+        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        return EXPR(:typed_hcat, EXPR[typ, cells...], trivia, 0, 0)
+    elseif k == K"typed_vcat"
+        # `T[1; 2]` / `T[1 2; 3 4]` → (:typed_vcat, [T, rows-or-cells...]),
+        # same `;`-fold + matrix-cell quirk as vcat, T prepended.
+        typ = kids[1]
+        trivia = EXPR[]
+        args = EXPR[]
+        cells = EXPR[]
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if j == 1
+                continue
+            elseif ck == K"[" || ck == K"]"
+                push!(trivia, ex)
+            elseif ck == K";"
+                semi_i = first(cur.kid_ranges[j])
+                fold_semi!(cur, semi_i, ex.fullspan) ||
+                    (isempty(args) || (args[end].fullspan += ex.fullspan))
+            elseif ck == K"row"
+                push!(args, ex)
+            else
+                push!(args, ex)
+                push!(cells, ex)
+            end
+        end
+        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        return EXPR(:typed_vcat, EXPR[typ, args...], trivia, 0, 0)
+    elseif k == K"typed_ncat"
+        # `T[1;; 2]` → typed_vcat plus the ncat dim marker after the type.
+        dim = JuliaSyntax.numeric_flags(JuliaSyntax.flags(node))
+        typ = kids[1]
+        trivia = EXPR[]
+        rest = EXPR[]
+        cells = EXPR[]
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if j == 1
+                continue
+            elseif ck == K"[" || ck == K"]"
+                push!(trivia, ex)
+            elseif ck == K";"
+                semi_i = first(cur.kid_ranges[j])
+                fold_semi!(cur, semi_i, ex.fullspan) ||
+                    (isempty(rest) || (rest[end].fullspan += ex.fullspan))
+            elseif ck == K"nrow"
+                push!(rest, ex)
+            else
+                push!(rest, ex)
+                push!(cells, ex)
+            end
+        end
+        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        args = EXPR[typ, EXPR(Symbol(string(dim)), 0, 0, ""), rest...]
+        return EXPR(:typed_ncat, args, trivia, 0, 0)
     elseif k == K"macrocall"
         # `@m x` fuses the `@` leaf and macro name into ONE IDENTIFIER
         # ("@m") — CSTParser never sees them as separate tokens. String/cmd
@@ -292,13 +443,123 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             name = kids[1]
             rest, restk = kids[2:end], kkinds[2:end]
         end
-        args, trivia, groups = collect_arglist(rest, restk, K"(", K")")
+        # Macro args keep `=` as assignment (never `:kw`), unlike call args.
+        args, trivia, groups = collect_arglist(rest, restk, K"(", K")"; kw=false)
         args = EXPR[name, EXPR(:NOTHING, 0, 0, nothing), args...]
         isempty(groups) || insert!(args, 3, merge_params!(groups))
         # Unprefixed cmd literals (name.head == :globalrefcmd) always keep
         # trivia = EXPR[], oracle-pinned, unlike every other macrocall shape.
         macro_trivia = name.head === :globalrefcmd ? EXPR[] : (isempty(trivia) ? nothing : trivia)
+        # Oracle quirk: a qualified (dotted-name) macrocall WITH a paren arg
+        # list has span == fullspan (its closing paren's trailing trivia is
+        # kept), unlike the unqualified or parenless forms.
+        if name.head isa EXPR && !isempty(kkinds) && kkinds[end] == K")"
+            ll = cur.leaves[cur.i-1]
+            cur.grow_span += ll.fullspan - ll.span
+        end
         return EXPR(:macrocall, args, macro_trivia, 0, 0)
+    elseif k == K"doc"
+        # `"..." expr` docstring → CSTParser's synthetic @doc macrocall:
+        # [globalrefdoc, NOTHING, docstring, documented_expr], no trivia.
+        return EXPR(:macrocall,
+                    EXPR[EXPR(:globalrefdoc, 0, 0, nothing),
+                         EXPR(:NOTHING, 0, 0, nothing), kids[1], kids[2]],
+                    nothing, 0, 0)
+    elseif k == K"importpath"
+        # `A`, `A.B.C`, `..A` → a synthetic zero-width `.`-operator-headed
+        # node: path components (identifiers + leading relative-dot operators)
+        # are args, separator dots between components are trivia.
+        dot_head = EXPR(:OPERATOR, 0, 0, ".")
+        args = EXPR[]
+        trivia = EXPR[]
+        seen = false
+        i = 1
+        while i <= length(kids)
+            ex, ck = kids[i], kkinds[i]
+            if ck == K"@" && i < length(kids)
+                # `A.@m` path component: fuse `@`+MacroName into one IDENTIFIER.
+                nm = kids[i+1]
+                push!(args, EXPR(:IDENTIFIER, ex.fullspan + nm.fullspan,
+                                 ex.span + nm.span, "@" * nm.val))
+                seen = true
+                i += 2
+            elseif ck == K"."
+                # Leading relative dots are OPERATOR args; separator dots
+                # between components are DOT-headed trivia.
+                seen ? push!(trivia, EXPR(:DOT, ex.fullspan, ex.span, ".")) :
+                       push!(args, ex)
+                i += 1
+            else
+                push!(args, ex)
+                seen = true
+                i += 1
+            end
+        end
+        return EXPR(dot_head, args, trivia, 0, 0)
+    elseif k == K"as"
+        # `A as B` → (:as, [path, newname], trivia=[as]).
+        args = EXPR[]
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            ck == K"as" ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:as, args, trivia, 0, 0)
+    elseif k == K":" && (kkinds[1] == K"using" || kkinds[1] == K"import")
+        # Selective import `using A: x, y` → colon-operator-headed node,
+        # args=[module_path, imported paths...], trivia=[commas]. The
+        # using/import keyword leaf lives here in the green tree but the
+        # oracle relocates it to the enclosing using/import node's trivia;
+        # trim its leading width off this node (the parent re-adds it).
+        cur.trim += kids[1].fullspan
+        head = nothing
+        args = EXPR[]
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids[2:end], kkinds[2:end])
+            if ck == K":"
+                head = ex
+            elseif ck == K","
+                push!(trivia, ex)
+            else
+                push!(args, ex)
+            end
+        end
+        return EXPR(head, args, trivia, 0, 0)
+    elseif k == K"using" || k == K"import"
+        sym = k == K"using" ? :using : :import
+        if kkinds[1] == K":"
+            # colon node already assembled; the keyword leaf it swallowed is
+            # this node's first consumed leaf (see the K":" branch above).
+            kw = cur.terminals[first(cur.kid_ranges[1])]
+            return EXPR(sym, EXPR[kids[1]], EXPR[kw], 0, 0)
+        end
+        kw = kids[1]
+        args = EXPR[]
+        trivia = EXPR[kw]
+        for (ex, ck) in zip(kids[2:end], kkinds[2:end])
+            ck == K"," ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(sym, args, trivia, 0, 0)
+    elseif k == K"export" || k == K"public"
+        # `export a, @m` → names in args (fusing `@`+MacroName), keyword and
+        # commas in trivia.
+        args = EXPR[]
+        trivia = EXPR[]
+        i = 1
+        while i <= length(kids)
+            ex, ck = kids[i], kkinds[i]
+            if ck == k || ck == K","
+                push!(trivia, ex)
+            elseif ck == K"@" && i < length(kids)
+                nm = kids[i+1]
+                push!(args, EXPR(:IDENTIFIER, ex.fullspan + nm.fullspan,
+                                 ex.span + nm.span, "@" * nm.val))
+                i += 1
+            else
+                push!(args, ex)
+            end
+            i += 1
+        end
+        return EXPR(Symbol(lowercase(string(k))), args, trivia, 0, 0)
     elseif k == K"do"
         # `f(x) do y ... end` desugars to a call plus a synthetic zero-width
         # `->` operator wrapping the (params-tuple, body-block) pair — no
@@ -377,6 +638,9 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         needs_block = (k == K"->" || kkinds[1] == K"call" || kkinds[1] == K"where") &&
                       kkinds[3] != K"block"
         body = needs_block ? EXPR(:block, EXPR[rhs], nothing, rhs.fullspan, rhs.span) : rhs
+        # Span is measured to the last arg; grow when that arg's span already
+        # reaches its fullspan (bare `return`, qualified-macrocall RHS).
+        grow_span_to_last_arg!(cur, EXPR[lhs, body])
         return EXPR(op, EXPR[lhs, body], nothing, 0, 0)
     elseif (k == K"::" || k == K"<:") && length(kids) == 3
         # binary syntax: operator EXPR becomes the head (type declarations,
@@ -389,7 +653,9 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         args = EXPR[]
         trivia = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
-            if ck == K"where"
+            if ck == K"where" && ex.args === nothing
+                # keyword leaf (nested `where` composite reuses the kind — the
+                # same trap as if/elseif; only the leaf goes to trivia).
                 push!(trivia, ex)
             elseif ck == K"braces"
                 append!(args, ex.args)
@@ -413,6 +679,12 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(args, ex)
             end
         end
+        # An `elseif` ends in its (possibly empty) body block, not an END
+        # keyword, so its span is measured to that last arg — grow when the
+        # block is empty (its trailing exclusion is 0 but the last real leaf's
+        # is not). An `if` ends in END trivia and must NOT grow (its END owns
+        # any trailing whitespace up to the next statement).
+        k == K"elseif" && grow_span_to_last_arg!(cur, args)
         return EXPR(k == K"if" ? :if : :elseif, args, trivia, 0, 0)
     elseif k == K"?"
         # ternary a ? b : c → (:if, [a, b, c], trivia=[?, :]) — reuses if's
@@ -771,7 +1043,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         args = EXPR[]
         trivia = EXPR[]
         for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
-            if ck == K"begin" || ck == K"end"
+            if ck == K"begin" || ck == K"end" || (ck == K"quote" && ex.args === nothing)
+                # `quote ... end`'s keywords live inside its body block; the
+                # K"quote" branch lifts them up to the :quote node. Guard on
+                # the leaf test so a nested composite quote statement stays.
                 push!(trivia, ex)
             elseif ck == K","
                 # `let`'s bindings list reuses K"block" for its comma-joined
@@ -879,10 +1154,11 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         marker = EXPR(is_bare ? :FALSE : :TRUE, 0, 0, nothing)
         return EXPR(:module, EXPR[marker, name, body], trivia, 0, 0)
     elseif k == K"const" || k == K"global" || k == K"local"
+        # `global a, b` / `local x, y` → names in args, keyword+commas trivia.
         trivia = EXPR[]
         args = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
-            ck == k ? push!(trivia, ex) : push!(args, ex)
+            (ck == k || ck == K",") ? push!(trivia, ex) : push!(args, ex)
         end
         return EXPR(Symbol(lowercase(string(k))), args, trivia, 0, 0)
     elseif length(kids) == 3 && kkinds[2] == k && JuliaSyntax.is_operator(k)
@@ -894,6 +1170,9 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # Placed last: `where`/`in`/`isa` are also JuliaSyntax "operators"
         # by precedence but have their own dedicated non-operator-headed
         # branches earlier, which must win first.
+        # A bare `return` RHS (`c && return`) has span==fullspan, so grow this
+        # node's span to its last arg (same as the trivia-less block case).
+        grow_span_to_last_arg!(cur, EXPR[kids[1], kids[3]])
         return EXPR(kids[2], EXPR[kids[1], kids[3]], nothing, 0, 0)
     elseif length(kids) == 2 && kkinds[1] == k && JuliaSyntax.is_operator(k)
         # Remaining prefix-unary-syntax-head kinds (e.g. `&x`), same shape

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -191,6 +191,17 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # unlike prefix calls (-x/!x) which stay :call-symbol-headed with the
         # operator as a plain leading arg.
         return EXPR(kids[2], EXPR[kids[1]], nothing, 0, 0)
+    elseif k == K"call" && JuliaSyntax.is_prefix_op_call(JuliaSyntax.head(node)) &&
+           length(kids) == 2 && kkinds[2] == K"parens" &&
+           !(kids[1].val in ("-", "!", "~"))
+        # `+(x)` — a prefix operator applied to a parenthesized single argument
+        # is a normal function call of the operator: unwrap the parens so `x`
+        # is the arg and the parens become the call's trivia. CSTParser keeps
+        # `-`/`!`/`~` as genuine unary applications of the bracketed operand.
+        op, parens = kids[1], kids[2]
+        args = EXPR[op]
+        append!(args, parens.args)
+        return EXPR(:call, args, parens.trivia, 0, 0)
     elseif k == K"juxtapose"
         # 2x / 2(x+1) → implicit multiplication; CSTParser synthesizes a
         # zero-width `*` operator since juxtaposition has no real op leaf.
@@ -348,7 +359,8 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         isempty(groups) || insert!(args, 1, merge_params!(groups))
         return EXPR(:tuple, args, trivia, 0, 0)
     elseif k == K"vect"
-        args, trivia, groups = collect_arglist(kids, kkinds, K"[", K"]")
+        # A `[a=b]` element keeps `=` as assignment (not `:kw`), like a tuple.
+        args, trivia, groups = collect_arglist(kids, kkinds, K"[", K"]"; kw=false)
         isempty(groups) || insert!(args, 1, merge_params!(groups))
         return EXPR(:vect, args, trivia, 0, 0)
     elseif k == K"braces"
@@ -458,6 +470,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             cur.grow_span += ll.fullspan - ll.span
         end
         return EXPR(:macrocall, args, macro_trivia, 0, 0)
+    elseif k == K"inert"
+        # `A.$f` getfield with an interpolated field name: the field is a
+        # K"inert"-wrapped `$` interpolation → CSTParser's :quotenode.
+        return EXPR(:quotenode, kids, nothing, 0, 0)
     elseif k == K"doc"
         # `"..." expr` docstring → CSTParser's synthetic @doc macrocall:
         # [globalrefdoc, NOTHING, docstring, documented_expr], no trivia.
@@ -490,6 +506,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                        push!(args, ex)
                 i += 1
             else
+                # `import Base: in` — a word-operator path component is
+                # tokenized as Identifier but labelled OPERATOR by CSTParser.
+                ex.head === :IDENTIFIER && ex.val in ("where", "in", "isa") &&
+                    (ex.head = :OPERATOR)
                 push!(args, ex)
                 seen = true
                 i += 1

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -655,6 +655,15 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 call_ex = ex
             end
         end
+        # `f(x) do; body end` (no params): the empty-params tuple carries a
+        # lone `;` — CSTParser folds that onto the DO keyword and leaves an
+        # empty tuple.
+        if tuple_ex.args !== nothing && length(tuple_ex.args) == 1 &&
+           tuple_ex.args[1].head === :SEMICOLON
+            semi = tuple_ex.args[1]
+            trivia[1].fullspan += semi.fullspan   # DO keyword is trivia[1]
+            tuple_ex = EXPR(:tuple, EXPR[], EXPR[], 0, 0)
+        end
         fullspan = tuple_ex.fullspan + block_ex.fullspan
         span = fullspan - (block_ex.fullspan - block_ex.span)
         op = EXPR(:OPERATOR, 0, 0, "->")

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -51,6 +51,53 @@ function merge_params!(groups::Vector{EXPR})
     return groups[1]
 end
 
+# Zero-width absent-clause marker shared by try's catch/finally/else slots
+# (val is the empty string, NOT nothing — differs from struct/module's
+# TRUE/FALSE marker convention, oracle-pinned via dump).
+false_arg() = EXPR(:FALSE, 0, 0, "")
+
+# generator/filter compute span via `fullspan - (args[end].fullspan -
+# args[end].span)` (CSTParser's own convention, same family as
+# merge_params!'s), not the auto raw-leaf-bookend calc `assemble()` performs
+# by default — the two coincide UNLESS args[end] itself already carries a
+# trim_span-style correction (filter's own fix feeds into generator's).
+# Corrects the auto calc via the existing trim_span field; needs no new
+# span machinery since it's a pure arithmetic reconciliation of the two
+# already-sanctioned formulas.
+function trim_span_to_last_arg!(cur::Cursor, args::Vector{EXPR})
+    isempty(args) && return
+    last_leaf = cur.leaves[cur.i-1]
+    a = args[end]
+    cur.trim_span += (a.fullspan - a.span) - (last_leaf.fullspan - last_leaf.span)
+end
+
+# Sum of the OWN spans of a maximal trailing run of `;`-kind kids (e.g. the
+# double `;;` promoting to the next ncat dimension) — every one of them
+# folds away via fold_semi!, but assemble()'s automatic span calc still
+# counts each dropped separator's own "meaningful" width since the raw
+# leaf-range last leaf IS the final one of the run; trim_span excludes them.
+function trailing_semi_span(kids::Vector{EXPR}, kkinds::Vector{Kind})
+    total = 0
+    for j in length(kkinds):-1:1
+        kkinds[j] == K";" || break
+        total += kids[j].span
+    end
+    return total
+end
+
+# Cell elements directly inside hcat/vcat/row/ncat/nrow get EMPTY args AND
+# trivia vectors instead of `nothing` when they're bare terminals — an
+# oracle-pinned CSTParser quirk exclusive to matrix-literal contexts
+# (vect/ref/call arguments keep the normal `nothing`). Composite cells
+# (already carrying real args/trivia) are untouched.
+function matrix_cell!(ex::EXPR)
+    if ex.args === nothing
+        ex.args = EXPR[]
+        ex.trivia = EXPR[]
+    end
+    return ex
+end
+
 # Shared by call/dotcall/curly/macrocall arg lists: split into positional
 # args, bracket/comma trivia, and `;`-groups (still unmerged/unrelocated —
 # each caller decides where the merged group lands); `a=b` becomes `:kw`.
@@ -110,9 +157,12 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # right after the callee (kids[1], which lands in args[1] here since
         # it matches none of collect_arglist's special cases); `a=b`
         # positional args become `:kw`.
+        # Pre-existing gap found via corpus probing: a parenless prefix-op
+        # call (`!x`, no LPAREN/RPAREN at all) never populates trivia, so it
+        # stayed the initial empty Vector{EXPR} instead of `nothing`.
         args, trivia, groups = collect_arglist(kids, kkinds, K"(", K")")
         isempty(groups) || insert!(args, 2, merge_params!(groups))
-        return EXPR(:call, args, trivia, 0, 0)
+        return EXPR(:call, args, isempty(trivia) ? nothing : trivia, 0, 0)
     elseif k == K"dotcall"
         # f.(x, y) → (:., [f, tuple(x, y)]); the parenthesized arg list packs
         # into a :tuple the same way a call's does (parameters relocate to
@@ -230,6 +280,14 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # their RHS in an implicit block; plain assignment does not, and an
         # explicit `begin ... end` RHS is never wrapped a second time.
         lhs, op, rhs = kids
+        if k == K"=" && op.val != "="
+            # for-loop/comprehension iteration spec (`i in xs`/`i ∈ xs`):
+            # JuliaSyntax reuses K"=" regardless of the actual keyword; the
+            # oracle always synthesizes a zero-width "=" head and relocates
+            # the real in/∈ operator to trivia.
+            head = EXPR(:OPERATOR, 0, 0, "=")
+            return EXPR(head, EXPR[lhs, rhs], EXPR[op], 0, 0)
+        end
         needs_block = (k == K"->" || kkinds[1] == K"call" || kkinds[1] == K"where") &&
                       kkinds[3] != K"block"
         body = needs_block ? EXPR(:block, EXPR[rhs], nothing, rhs.fullspan, rhs.span) : rhs
@@ -255,6 +313,339 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             end
         end
         return EXPR(:where, args, trivia, 0, 0)
+    elseif k == K"if" || k == K"elseif"
+        # JuliaSyntax reuses K"if"/K"elseif" for both the composite node AND
+        # its own leading keyword leaf — a leaf keyword has `args === nothing`
+        # (built by terminal_expr), a nested elseif clause doesn't, so that's
+        # the only reliable way to tell "keyword to drop" from "child node".
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ex.args === nothing && JuliaSyntax.is_keyword(ck)
+                push!(trivia, ex)
+            else
+                push!(args, ex)
+            end
+        end
+        return EXPR(k == K"if" ? :if : :elseif, args, trivia, 0, 0)
+    elseif k == K"?"
+        # ternary a ? b : c → (:if, [a, b, c], trivia=[?, :]) — reuses if's head.
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == K"?" || ck == K":") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:if, args, trivia, 0, 0)
+    elseif (k == K"break" || k == K"continue") && length(kids) == 1
+        # The composite node wraps a single leaf of the SAME kind; the oracle
+        # collapses the statement to just that leaf, no wrapping at all.
+        return kids[1]
+    elseif k == K"return"
+        # `return` (no value) gets a synthetic zero-width NOTHING arg; `return
+        # x` already has a real value kid, no synthesis needed.
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            ck == K"return" ? push!(trivia, ex) : push!(args, ex)
+        end
+        isempty(args) && push!(args, EXPR(:NOTHING, 0, 0, ""))
+        return EXPR(:return, args, trivia, 0, 0)
+    elseif k == K"catch"
+        # Flattened into try's own args/trivia by the K"try" branch below;
+        # this intermediate shape is never part of the final tree.
+        catch_kw = nothing
+        rest = EXPR[]
+        restk = Kind[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"catch"
+                catch_kw = ex
+            else
+                push!(rest, ex)
+                push!(restk, ck)
+            end
+        end
+        var, block = rest[1], rest[2]
+        if var.span == 0 && var.fullspan != 0
+            # JuliaSyntax's absent-catch-var placeholder is a zero-content
+            # leaf that still swallows trailing whitespace up to the next
+            # token; CSTParser's own CATCH keyword owns that width instead.
+            catch_kw.fullspan += var.fullspan
+            var.fullspan = 0
+        end
+        if restk[1] == K"false" && isempty(block.args)
+            # Oracle-pinned quirk: an empty catch body with NO named var
+            # keeps `trivia = EXPR[]`, not `nothing` (every other empty
+            # block, incl. this same one WITH a var, uses `nothing`).
+            block.trivia = EXPR[]
+        end
+        return EXPR(:catch, EXPR[var, block], EXPR[catch_kw], 0, 0)
+    elseif k == K"finally"
+        # Oracle-pinned: the finally block always keeps `trivia = EXPR[]`,
+        # never `nothing`, regardless of statement count.
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"finally"
+                push!(trivia, ex)
+            else
+                ex.trivia === nothing && (ex.trivia = EXPR[])
+                push!(args, ex)
+            end
+        end
+        return EXPR(:finally, args, trivia, 0, 0)
+    elseif k == K"else" && kkinds[1] == K"else"
+        # try's else-clause is its own composite node (unlike if/elseif's
+        # bare ELSE leaf, which never reaches assemble_form at all). Same
+        # trivia-always-EXPR[] quirk as finally's block.
+        block = kids[2]
+        block.trivia === nothing && (block.trivia = EXPR[])
+        return EXPR(:elseclause, EXPR[block], EXPR[kids[1]], 0, 0)
+    elseif k == K"try"
+        # CSTParser's :try has a fixed 5-slot layout beyond the try-block:
+        # [catch_var, catch_block, finally_block, else_block]. Absent
+        # trailing slots are dropped entirely; an absent slot that still has
+        # a present slot AFTER it (in this order) keeps a zero-width FALSE
+        # placeholder instead. Same trim-from-the-tail rule applies to the
+        # keyword trivia (CATCH is unconditional — a try always has catch or
+        # finally, so CATCH is never the trailing item).
+        try_kw = end_kw = try_block = nothing
+        catch_kw = catch_var = catch_block = nothing
+        finally_kw = finally_block = nothing
+        else_kw = else_block = nothing
+        has_catch = has_finally = has_else = false
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"try"
+                try_kw = ex
+            elseif ck == K"end"
+                end_kw = ex
+            elseif ck == K"catch"
+                has_catch = true
+                catch_kw, catch_var, catch_block = ex.trivia[1], ex.args[1], ex.args[2]
+            elseif ck == K"finally"
+                has_finally = true
+                finally_kw, finally_block = ex.trivia[1], ex.args[1]
+            elseif ck == K"else"
+                has_else = true
+                else_kw, else_block = ex.trivia[1], ex.args[1]
+            else
+                try_block = ex
+            end
+        end
+        raw = [(catch_var, has_catch), (catch_block, has_catch),
+               (finally_block, has_finally), (else_block, has_else)]
+        while !isempty(raw) && !raw[end][2]
+            pop!(raw)
+        end
+        args = EXPR[try_block]
+        for (v, present) in raw
+            push!(args, present ? v : false_arg())
+        end
+        catch_trivia = has_catch ? catch_kw : EXPR(:CATCH, 0, 0, nothing)
+        raw_t = [(finally_kw, has_finally), (else_kw, has_else)]
+        while !isempty(raw_t) && !raw_t[end][2]
+            pop!(raw_t)
+        end
+        trivia = EXPR[try_kw, catch_trivia]
+        for (v, present) in raw_t
+            push!(trivia, present ? v : false_arg())
+        end
+        push!(trivia, end_kw)
+        return EXPR(:try, args, trivia, 0, 0)
+    elseif k == K"let"
+        # bindings block collapses to its single item when there's exactly
+        # one binding (`let x = 1` / `let x`); stays a :block for 0 or 2+.
+        trivia = EXPR[]
+        bindings = body = nothing
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"let" || ck == K"end"
+                push!(trivia, ex)
+            elseif bindings === nothing
+                bindings = ex
+            else
+                body = ex
+            end
+        end
+        length(bindings.args) == 1 && (bindings = bindings.args[1])
+        return EXPR(:let, EXPR[bindings, body], trivia, 0, 0)
+    elseif k == K"cartesian_iterator"
+        # Multi-spec `for`/generator iteration (`i = 1:10, j in ys`) → a
+        # synthetic :block of iteration specs with comma trivia.
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            ck == K"," ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:block, args, trivia, 0, 0)
+    elseif k == K"comprehension"
+        trivia = EXPR[kids[1], kids[end]]
+        return EXPR(:comprehension, EXPR[kids[2]], trivia, 0, 0)
+    elseif k == K"generator"
+        # [expr for spec] → (:generator, [expr, spec], trivia=[for]); a
+        # multi-spec cartesian_iterator FLATTENS its args/trivia directly
+        # into generator's own (unlike `for`, which keeps it as a nested
+        # :block) — confirmed via dump: comma lands in generator's trivia.
+        trivia = EXPR[]
+        expr = spec = nothing
+        speck = K"None"
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"for"
+                push!(trivia, ex)
+            elseif expr === nothing
+                expr = ex
+            else
+                spec, speck = ex, ck
+            end
+        end
+        args = EXPR[expr]
+        if speck == K"cartesian_iterator"
+            append!(args, spec.args)
+            append!(trivia, spec.trivia)
+        else
+            push!(args, spec)
+        end
+        trim_span_to_last_arg!(cur, args)
+        return EXPR(:generator, args, trivia, 0, 0)
+    elseif k == K"filter"
+        # `... if cond` clause → (:filter, [cond, spec], trivia=[if]) — args
+        # order is COND-then-SPEC, reversed from source order (spec if cond),
+        # so span follows CSTParser's own args[end]-trailing-exclusion
+        # convention rather than the raw leaf-bookend calc.
+        trivia = EXPR[]
+        spec = cond = nothing
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"if"
+                push!(trivia, ex)
+            elseif spec === nothing
+                spec = ex
+            else
+                cond = ex
+            end
+        end
+        args = EXPR[cond, spec]
+        trim_span_to_last_arg!(cur, args)
+        return EXPR(:filter, args, trivia, 0, 0)
+    elseif k == K"hcat"
+        # Bare cells get the matrix_cell! quirk (hcat always has >=2, since
+        # a single bracketed item is a :vect instead).
+        trivia = EXPR[kids[1], kids[end]]
+        cells = kids[2:end-1]
+        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        return EXPR(:hcat, cells, trivia, 0, 0)
+    elseif k == K"row"
+        # `1 2;` inside vcat — bare cells, trailing `;` dropped/folded like a
+        # block's, oracle-pinned zero-width trivia (never `nothing`). The
+        # matrix_cell! quirk only fires with >=2 real cells — oracle-pinned:
+        # a lone cell (e.g. the degenerate `[a;]`, no row wrapping needed)
+        # keeps the normal `nothing` args/trivia.
+        cells = EXPR[]
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if ck == K";"
+                semi_i = first(cur.kid_ranges[j])
+                fold_semi!(cur, semi_i, ex.fullspan) ||
+                    (isempty(cells) || (cells[end].fullspan += ex.fullspan))
+            else
+                push!(cells, ex)
+            end
+        end
+        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        !isempty(kkinds) && kkinds[end] == K";" &&
+            (cur.trim_span += trailing_semi_span(kids, kkinds))
+        return EXPR(:row, cells, EXPR[], 0, 0)
+    elseif k == K"vcat"
+        # Either wraps nested :row children (2D matrices) or holds bare cells
+        # directly with `;` fold (flat column vectors) — both shapes seen in
+        # the wild; handle both in one pass. Unlike row/nrow, a trailing `;`
+        # here is always followed by the closing `]`, so it's never this
+        # node's own leaf-range-computed last leaf — no trim_span needed.
+        trivia = EXPR[kids[1], kids[end]]
+        args = EXPR[]
+        cells = EXPR[]   # bare (non-row) cells only, to gate the quirk
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if ck == K"[" || ck == K"]"
+                continue
+            elseif ck == K";"
+                semi_i = first(cur.kid_ranges[j])
+                fold_semi!(cur, semi_i, ex.fullspan) ||
+                    (isempty(args) || (args[end].fullspan += ex.fullspan))
+            elseif ck == K"row"
+                push!(args, ex)
+            else
+                push!(args, ex)
+                push!(cells, ex)
+            end
+        end
+        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        return EXPR(:vcat, args, trivia, 0, 0)
+    elseif k == K"nrow"
+        # Like row, but prefixed with a synthetic dim-number marker (a bare
+        # Symbol head named after the digit, e.g. Symbol("1")) read from the
+        # green node's own flags — CSTParser's ncat/nrow dimension encoding.
+        dim = JuliaSyntax.numeric_flags(JuliaSyntax.flags(node))
+        cells = EXPR[]
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if ck == K";"
+                semi_i = first(cur.kid_ranges[j])
+                fold_semi!(cur, semi_i, ex.fullspan) ||
+                    (isempty(cells) || (cells[end].fullspan += ex.fullspan))
+            else
+                push!(cells, ex)
+            end
+        end
+        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        !isempty(kkinds) && kkinds[end] == K";" &&
+            (cur.trim_span += trailing_semi_span(kids, kkinds))
+        args = EXPR[EXPR(Symbol(string(dim)), 0, 0, "")]
+        append!(args, cells)
+        return EXPR(:nrow, args, EXPR[], 0, 0)
+    elseif k == K"ncat"
+        dim = JuliaSyntax.numeric_flags(JuliaSyntax.flags(node))
+        trivia = EXPR[kids[1], kids[end]]
+        rest = EXPR[]
+        cells = EXPR[]
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if ck == K"[" || ck == K"]"
+                continue
+            elseif ck == K";"
+                semi_i = first(cur.kid_ranges[j])
+                fold_semi!(cur, semi_i, ex.fullspan) ||
+                    (isempty(rest) || (rest[end].fullspan += ex.fullspan))
+            elseif ck == K"nrow"
+                push!(rest, ex)
+            else
+                push!(rest, ex)
+                push!(cells, ex)
+            end
+        end
+        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        args = EXPR[EXPR(Symbol(string(dim)), 0, 0, "")]
+        append!(args, rest)
+        return EXPR(:ncat, args, trivia, 0, 0)
+    elseif k == K"block" && length(kids) >= 2 && kkinds[1] == K"(" && kkinds[end] == K")"
+        # `(a; b)` — JuliaSyntax gives ONE green `block` node wrapping the
+        # parens directly (no nested "parens" node); the oracle synthesizes
+        # two EXPR levels instead: outer :brackets(paren trivia) wrapping an
+        # inner :block built with the same `;`-fold rules as a real block.
+        # The inner node is hand-built (not an assemble_form return value
+        # for a real node), so its span is computed directly rather than via
+        # Cursor.trim/trim_span.
+        args = EXPR[]
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if j == 1 || j == length(kids)
+                continue
+            elseif ck == K";"
+                semi_i = first(cur.kid_ranges[j])
+                if fold_semi!(cur, semi_i, ex.fullspan)
+                else
+                    isempty(args) || (args[end].fullspan += ex.fullspan)
+                end
+            else
+                push!(args, ex)
+            end
+        end
+        fullspan = sum(x -> x.fullspan, args; init=0)
+        span = isempty(args) ? 0 : fullspan - (args[end].fullspan - args[end].span)
+        inner = EXPR(:block, args, EXPR[], fullspan, span)
+        return EXPR(:brackets, EXPR[inner], EXPR[kids[1], kids[end]], 0, 0)
     elseif k == K"block"
         # `;`-separated statements drop the `;` entirely, same as toplevel's:
         # its width folds onto the rightmost leaf of the preceding statement.
@@ -262,6 +653,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         trivia = EXPR[]
         for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ck == K"begin" || ck == K"end"
+                push!(trivia, ex)
+            elseif ck == K","
+                # `let`'s bindings list reuses K"block" for its comma-joined
+                # `=` items; a plain statement block never has raw commas.
                 push!(trivia, ex)
             elseif ck == K";"
                 semi_i = first(cur.kid_ranges[j])

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -20,7 +20,8 @@ function widen_at_leaf!(cur::Cursor, i::Int, width::Int)
         # the `;` as excluded trailing width even with an empty last arg.
         grow = node.args !== nothing && !isempty(node.args) &&
                node.args[end].fullspan == 0 && node.span == node.fullspan &&
-               (node.trivia === nothing || isempty(node.trivia))
+               (node.trivia === nothing || isempty(node.trivia) ||
+                !(node.trivia[end].head in (:END, :RPAREN, :RSQUARE, :RBRACE)))
         node.fullspan += width
         grow && (node.span += width)
         node = node.parent
@@ -1215,7 +1216,16 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                     # node's leaf-range-computed last leaf — its own (never
                     # folded-away) span still inflates the auto span calc;
                     # exclude just that span-only, fullspan stays correct.
-                    j == length(kids) && (cur.trim_span += ex.span)
+                    # ...unless the preceding arg absorbed the `;` into its own
+                    # SPAN (a bare `return`, span == fullspan): then the block
+                    # measures to that full span (grow, don't trim).
+                    if j == length(kids) && !isempty(args)
+                        if args[end].span != args[end].fullspan
+                            cur.trim_span += ex.span
+                        else
+                            grow_span_to_last_arg!(cur, args)
+                        end
+                    end
                 else
                     isempty(args) || (args[end].fullspan += ex.fullspan)
                 end

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -1054,17 +1054,25 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         trivia = EXPR[]
         args = EXPR[]
         has_end = K"end" in kkinds
+        err_w = 0
         for (ex, ck) in zip(kids, kkinds)
             if ex.args === nothing && JuliaSyntax.is_keyword(ck)
                 push!(trivia, ex)
             elseif JuliaSyntax.is_error(ck) && !has_end && !isempty(args)
-                # Unterminated `if`: the missing-`end` marker becomes a trivia
-                # END-placeholder (not a spurious extra arg) so iterate holds.
-                push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)],
-                                   nothing, ex.fullspan, ex.span))
+                # missing-`end` recovery marker; its width rides on the
+                # END-placeholder appended below
+                err_w += ex.fullspan
             else
                 push!(args, ex)
             end
+        end
+        if k == K"if" && !has_end
+            # Unterminated `if` needs a trivia END-placeholder for iterate's
+            # arity even when no marker kid survived (a stray-content error
+            # was absorbed into the body block, or `else`/`end` escaped to
+            # toplevel error siblings). Never for `elseif` (no END slot).
+            push!(trivia, EXPR(:errortoken, EXPR[EXPR(:END, 0, 0, nothing)],
+                               nothing, err_w, 0))
         end
         # An `elseif` ends in its (possibly empty) body block, not an END
         # keyword, so its span is measured to that last arg — grow when the

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -125,6 +125,38 @@ function matrix_cell!(ex::EXPR)
     return ex
 end
 
+# 1.x wraps a getfield/qualified-macro field name in a K"quote" green child
+# only when the source used an explicit `:` (`a.:b`); a bare atom (`a.b`,
+# `a.begin`, `a."prop"`) or a bare `@`+MacroName pair (`a.@m`) arrives
+# unwrapped. These two helpers synthesize the :quotenode/:quote shape
+# CSTParser still expects, mirroring the K"quote" branch's own atom path.
+function wrap_field_atom(inner::EXPR)::EXPR
+    inner.head === :BEGIN && (inner.head = :IDENTIFIER)
+    inner.head in (:STRING, :TRIPLESTRING) && return inner
+    head = (inner.args === nothing || inner.head === :NONSTDIDENTIFIER) ? :quotenode : :quote
+    # Transparent width: this wrapper adds no source characters of its own,
+    # so it must inherit inner's span (assemble()'s automatic fullspan/span
+    # fixup only applies to a form's own top-level return, not this kind of
+    # freshly-synthesized nested wrapper).
+    return EXPR(head, EXPR[inner], nothing, inner.fullspan, inner.span)
+end
+
+function fuse_field_macroname(atex::EXPR, nameex::EXPR, cur::Cursor, name_slot::Int)::EXPR
+    if nameex.val isa String
+        fused = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
+                    atex.span + nameex.span, "@" * nameex.val)
+        # Register the fused name at its leaf slot so a later `;`-fold
+        # (e.g. `(Base.@m; x)`) widens THIS EXPR, not the orphaned MacroName.
+        cur.terminals[name_slot] = fused
+        return EXPR(:quotenode, EXPR[fused], nothing, fused.fullspan, fused.span)
+    end
+    # Broken macro name (missing/errored) — can't fuse into one IDENTIFIER;
+    # keep both pieces reachable instead.
+    fused = EXPR(:errortoken, EXPR[atex, nameex], nothing,
+                 atex.fullspan + nameex.fullspan, atex.span + nameex.span)
+    return EXPR(:quotenode, EXPR[fused], nothing, fused.fullspan, fused.span)
+end
+
 # Shared by call/dotcall/curly/macrocall arg lists: split into positional
 # args, bracket/comma trivia, and `;`-groups (still unmerged/unrelocated —
 # each caller decides where the merged group lands); `a=b` becomes `:kw`.
@@ -188,6 +220,11 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
     elseif k == K"call" && JuliaSyntax.is_infix_op_call(JuliaSyntax.head(node))
         # a + b (+ c ...) → (:call, [op, a, b, c...]); extra op tokens → trivia
         op = kids[2]
+        # Word operators (isa/in/where) used as the callee of a real infix
+        # call reclassify to plain Identifier in 1.x (same normalization as
+        # +/-/==/etc.); the INFIX_FLAG on this node is authoritative that
+        # it's semantically an operator regardless of the leaf's own kind.
+        op.head === :IDENTIFIER && (op.head = :OPERATOR)
         args = EXPR[op, kids[1]]
         trivia = EXPR[]
         for j in 3:length(kids)
@@ -253,6 +290,26 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             end
         end
         return EXPR(:comparison, args, nothing, 0, 0)
+    elseif k == K"call" && !isempty(kkinds) && kkinds[end] == K"do"
+        # `f(x) do y ... end`: 1.x nests the do-block as this call's own
+        # last child (0.4 had it inverted, a K"do" node wrapping the call)
+        # — reunite the call target (this node's own kids minus the
+        # trailing do-node, built the same way the plain K"call" branch
+        # below does) with the do-body carrier the K"do" branch packaged.
+        do_partial = kids[end]
+        call_kids, call_kkinds = kids[1:end-1], kkinds[1:end-1]
+        args, trivia, groups = collect_arglist(call_kids, call_kkinds, K"(", K")")
+        isempty(groups) || insert!(args, 2, merge_params!(groups))
+        if kkinds[1] == K"." && args[1].head isa EXPR && args[1].head.val == "." &&
+           args[1].args !== nothing && length(args[1].args) == 1 &&
+           args[1].args[1].head === :OPERATOR
+            di = args[1]
+            args[1] = EXPR(:OPERATOR, di.fullspan, di.span, di.head.val * di.args[1].val)
+        end
+        call_fs = sum(x -> x.fullspan, call_kids; init=0)
+        call_sp = call_fs - (call_kids[end].fullspan - call_kids[end].span)
+        call_ex = EXPR(:call, args, isempty(trivia) ? nothing : trivia, call_fs, call_sp)
+        return EXPR(:do, EXPR[call_ex, do_partial.args[1]], do_partial.trivia, 0, 0)
     elseif k == K"call"
         # f(x, y) → (:call, [f, x, y], trivia=[lparen, commas..., rparen]).
         # `;`-separated keyword args nest under a `parameters` child at their
@@ -329,17 +386,32 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         span = fullspan - (sub[end].fullspan - sub[end].span)
         tup = EXPR(:tuple, args, trivia, fullspan, span)
         return EXPR(dot, EXPR[callee, tup], nothing, 0, 0)
-    elseif k == K"." && length(kids) == 3
-        # a.b / a.b.c → (:., [a, quotenode(b)]); dot is operator-headed like
-        # ::/<:/->. The field-name side is always a K"quote" child (see the
-        # branch below), already packaged as :quotenode by the time we see it.
-        return EXPR(kids[2], EXPR[kids[1], kids[3]], nothing, 0, 0)
+    elseif k == K"." && length(kids) >= 3 && kkinds[2] == K"."
+        # a.b / a.b.c / a.:b / a.begin / a."prop" / a.@m x → (:., [a, field]);
+        # dot is operator-headed like ::/<:/->. 1.x wraps the field-name side
+        # in a K"quote" child only when the source used an explicit `:`
+        # (`a.:b`); a bare atom (or a bare `@`+MacroName pair for `a.@m`)
+        # needs the :quotenode/:quote wrap synthesized here instead.
+        field = if kkinds[3] == K"quote"
+            kids[3]
+        elseif length(kids) == 4 && kkinds[3] == K"@"
+            fuse_field_macroname(kids[3], kids[4], cur, first(cur.kid_ranges[4]))
+        elseif kkinds[3] == K"$"
+            # `a.$f` — interpolated field name (0.4 wrapped this in K"inert",
+            # 1.x drops that indirection); kids[3] is already the converted
+            # `$`-operator-headed EXPR, just needs the :quotenode wrap.
+            EXPR(:quotenode, EXPR[kids[3]], nothing, kids[3].fullspan, kids[3].span)
+        else
+            wrap_field_atom(kids[3])
+        end
+        return EXPR(kids[2], EXPR[kids[1], field], nothing, 0, 0)
     elseif k == K"." && length(kids) == 4 && kkinds[1] == K"@"
         # @m.n x: a dotted/qualified macro name — the LHS itself is an
         # unfused `@`+name pair (same fusion as macrocall's own @+name, and
-        # as the K"quote" branch below does for the A.@m x case where the
-        # `@` sits on the RHS instead).
-        atex, nameex, dotex, rhs = kids
+        # as the branch above does for the A.@m x case where the `@` sits on
+        # the RHS instead). The RHS MacroName arrives as a bare atom in 1.x
+        # (no K"quote" wrapper unless colon-prefixed), same wrap as above.
+        atex, nameex, dotex, rhsraw = kids
         lhs = if nameex.val isa String
             EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
                  atex.span + nameex.span, "@" * nameex.val)
@@ -349,6 +421,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             EXPR(:errortoken, EXPR[atex, nameex], nothing,
                  atex.fullspan + nameex.fullspan, atex.span + nameex.span)
         end
+        rhs = kkinds[4] == K"quote" ? rhsraw : wrap_field_atom(rhsraw)
         return EXPR(dotex, EXPR[lhs, rhs], nothing, 0, 0)
     elseif k == K"quote"
         # Three shapes share this kind:
@@ -444,6 +517,21 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         isempty(groups) || insert!(args, 2, merge_params!(groups))
         return EXPR(:curly, args, trivia, 0, 0)
     elseif k == K"tuple"
+        if length(kids) == 1 && kkinds[1] != K";"
+            # Paren-less single-element tuple: 1.x's uniform node kind for a
+            # `->` LHS param regardless of spelling (`x -> ...` vs
+            # `(x) -> ...`), and for a `do y ... end` single-param list; the
+            # bare form has no bracket/comma kids at all (a real 1-tuple
+            # `(x,)` always keeps its parens+comma kids). The oracle keeps a
+            # do-param list as a :tuple (empty trivia) but a bare `->` LHS
+            # as the plain identifier — trivia === nothing marks the bare
+            # form so each consumer can tell (a bracketed tuple always has
+            # paren/comma trivia): `do` normalizes it to EXPR[], `->`
+            # unwraps it. Excludes the bare `;` placeholder of a no-params
+            # `do; ... end` (still needs the regular :tuple path below, so
+            # the K"do" branch's SEMICOLON check keeps working).
+            return EXPR(:tuple, kids, nothing, kids[1].fullspan, kids[1].span)
+        end
         # `(a, :b)` → (:tuple, [args], trivia=[parens, commas]); a named-tuple
         # field (`(a=b,)`) keeps `=` as assignment (not `:kw`); `;`-parameters
         # (`(; a=1)`) relocate to the front and keep their own `:kw` shape.
@@ -538,6 +626,16 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # in terminal_expr), nothing to fuse. A synthetic zero-width NOTHING
         # marker always follows the name; `;`-parameters relocate to right
         # after it (args[3]).
+        # `@recipe(A) do scene ... end`: 1.x nests the do-node as this
+        # macrocall's own last child (same inversion as call+do); split it
+        # off, build the macrocall from the rest, and wrap in :do at the end.
+        do_partial = nothing
+        if kkinds[end] == K"do"
+            do_partial = kids[end]
+            mac_fs = sum(x -> x.fullspan, kids[1:end-1]; init=0)
+            mac_sp = mac_fs - (kids[end-1].fullspan - kids[end-1].span)
+            kids, kkinds = kids[1:end-1], kkinds[1:end-1]
+        end
         if kkinds[1] == K"@"
             atex, nameex = kids[1], kids[2]
             if nameex.val isa String
@@ -570,6 +668,12 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # (`M.@m(a)`) or has no real args at all (`Base.@_inline_meta`, whose
         # last arg is the zero-width NOTHING). A qualified macrocall with a
         # trailing real arg (`M.@m a`) keeps a normal span.
+        if do_partial !== nothing
+            # The span quirks below don't apply: the macrocall is not the
+            # returned node, and its right edge is the do-block's start.
+            mac = EXPR(:macrocall, args, macro_trivia, mac_fs, mac_sp)
+            return EXPR(:do, EXPR[mac, do_partial.args[1]], do_partial.trivia, 0, 0)
+        end
         if name.head isa EXPR && (kkinds[end] == K")" || last(args).fullspan == 0)
             ll = cur.leaves[cur.i-1]
             cur.grow_span += ll.fullspan - ll.span
@@ -709,20 +813,22 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         end
         return EXPR(Symbol(lowercase(string(k))), args, trivia, 0, 0)
     elseif k == K"do"
-        # `f(x) do y ... end` desugars to a call plus a synthetic zero-width
-        # `->` operator wrapping the (params-tuple, body-block) pair — no
-        # literal `->` token exists in the source.
-        call_ex = tuple_ex = block_ex = nothing
+        # `f(x) do y ... end`: 1.x nests this do-node as the LAST child of
+        # the enclosing K"call" node (0.4 had it inverted — a K"do" node
+        # wrapped the call). This node's own kids are just [do, params-
+        # tuple, body-block, end], with no call target; package the params/
+        # body pair (with a synthetic zero-width `->`, no literal token
+        # exists) plus the do/end trivia into a private carrier EXPR that
+        # the enclosing K"call" branch below reunites with the call target.
+        tuple_ex = block_ex = nothing
         trivia = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
             if ck == K"do" || ck == K"end"
                 push!(trivia, ex)
             elseif ck == K"tuple"
                 tuple_ex = ex
-            elseif ck == K"block"
-                block_ex = ex
             else
-                call_ex = ex
+                block_ex = ex
             end
         end
         # `f(x) do; body end` (no params): the empty-params tuple carries a
@@ -734,11 +840,15 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             trivia[1].fullspan += semi.fullspan   # DO keyword is trivia[1]
             tuple_ex = EXPR(:tuple, EXPR[], EXPR[], 0, 0)
         end
+        # Bare single-param list (`do y`): the K"tuple" branch marks it with
+        # nothing-trivia; the oracle's do-param tuple always has EXPR[].
+        tuple_ex.head === :tuple && tuple_ex.trivia === nothing &&
+            (tuple_ex.trivia = EXPR[])
         fullspan = tuple_ex.fullspan + block_ex.fullspan
         span = fullspan - (block_ex.fullspan - block_ex.span)
         op = EXPR(:OPERATOR, 0, 0, "->")
         body = EXPR(op, EXPR[tuple_ex, block_ex], EXPR[], fullspan, span)
-        return EXPR(:do, EXPR[call_ex, body], trivia, 0, 0)
+        return EXPR(:__do_body__, EXPR[body], trivia, body.fullspan, body.span)
     elseif k == K"..." && length(kids) == 2
         # x... (splat) → (:..., [x]) — postfix unary, operator is the 2nd kid.
         return EXPR(kids[2], EXPR[kids[1]], nothing, 0, 0)
@@ -772,11 +882,44 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         end
         return EXPR(:parameters, args,
                     isempty(args) && isempty(trivia) ? nothing : trivia, 0, 0)
-    elseif (k == K"=" || k == K"->") && length(kids) == 3
+    elseif k == K"in" && length(kids) == 3
+        # for-loop/comprehension iteration spec (`i = xs`/`i in xs`/`i ∈ xs`),
+        # always wrapped in a K"iteration" node (see that branch below).
+        # JuliaSyntax gives the spec node its own Kind regardless of the
+        # actual keyword. When literally spelled `=`, the oracle just uses
+        # that real operator leaf as head (indistinguishable from a plain
+        # assignment); only `in`/`∈` get a synthetic zero-width "=" head
+        # with the real operator relocated to trivia.
+        lhs, op, rhs = kids
+        if op.val == "="
+            return EXPR(op, EXPR[lhs, rhs], nothing, 0, 0)
+        end
+        head = EXPR(:OPERATOR, 0, 0, "=")
+        return EXPR(head, EXPR[lhs, rhs], EXPR[op], 0, 0)
+    elseif k == K"iteration"
+        # Wraps one (single-spec for/generator) or several comma-joined
+        # (multi-spec) iteration bindings. Multi collapses to the same
+        # :block shape the old cartesian_iterator node produced; single is
+        # transparent (no wrapper existed pre-1.x for the single-spec case).
+        if length(kids) == 1
+            return kids[1]
+        end
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            ck == K"," ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:block, args, trivia, 0, 0)
+    elseif (k == K"=" || k == K"->" ||
+            (k == K"function" && K"function" ∉ kkinds)) && length(kids) == 3
         # binary syntax: operator EXPR becomes the head. Short-form function
         # defs (`f(x) = ...`, `f(x::T) where T = ...`) and `->` bodies wrap
         # their RHS in an implicit block; plain assignment does not, and an
         # explicit `begin ... end` RHS is never wrapped a second time.
+        # 1.x normalizes ALL short-form defs to the K"function" node kind
+        # (shared with the long `function ... end` form, which always keeps
+        # a literal K"function" keyword child — the discriminator here);
+        # CSTParser still treats them as `=`-headed binary syntax.
         lhs, op, rhs = kids
         if k == K"=" && JuliaSyntax.is_dotted(JuliaSyntax.head(node))
             # a .= b: dotted assignment reuses base K"=" plus a DOTTED flag
@@ -784,13 +927,61 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             # own Kind and are handled by the generic operator branch below)
             # — op.val is already the real ".=" text, no fusion needed.
             return EXPR(op, EXPR[lhs, rhs], nothing, 0, 0)
-        elseif k == K"=" && op.val != "="
-            # for-loop/comprehension iteration spec (`i in xs`/`i ∈ xs`):
-            # JuliaSyntax reuses K"=" regardless of the actual keyword; the
-            # oracle always synthesizes a zero-width "=" head and relocates
-            # the real in/∈ operator to trivia.
-            head = EXPR(:OPERATOR, 0, 0, "=")
-            return EXPR(head, EXPR[lhs, rhs], EXPR[op], 0, 0)
+        end
+        if k == K"->" && lhs.head === :tuple && lhs.args !== nothing &&
+           length(lhs.args) == 1 && lhs.args[1].head !== :parameters
+            if lhs.trivia === nothing
+                # Bare single-param LHS (`x -> ...`): unwrap the K"tuple"
+                # branch's marked wrapper — the oracle keeps the plain
+                # identifier (only do-blocks keep the :tuple shape).
+                lhs = lhs.args[1]
+            elseif length(lhs.trivia) == 2
+                # `(x) -> ...`: parens but no comma (a real 1-tuple `(x,)`
+                # has 3 trivia) — the oracle keeps a plain :brackets
+                # grouping here, unlike `function (x) ... end`, which keeps
+                # the :tuple under the same green shape.
+                lhs = EXPR(:brackets, lhs.args, lhs.trivia, lhs.fullspan, lhs.span)
+            end
+        elseif k == K"->" && lhs.head === :tuple && lhs.args !== nothing &&
+               length(lhs.args) == 2 && lhs.args[1].head === :parameters &&
+               lhs.trivia !== nothing && length(lhs.trivia) == 2 &&
+               !(lhs.args[2].head isa EXPR && lhs.args[2].head.val == "...")
+            # `(s; kws...) -> ...`: `;`-split LHS with exactly ONE element
+            # on each side of every `;` and no commas — the oracle parses
+            # the paren group as a plain paren-BLOCK (brackets[block[s,
+            # kws...]]) instead of recognizing `;`-parameters; `=` elements
+            # stay plain assignments, not :kw. Any comma (`(a, b; c)`,
+            # `(x; a, b)`), a params-ONLY LHS (`(;x)`) or a SPLAT pre-`;`
+            # element (`(args...; kwargs...)`) keeps the :tuple+parameters
+            # shape — all oracle-pinned. Flatten the group chain (sibling
+            # `;` groups nested by merge_params!) back into block elements.
+            elems = EXPR[lhs.args[2]]
+            group = lhs.args[1]
+            ok = true
+            while group !== nothing
+                nested = nothing
+                n_real = 0
+                for (gi, ge) in enumerate(group.args)
+                    if gi == 1 && ge.head === :parameters
+                        nested = ge
+                    elseif ge.head === :kw
+                        n_real += 1
+                        push!(elems, EXPR(ge.trivia[1], ge.args, nothing,
+                                          ge.fullspan, ge.span))
+                    else
+                        n_real += 1
+                        push!(elems, ge)
+                    end
+                end
+                n_real == 1 || (ok = false; break)
+                group = nested
+            end
+            if ok
+                bfs = sum(x -> x.fullspan, elems; init=0)
+                bsp = bfs - (elems[end].fullspan - elems[end].span)
+                blk = EXPR(:block, elems, EXPR[], bfs, bsp)
+                lhs = EXPR(:brackets, EXPR[blk], lhs.trivia, lhs.fullspan, lhs.span)
+            end
         end
         # A short-form definition (block-wrapped body) is keyed by the LHS
         # being a call / where-clause / return-type-annotated call
@@ -917,7 +1108,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             catch_kw.fullspan += var.fullspan
             var.fullspan = 0
         end
-        if restk[1] == K"false" && isempty(block.args)
+        if restk[1] == K"Placeholder" && isempty(block.args)
             # Oracle-pinned quirk: an empty catch body with NO named var
             # keeps `trivia = EXPR[]`, not `nothing` (every other empty
             # block, incl. this same one WITH a var, uses `nothing`).
@@ -1045,41 +1236,33 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             (ck == k || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
         end
         return EXPR(sym, args, trivia, 0, 0)
-    elseif k == K"cartesian_iterator"
-        # Multi-spec `for`/generator iteration (`i = 1:10, j in ys`) → a
-        # synthetic :block of iteration specs with comma trivia.
-        trivia = EXPR[]
-        args = EXPR[]
-        for (ex, ck) in zip(kids, kkinds)
-            ck == K"," ? push!(trivia, ex) : push!(args, ex)
-        end
-        return EXPR(:block, args, trivia, 0, 0)
     elseif k == K"comprehension"
         trivia = EXPR[kids[1], kids[end]]
         return EXPR(:comprehension, EXPR[kids[2]], trivia, 0, 0)
     elseif k == K"generator"
         # [expr for spec] → (:generator, [expr, spec], trivia=[for]); a
-        # multi-spec cartesian_iterator FLATTENS its args/trivia directly
-        # into generator's own (unlike `for`, which keeps it as a nested
-        # :block) — confirmed via dump: comma lands in generator's trivia.
-        # Multiple `for` clauses (`[x for a in as for b in bs]`) are ONE
-        # flat green node, but the oracle nests them INVERTED — innermost
-        # generator holds the body + LAST clause, each enclosing level adds
-        # the next-earlier clause, and every multi-clause generator gets a
+        # multi-spec K"iteration" FLATTENS its args/trivia directly into
+        # generator's own (unlike `for`, which keeps it as a nested :block)
+        # — confirmed via dump: comma lands in generator's trivia. Multiple
+        # `for` clauses (`[x for a in as for b in bs]`) are ONE flat green
+        # node, but the oracle nests them INVERTED — innermost generator
+        # holds the body + LAST clause, each enclosing level adds the
+        # next-earlier clause, and every multi-clause generator gets a
         # :flatten wrapper (child levels included, the innermost single-
         # clause one excluded). Nested levels are discontiguous in source,
         # so their spans are hand-built from child fullspan sums.
         body = kids[1]
-        groups = Tuple{EXPR,EXPR,Kind}[]   # (for_kw, spec, spec_kind)
+        groups = Tuple{EXPR,EXPR}[]   # (for_kw, spec)
         j = 2
         while j <= length(kids)
-            push!(groups, (kids[j], kids[j+1], kkinds[j+1]))
+            push!(groups, (kids[j], kids[j+1]))
             j += 2
         end
-        function gen_level(child::EXPR, kw::EXPR, spec::EXPR, sk::Kind)
+        function gen_level(child::EXPR, kw::EXPR, spec::EXPR)
             args = EXPR[child]
             trivia = EXPR[kw]
-            if sk == K"cartesian_iterator"
+            if spec.head === :block
+                # multi-spec K"iteration" collapsed to :block; flatten it.
                 append!(args, spec.args)
                 append!(trivia, spec.trivia)
             else
@@ -1343,6 +1526,24 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             end
         end
         marker = EXPR(is_mutable ? :TRUE : :FALSE, 0, 0, nothing)
+        # Field docstrings: 1.x emits K"doc" nodes inside a struct body too,
+        # but the oracle only fuses docstrings at toplevel/module/begin
+        # scope — a struct body keeps the string and the field as separate
+        # block siblings. Unfuse the doc-macrocalls the K"doc" branch built.
+        if body !== nothing && body.args !== nothing
+            unfused = EXPR[]
+            for a in body.args
+                if a.head === :macrocall && a.args !== nothing &&
+                   length(a.args) == 4 && a.args[1].head === :globalrefdoc
+                    push!(unfused, a.args[3], a.args[4])
+                    CSTParser.setparent!(a.args[3], body)
+                    CSTParser.setparent!(a.args[4], body)
+                else
+                    push!(unfused, a)
+                end
+            end
+            body.args = unfused
+        end
         return EXPR(:struct, EXPR[marker, sig, body, errs...], trivia, 0, 0)
     elseif k == K"abstract"
         trivia = EXPR[]
@@ -1418,12 +1619,28 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
             return EXPR(:const, EXPR[modifier], inner.trivia, 0, 0)
         end
         return EXPR(sym, args, trivia, 0, 0)
-    elseif length(kids) == 3 && kkinds[2] == k && JuliaSyntax.is_operator(k)
+    elseif k == K"op=" && length(kids) in (4, 5)
+        # 1.x splits a compound-assignment operator into separate leaves:
+        # the operator name (reclassified to plain Identifier — same "value
+        # position" normalization as any other operator used as a callee),
+        # the real `=`, and for the broadcast form (`.+=`, same kind plus
+        # the DOTTED flag) a leading `.` too. Fuse them into one OPERATOR
+        # EXPR matching the oracle's single-token expectation.
+        lhs, rhs = kids[1], kids[end]
+        mid = kids[2:end-1]
+        fused = EXPR(:OPERATOR, sum(x -> x.fullspan, mid),
+                     sum(x -> x.span, mid), join(x.val for x in mid))
+        grow_span_to_last_arg!(cur, EXPR[lhs, rhs])
+        return EXPR(fused, EXPR[lhs, rhs], nothing, 0, 0)
+    elseif length(kids) == 3 && kids[2].head === :OPERATOR && JuliaSyntax.is_operator(k)
         # Remaining binary-syntax-head kinds that use the operator's own
-        # Kind as the NODE's kind (not K"call"): compound assignment
-        # (+=/.=/...), short-circuit (&&/||), and remaining comparison-as-
-        # syntax ops (>:) — same shape as =/->/::/<:` above, just not
-        # special-cased per-operator since none of them need block-wrapping.
+        # Kind as the NODE's kind (not K"call"): short-circuit (&&/||), and
+        # remaining comparison-as-syntax ops (>:) — same shape as
+        # =/->/::/<:` above, just not special-cased per-operator since none
+        # of them need block-wrapping. Checks the already-converted kid's
+        # head rather than its raw green Kind: 1.x reclassifies some of
+        # these operator leaves (e.g. `>:`/`<:` used infix) to plain
+        # Identifier, already normalized to :OPERATOR by terminal_expr.
         # Placed last: `where`/`in`/`isa` are also JuliaSyntax "operators"
         # by precedence but have their own dedicated non-operator-headed
         # branches earlier, which must win first.
@@ -1431,7 +1648,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # node's span to its last arg (same as the trivia-less block case).
         grow_span_to_last_arg!(cur, EXPR[kids[1], kids[3]])
         return EXPR(kids[2], EXPR[kids[1], kids[3]], nothing, 0, 0)
-    elseif length(kids) == 2 && kkinds[1] == k && JuliaSyntax.is_operator(k)
+    elseif length(kids) == 2 && kids[1].head === :OPERATOR && JuliaSyntax.is_operator(k)
         # Remaining prefix-unary-syntax-head kinds (e.g. `&x`), same shape
         # as bare `::T` above; same last-resort placement rationale.
         return EXPR(kids[1], EXPR[kids[2]], nothing, 0, 0)

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -3,12 +3,27 @@
 # (same leaf spans, just relabeled) into CSTParser's kw shape.
 to_kw(ex::EXPR) = EXPR(:kw, ex.args, EXPR[ex.head], ex.fullspan, ex.span)
 
-# Widen the trailing edge of a subtree by `excess` fullspan, recursing down
-# the rightmost arg each level (mirrors how trailing trivia normally only
-# ever bumps fullspan, never span, all the way down to the actual last leaf).
-function widen_trailing!(ex::EXPR, excess::Int)
-    ex.fullspan += excess
-    ex.args === nothing || isempty(ex.args) || widen_trailing!(ex.args[end], excess)
+# The oracle excludes a parameters group's leading `;` (plus its trailing
+# whitespace) from the parameters node entirely: the width folds onto the
+# rightmost LEAF before the `;` in source — often a closing paren/bracket
+# living in trivia, so walking args can't find it — and onto every ancestor
+# of that leaf up to (and including) the preceding sibling's root. The leaf
+# is located by position via the cursor's terminals map; the ancestors via
+# its parent chain, which ends exactly at the sibling root because the
+# enclosing node isn't constructed yet. Only fullspans grow, never spans.
+function fold_params_semi!(params::EXPR, kid_idx::Int, cur::Cursor)
+    semi_i = first(cur.kid_ranges[kid_idx])
+    semi_i > 1 || return
+    semi = cur.leaves[semi_i]
+    semi.kind == K";" || return
+    node = cur.terminals[semi_i - 1]
+    node === nothing && return
+    while node !== nothing
+        node.fullspan += semi.fullspan
+        node = node.parent
+    end
+    params.fullspan -= semi.fullspan
+    params.span -= semi.fullspan
 end
 
 function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vector{Kind}, cur::Cursor)::EXPR
@@ -47,31 +62,16 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         args = EXPR[]
         trivia = EXPR[]
         params = nothing
-        last_pushed = nothing
-        for (ex, ck) in zip(kids, kkinds)
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ck == K"(" || ck == K")" || ck == K","
                 push!(trivia, ex)
-                last_pushed = ex
             elseif ck == K"parameters"
-                # The leading `;` isn't its own trivia in the oracle shape
-                # (K"parameters" branch drops it); fold its width into
-                # whatever immediately precedes it here, oracle-style.
-                excess = ex.fullspan - sum(c -> c.fullspan, ex.args; init=0) -
-                         (ex.trivia === nothing ? 0 : sum(c -> c.fullspan, ex.trivia; init=0))
-                if excess > 0 && last_pushed !== nothing
-                    widen_trailing!(last_pushed, excess)
-                    ex.fullspan -= excess
-                    ex.span -= excess
-                end
+                fold_params_semi!(ex, j, cur)
                 params = ex
-                last_pushed = ex
             elseif ck == K"="
-                kw = to_kw(ex)
-                push!(args, kw)
-                last_pushed = kw
+                push!(args, to_kw(ex))
             else
                 push!(args, ex)
-                last_pushed = ex
             end
         end
         params === nothing || insert!(args, 2, params)
@@ -79,8 +79,8 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
     elseif k == K"parameters"
         # `; z, w=1` after a call's semicolon → (:parameters, [z, kw(w=1)], trivia=[,]).
         # The leading `;` is dropped entirely (not even trivia); its width
-        # is folded into the preceding call-level sibling by the K"call"
-        # branch, which is the only place that sibling is reachable.
+        # is folded onto the preceding leaf by the K"call" branch via
+        # fold_params_semi!, the only place that leaf is reachable.
         args = EXPR[]
         trivia = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
@@ -98,9 +98,11 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
     elseif (k == K"=" || k == K"->") && length(kids) == 3
         # binary syntax: operator EXPR becomes the head. Short-form function
         # defs (`f(x) = ...`, `f(x::T) where T = ...`) and `->` bodies wrap
-        # their RHS in an implicit block; plain assignment does not.
+        # their RHS in an implicit block; plain assignment does not, and an
+        # explicit `begin ... end` RHS is never wrapped a second time.
         lhs, op, rhs = kids
-        needs_block = k == K"->" || kkinds[1] == K"call" || kkinds[1] == K"where"
+        needs_block = (k == K"->" || kkinds[1] == K"call" || kkinds[1] == K"where") &&
+                      kkinds[3] != K"block"
         body = needs_block ? EXPR(:block, EXPR[rhs], nothing, rhs.fullspan, rhs.span) : rhs
         return EXPR(op, EXPR[lhs, body], nothing, 0, 0)
     elseif (k == K"::" || k == K"<:") && length(kids) == 3

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -209,6 +209,16 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         args = EXPR[op]
         append!(args, parens.args)
         return EXPR(:call, args, parens.trivia, 0, 0)
+    elseif k == K"call" && kids[1].head === :OPERATOR && kids[1].val in ("-", "!", "~") &&
+           length(kids) == 4 && kkinds[2] == K"(" && kkinds[3] != K"," && kkinds[4] == K")"
+        # `macro -(ex)` / `function -(x)` — `-`/`!`/`~` applied to a single
+        # directly-parenthesized operand keeps it as a :brackets (unlike other
+        # prefix operators, which unwrap). The green tree here has the parens
+        # as direct children (no K"parens" wrapper), so synthesize the brackets.
+        op, lp, inner, rp = kids
+        fs = lp.fullspan + inner.fullspan + rp.fullspan
+        brackets = EXPR(:brackets, EXPR[inner], EXPR[lp, rp], fs, fs - (rp.fullspan - rp.span))
+        return EXPR(:call, EXPR[op, brackets], nothing, 0, 0)
     elseif k == K"juxtapose"
         # 2x / 2(x+1) → implicit multiplication; CSTParser synthesizes a
         # zero-width `*` operator since juxtaposition has no real op leaf.
@@ -338,6 +348,13 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         trivia = EXPR[]
         for (ex, ck) in zip(kids, kkinds)
             ck == K":" ? push!(trivia, ex) : push!(args, ex)
+        end
+        # A quoted dotted operator (`:.&`) arrives as a K"." composite (dot+op
+        # leaves); fuse it into one OPERATOR leaf, same as comparison does.
+        if args[1].head isa EXPR && args[1].head.val == "." && args[1].args !== nothing &&
+           length(args[1].args) == 1 && args[1].args[1].head === :OPERATOR
+            di = args[1]
+            args[1] = EXPR(:OPERATOR, di.fullspan, di.span, di.head.val * di.args[1].val)
         end
         inner = args[1]
         # Word operators (`:where`/`:in`/`:isa`) tokenize as Identifier after

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -464,7 +464,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(cells, ex)
             end
         end
-        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        length(args) >= 2 && foreach(matrix_cell!, cells)
         return EXPR(:typed_vcat, EXPR[typ, args...], trivia, 0, 0)
     elseif k == K"typed_ncat"
         # `T[1;; 2]` → typed_vcat plus the ncat dim marker after the type.
@@ -489,7 +489,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(cells, ex)
             end
         end
-        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        length(rest) >= 2 && foreach(matrix_cell!, cells)
         args = EXPR[typ, EXPR(Symbol(string(dim)), 0, 0, ""), rest...]
         return EXPR(:typed_ncat, args, trivia, 0, 0)
     elseif k == K"macrocall"
@@ -1074,7 +1074,10 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(cells, ex)
             end
         end
-        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        # The bare-cell quirk fires when the matrix has 2+ elements total
+        # (rows + bare cells) — a lone bare cell in a multi-row vcat
+        # (`[1 2; 3]`) still gets it, unlike the degenerate `[a;]`.
+        length(args) >= 2 && foreach(matrix_cell!, cells)
         return EXPR(:vcat, args, trivia, 0, 0)
     elseif k == K"nrow"
         # Like row, but prefixed with a synthetic dim-number marker (a bare
@@ -1118,7 +1121,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(cells, ex)
             end
         end
-        length(cells) >= 2 && foreach(matrix_cell!, cells)
+        length(rest) >= 2 && foreach(matrix_cell!, cells)
         args = EXPR[EXPR(Symbol(string(dim)), 0, 0, "")]
         append!(args, rest)
         return EXPR(:ncat, args, trivia, 0, 0)

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -3,39 +3,51 @@
 # (same leaf spans, just relabeled) into CSTParser's kw shape.
 to_kw(ex::EXPR) = EXPR(:kw, ex.args, EXPR[ex.head], ex.fullspan, ex.span)
 
-# The oracle excludes a parameters group's leading `;` (plus its trailing
-# whitespace) from the parameters node entirely: the width folds onto the
-# rightmost LEAF before the `;` in source — often a closing paren/bracket
-# living in trivia, so walking args can't find it — and onto every ancestor
-# of that leaf up to (and including) the preceding sibling's root. The leaf
-# is located by position via the cursor's terminals map; the ancestors via
-# its parent chain, which ends exactly at the sibling root because the
-# enclosing node isn't constructed yet. Only fullspans grow, never spans.
-function fold_params_semi!(params::EXPR, kid_idx::Int, cur::Cursor)
-    semi_i = first(cur.kid_ranges[kid_idx])
-    semi_i > 1 || return
-    semi = cur.leaves[semi_i]
-    semi.kind == K";" || return
-    node = cur.terminals[semi_i - 1]
-    node === nothing && return
+# Fold `width` onto the leaf at absolute leaf index `i` — often a trivia
+# token like a closing paren/bracket, so args-walking can't find it — and
+# onto every ancestor of that leaf via the parent chain, which ends exactly
+# at the leaf's currently-unattached subtree root (enclosing nodes are not
+# constructed yet). Only fullspans grow, never spans. Returns false when no
+# EXPR exists for that leaf.
+function widen_at_leaf!(cur::Cursor, i::Int, width::Int)
+    node = i >= 1 ? cur.terminals[i] : nothing
+    node === nothing && return false
     while node !== nothing
-        node.fullspan += semi.fullspan
+        node.fullspan += width
         node = node.parent
     end
-    params.fullspan -= semi.fullspan
-    params.span -= semi.fullspan
+    return true
+end
+
+# Sibling `;` groups nest recursively: for `f(a; b; c)` the oracle stores
+# the c-group inside the b-group at args[1]. Spans follow CSTParser's
+# update_span convention — span measured to the last STORED arg, which
+# after the relocation is not the source-last child.
+function merge_params!(groups::Vector{EXPR})
+    for i in length(groups)-1:-1:1
+        outer, inner = groups[i], groups[i+1]
+        insert!(outer.args, 1, inner)
+        CSTParser.setparent!(inner, outer)
+        outer.fullspan += inner.fullspan
+        lastarg = outer.args[end]
+        outer.span = outer.fullspan - (lastarg.fullspan - lastarg.span)
+    end
+    return groups[1]
 end
 
 function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vector{Kind}, cur::Cursor)::EXPR
     if k == K"toplevel"
         # Both the file root and semicolon-joined statement sequences share
         # this kind (build_cst renames the root's head to :file afterward).
-        # Bare `;` separators are dropped entirely; their width is folded
-        # into the preceding statement's fullspan, oracle-style.
+        # Bare `;` separators are dropped entirely; their width folds onto
+        # the rightmost leaf of the preceding statement (and that leaf's
+        # ancestors), oracle-style.
         args = EXPR[]
-        for (ex, ck) in zip(kids, kkinds)
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ck == K";"
-                isempty(args) || (args[end].fullspan += ex.fullspan)
+                semi_i = first(cur.kid_ranges[j])
+                widen_at_leaf!(cur, semi_i - 1, ex.fullspan) ||
+                    (isempty(args) || (args[end].fullspan += ex.fullspan))
             else
                 push!(args, ex)
             end
@@ -61,31 +73,36 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # right after the callee; `a=b` positional args become `:kw`.
         args = EXPR[]
         trivia = EXPR[]
-        params = nothing
-        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+        groups = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
             if ck == K"(" || ck == K")" || ck == K","
                 push!(trivia, ex)
             elseif ck == K"parameters"
-                fold_params_semi!(ex, j, cur)
-                params = ex
+                push!(groups, ex)
             elseif ck == K"="
                 push!(args, to_kw(ex))
             else
                 push!(args, ex)
             end
         end
-        params === nothing || insert!(args, 2, params)
+        isempty(groups) || insert!(args, 2, merge_params!(groups))
         return EXPR(:call, args, trivia, 0, 0)
     elseif k == K"parameters"
         # `; z, w=1` after a call's semicolon → (:parameters, [z, kw(w=1)], trivia=[,]).
-        # The leading `;` is dropped entirely (not even trivia); its width
-        # is folded onto the preceding leaf by the K"call" branch via
-        # fold_params_semi!, the only place that leaf is reachable.
+        # The `;` is dropped entirely (not even trivia); its width folds
+        # onto the leaf preceding it, whichever parent the group sits under,
+        # and the leading `;`'s width is trimmed from this node's own spans.
+        # An all-empty group (`f(;)`) has trivia === nothing, not EXPR[].
         args = EXPR[]
         trivia = EXPR[]
-        for (ex, ck) in zip(kids, kkinds)
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ck == K";"
-                continue
+                semi_i = first(cur.kid_ranges[j])
+                if widen_at_leaf!(cur, semi_i - 1, ex.fullspan)
+                    j == 1 && (cur.trim += ex.fullspan)
+                else
+                    push!(trivia, ex)   # nothing precedes; keep sums balanced
+                end
             elseif ck == K","
                 push!(trivia, ex)
             elseif ck == K"="
@@ -94,7 +111,8 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(args, ex)
             end
         end
-        return EXPR(:parameters, args, trivia, 0, 0)
+        return EXPR(:parameters, args,
+                    isempty(args) && isempty(trivia) ? nothing : trivia, 0, 0)
     elseif (k == K"=" || k == K"->") && length(kids) == 3
         # binary syntax: operator EXPR becomes the head. Short-form function
         # defs (`f(x) = ...`, `f(x::T) where T = ...`) and `->` bodies wrap

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -265,6 +265,14 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # stayed the initial empty Vector{EXPR} instead of `nothing`.
         args, trivia, groups = collect_arglist(kids, kkinds, K"(", K")")
         isempty(groups) || insert!(args, 2, merge_params!(groups))
+        # A dotted-operator callee (`.+(a, b)`) arrives as a K"." composite
+        # (dot+op leaves); fuse it into one OPERATOR leaf.
+        if kkinds[1] == K"." && args[1].head isa EXPR && args[1].head.val == "." &&
+           args[1].args !== nothing && length(args[1].args) == 1 &&
+           args[1].args[1].head === :OPERATOR
+            di = args[1]
+            args[1] = EXPR(:OPERATOR, di.fullspan, di.span, di.head.val * di.args[1].val)
+        end
         return EXPR(:call, args, isempty(trivia) ? nothing : trivia, 0, 0)
     elseif k == K"dotcall" && JuliaSyntax.is_infix_op_call(JuliaSyntax.head(node))
         # a .+ b (.+ c ...) → dotted infix broadcast; JuliaSyntax keeps `.`
@@ -293,9 +301,17 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         return EXPR(:call, args, isempty(trivia) ? nothing : trivia, 0, 0)
     elseif k == K"dotcall" && JuliaSyntax.is_prefix_op_call(JuliaSyntax.head(node))
         # .!x → dotted prefix broadcast; same `.`+op fusion, single operand.
+        # `.+(x)` — a parenthesized operand unwraps to a call (parens →
+        # trivia), like the non-dotted `+(x)` path; unlike `-`/`!`/`~`,
+        # dotted operators have NO keep-brackets exception.
         dotex, opex, operand = kids[1], kids[2], kids[3]
         fused = EXPR(:OPERATOR, dotex.fullspan + opex.fullspan,
                     dotex.span + opex.span, dotex.val * opex.val)
+        if kkinds[3] == K"parens"
+            args = EXPR[fused]
+            append!(args, operand.args)
+            return EXPR(:call, args, operand.trivia, 0, 0)
+        end
         return EXPR(:call, EXPR[fused, operand], nothing, 0, 0)
     elseif k == K"dotcall"
         # f.(x, y) → (:., [f, tuple(x, y)]); the parenthesized arg list packs
@@ -535,6 +551,14 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         if name.head isa EXPR && (kkinds[end] == K")" || last(args).fullspan == 0)
             ll = cur.leaves[cur.i-1]
             cur.grow_span += ll.fullspan - ll.span
+        elseif kkinds[end] != K")" && last(args).fullspan != 0
+            # A parenless macrocall's span is measured to its last REAL arg —
+            # grow when that arg's span already extends past its own raw
+            # leaves (e.g. `@eval M.@m(a)`: the nested qualified macrocall has
+            # span == fullspan), so the quirk propagates through nesting. A
+            # zero-width last arg (bare unqualified `@m`'s NOTHING) keeps the
+            # normal trailing exclusion.
+            grow_span_to_last_arg!(cur, args)
         end
         return EXPR(:macrocall, args, macro_trivia, 0, 0)
     elseif k == K"inert"

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -1,3 +1,16 @@
+# Default-value/kwarg `a=b` inside a call's arg list is `:kw`, not the
+# operator-as-head binary form: repackage the already-assembled `=` EXPR
+# (same leaf spans, just relabeled) into CSTParser's kw shape.
+to_kw(ex::EXPR) = EXPR(:kw, ex.args, EXPR[ex.head], ex.fullspan, ex.span)
+
+# Widen the trailing edge of a subtree by `excess` fullspan, recursing down
+# the rightmost arg each level (mirrors how trailing trivia normally only
+# ever bumps fullspan, never span, all the way down to the actual last leaf).
+function widen_trailing!(ex::EXPR, excess::Int)
+    ex.fullspan += excess
+    ex.args === nothing || isempty(ex.args) || widen_trailing!(ex.args[end], excess)
+end
+
 function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vector{Kind}, cur::Cursor)::EXPR
     if k == K"toplevel"
         # Both the file root and semicolon-joined statement sequences share
@@ -27,20 +40,90 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         end
         return EXPR(:call, args, isempty(trivia) ? nothing : trivia, 0, 0)
     elseif k == K"call"
-        # f(x, y) → (:call, [f, x, y], trivia=[lparen, commas..., rparen])
+        # f(x, y) → (:call, [f, x, y], trivia=[lparen, commas..., rparen]).
+        # `;`-separated keyword args nest under a `parameters` child at their
+        # source position but the oracle always relocates it to args[2],
+        # right after the callee; `a=b` positional args become `:kw`.
         args = EXPR[]
         trivia = EXPR[]
+        params = nothing
+        last_pushed = nothing
         for (ex, ck) in zip(kids, kkinds)
             if ck == K"(" || ck == K")" || ck == K","
                 push!(trivia, ex)
+                last_pushed = ex
+            elseif ck == K"parameters"
+                # The leading `;` isn't its own trivia in the oracle shape
+                # (K"parameters" branch drops it); fold its width into
+                # whatever immediately precedes it here, oracle-style.
+                excess = ex.fullspan - sum(c -> c.fullspan, ex.args; init=0) -
+                         (ex.trivia === nothing ? 0 : sum(c -> c.fullspan, ex.trivia; init=0))
+                if excess > 0 && last_pushed !== nothing
+                    widen_trailing!(last_pushed, excess)
+                    ex.fullspan -= excess
+                    ex.span -= excess
+                end
+                params = ex
+                last_pushed = ex
+            elseif ck == K"="
+                kw = to_kw(ex)
+                push!(args, kw)
+                last_pushed = kw
+            else
+                push!(args, ex)
+                last_pushed = ex
+            end
+        end
+        params === nothing || insert!(args, 2, params)
+        return EXPR(:call, args, trivia, 0, 0)
+    elseif k == K"parameters"
+        # `; z, w=1` after a call's semicolon → (:parameters, [z, kw(w=1)], trivia=[,]).
+        # The leading `;` is dropped entirely (not even trivia); its width
+        # is folded into the preceding call-level sibling by the K"call"
+        # branch, which is the only place that sibling is reachable.
+        args = EXPR[]
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K";"
+                continue
+            elseif ck == K","
+                push!(trivia, ex)
+            elseif ck == K"="
+                push!(args, to_kw(ex))
             else
                 push!(args, ex)
             end
         end
-        return EXPR(:call, args, trivia, 0, 0)
-    elseif k == K"=" && length(kids) == 3
-        # binary syntax: operator EXPR becomes the head
+        return EXPR(:parameters, args, trivia, 0, 0)
+    elseif (k == K"=" || k == K"->") && length(kids) == 3
+        # binary syntax: operator EXPR becomes the head. Short-form function
+        # defs (`f(x) = ...`, `f(x::T) where T = ...`) and `->` bodies wrap
+        # their RHS in an implicit block; plain assignment does not.
+        lhs, op, rhs = kids
+        needs_block = k == K"->" || kkinds[1] == K"call" || kkinds[1] == K"where"
+        body = needs_block ? EXPR(:block, EXPR[rhs], nothing, rhs.fullspan, rhs.span) : rhs
+        return EXPR(op, EXPR[lhs, body], nothing, 0, 0)
+    elseif (k == K"::" || k == K"<:") && length(kids) == 3
+        # binary syntax: operator EXPR becomes the head (type declarations,
+        # supertype clauses)
         return EXPR(kids[2], EXPR[kids[1], kids[3]], nothing, 0, 0)
+    elseif k == K"where"
+        # f(x) where T → (:where, [sig, T], trivia=[where]); braces-wrapped
+        # typevar lists (`where {T <: S}`) are flattened into where's own
+        # args/trivia rather than kept as a nested :braces node.
+        args = EXPR[]
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"where"
+                push!(trivia, ex)
+            elseif ck == K"braces"
+                append!(args, ex.args)
+                append!(trivia, ex.trivia)
+            else
+                push!(args, ex)
+            end
+        end
+        return EXPR(:where, args, trivia, 0, 0)
     elseif k == K"block"
         args = EXPR[]
         trivia = EXPR[]
@@ -51,6 +134,85 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
     elseif k == K"parens"
         trivia = EXPR[kids[1], kids[end]]
         return EXPR(:brackets, kids[2:end-1], trivia, 0, 0)
+    elseif k == K"function"
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == K"function" || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:function, args, trivia, 0, 0)
+    elseif k == K"struct"
+        # struct A ... end / mutable struct A ... end share this green kind;
+        # CSTParser marks mutability with a synthetic zero-width TRUE/FALSE
+        # leaf as args[1] (no corresponding source token).
+        trivia = EXPR[]
+        is_mutable = false
+        sig = nothing
+        body = nothing
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"mutable"
+                is_mutable = true
+                push!(trivia, ex)
+            elseif ck == K"struct" || ck == K"end"
+                push!(trivia, ex)
+            elseif ck == K"block"
+                body = ex
+            else
+                sig = ex
+            end
+        end
+        marker = EXPR(is_mutable ? :TRUE : :FALSE, 0, 0, nothing)
+        return EXPR(:struct, EXPR[marker, sig, body], trivia, 0, 0)
+    elseif k == K"abstract"
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == K"abstract" || ck == K"type" || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:abstract, args, trivia, 0, 0)
+    elseif k == K"primitive"
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == K"primitive" || ck == K"type" || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:primitive, args, trivia, 0, 0)
+    elseif k == K"macro"
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            (ck == K"macro" || ck == K"end") ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:macro, args, trivia, 0, 0)
+    elseif k == K"module"
+        # module A ... end / baremodule A ... end share this green kind;
+        # same synthetic-marker trick as struct's mutability flag, here
+        # meaning "not bare" (baremodule → FALSE).
+        trivia = EXPR[]
+        is_bare = false
+        name = nothing
+        body = nothing
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"baremodule"
+                is_bare = true
+                push!(trivia, ex)
+            elseif ck == K"module" || ck == K"end"
+                push!(trivia, ex)
+            elseif ck == K"block"
+                body = ex
+            else
+                name = ex
+            end
+        end
+        marker = EXPR(is_bare ? :FALSE : :TRUE, 0, 0, nothing)
+        return EXPR(:module, EXPR[marker, name, body], trivia, 0, 0)
+    elseif k == K"const" || k == K"global" || k == K"local"
+        trivia = EXPR[]
+        args = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            ck == k ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(Symbol(lowercase(string(k))), args, trivia, 0, 0)
     end
     return generic_form(k, kids, kkinds)
 end

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -19,11 +19,27 @@ function widen_at_leaf!(cur::Cursor, i::Int, width::Int)
     return true
 end
 
+# Fold a dropped `;`'s width onto the last REAL leaf before it. Consecutive
+# separators (`a;; b`) must skip already-dropped `;` leaves — their EXPRs
+# live in neither args nor trivia, so widening one loses the width.
+function fold_semi!(cur::Cursor, semi_i::Int, width::Int)
+    i = semi_i - 1
+    while i >= 1 && cur.leaves[i].kind == K";"
+        i -= 1
+    end
+    return widen_at_leaf!(cur, i, width)
+end
+
 # Sibling `;` groups nest recursively: for `f(a; b; c)` the oracle stores
 # the c-group inside the b-group at args[1]. Spans follow CSTParser's
 # update_span convention — span measured to the last STORED arg, which
-# after the relocation is not the source-last child.
+# after the relocation is not the source-last child. Zero-width empty
+# groups (a bare extra `;`, e.g. `f(a;;b)`) collapse away entirely; only
+# an all-empty run (`f(;;)`) keeps a single empty group.
 function merge_params!(groups::Vector{EXPR})
+    real = filter(g -> !isempty(g.args) || g.fullspan != 0, groups)
+    isempty(real) && return groups[1]
+    groups = real
     for i in length(groups)-1:-1:1
         outer, inner = groups[i], groups[i+1]
         insert!(outer.args, 1, inner)
@@ -67,7 +83,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ck == K";"
                 semi_i = first(cur.kid_ranges[j])
-                widen_at_leaf!(cur, semi_i - 1, ex.fullspan) ||
+                fold_semi!(cur, semi_i, ex.fullspan) ||
                     (isempty(args) || (args[end].fullspan += ex.fullspan))
             else
                 push!(args, ex)
@@ -193,7 +209,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
             if ck == K";"
                 semi_i = first(cur.kid_ranges[j])
-                if widen_at_leaf!(cur, semi_i - 1, ex.fullspan)
+                if fold_semi!(cur, semi_i, ex.fullspan)
                     j == 1 && (cur.trim += ex.fullspan)
                 else
                     push!(trivia, ex)   # nothing precedes; keep sums balanced
@@ -249,7 +265,7 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
                 push!(trivia, ex)
             elseif ck == K";"
                 semi_i = first(cur.kid_ranges[j])
-                if widen_at_leaf!(cur, semi_i - 1, ex.fullspan)
+                if fold_semi!(cur, semi_i, ex.fullspan)
                     # A leading `;` (e.g. a do-block's params/body separator)
                     # widens a leaf OUTSIDE this block; exclude that width
                     # from the block's own leaf-range-computed span too.

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -35,6 +35,27 @@ function merge_params!(groups::Vector{EXPR})
     return groups[1]
 end
 
+# Shared by call/dotcall/curly/macrocall arg lists: split into positional
+# args, bracket/comma trivia, and `;`-groups (still unmerged/unrelocated —
+# each caller decides where the merged group lands); `a=b` becomes `:kw`.
+function collect_arglist(kids::Vector{EXPR}, kkinds::Vector{Kind}, open::Kind, close::Kind)
+    args = EXPR[]
+    trivia = EXPR[]
+    groups = EXPR[]
+    for (ex, ck) in zip(kids, kkinds)
+        if ck == open || ck == close || ck == K","
+            push!(trivia, ex)
+        elseif ck == K"parameters"
+            push!(groups, ex)
+        elseif ck == K"="
+            push!(args, to_kw(ex))
+        else
+            push!(args, ex)
+        end
+    end
+    return args, trivia, groups
+end
+
 function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vector{Kind}, cur::Cursor)::EXPR
     if k == K"toplevel"
         # Both the file root and semicolon-joined statement sequences share
@@ -70,23 +91,97 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # f(x, y) → (:call, [f, x, y], trivia=[lparen, commas..., rparen]).
         # `;`-separated keyword args nest under a `parameters` child at their
         # source position but the oracle always relocates it to args[2],
-        # right after the callee; `a=b` positional args become `:kw`.
-        args = EXPR[]
-        trivia = EXPR[]
-        groups = EXPR[]
-        for (ex, ck) in zip(kids, kkinds)
-            if ck == K"(" || ck == K")" || ck == K","
-                push!(trivia, ex)
-            elseif ck == K"parameters"
-                push!(groups, ex)
-            elseif ck == K"="
-                push!(args, to_kw(ex))
-            else
-                push!(args, ex)
-            end
-        end
+        # right after the callee (kids[1], which lands in args[1] here since
+        # it matches none of collect_arglist's special cases); `a=b`
+        # positional args become `:kw`.
+        args, trivia, groups = collect_arglist(kids, kkinds, K"(", K")")
         isempty(groups) || insert!(args, 2, merge_params!(groups))
         return EXPR(:call, args, trivia, 0, 0)
+    elseif k == K"dotcall"
+        # f.(x, y) → (:., [f, tuple(x, y)]); the parenthesized arg list packs
+        # into a :tuple the same way a call's does (parameters relocate to
+        # its front — there's no callee slot to land after).
+        callee, dot = kids[1], kids[2]
+        sub = kids[3:end]
+        args, trivia, groups = collect_arglist(sub, kkinds[3:end], K"(", K")")
+        isempty(groups) || insert!(args, 1, merge_params!(groups))
+        # Synthetic :tuple node — not a return value of assemble_form, so its
+        # span isn't computed automatically; sum the pre-partition kids
+        # (widths only move between them via merge_params!/to_kw, never
+        # change) and exclude the trailing edge (always the RPAREN).
+        fullspan = sum(x -> x.fullspan, sub; init=0)
+        span = fullspan - (sub[end].fullspan - sub[end].span)
+        tup = EXPR(:tuple, args, trivia, fullspan, span)
+        return EXPR(dot, EXPR[callee, tup], nothing, 0, 0)
+    elseif k == K"." && length(kids) == 3
+        # a.b / a.b.c → (:., [a, quotenode(b)]); dot is operator-headed like
+        # ::/<:/->. The field-name side is always a K"quote" child (see the
+        # branch below), already packaged as :quotenode by the time we see it.
+        return EXPR(kids[2], EXPR[kids[1], kids[3]], nothing, 0, 0)
+    elseif k == K"quote" && length(kids) <= 2
+        # Field-name wrapper under getfield's `.`: bare `b`, or `:b` with an
+        # explicit-quote colon kept as trivia.
+        args = EXPR[]
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            ck == K":" ? push!(trivia, ex) : push!(args, ex)
+        end
+        return EXPR(:quotenode, args, isempty(trivia) ? nothing : trivia, 0, 0)
+    elseif k == K"curly"
+        # A{T; S} → (:curly, [A, parameters, T]) — parameters relocates to
+        # args[2] exactly like call's.
+        args, trivia, groups = collect_arglist(kids, kkinds, K"{", K"}")
+        isempty(groups) || insert!(args, 2, merge_params!(groups))
+        return EXPR(:curly, args, trivia, 0, 0)
+    elseif k == K"macrocall"
+        # `@m x` fuses the `@` leaf and macro name into ONE IDENTIFIER
+        # ("@m") — CSTParser never sees them as separate tokens. String/cmd
+        # macro names (`m"str"`) are already a single mangled leaf (handled
+        # in terminal_expr), nothing to fuse. A synthetic zero-width NOTHING
+        # marker always follows the name; `;`-parameters relocate to right
+        # after it (args[3]).
+        if kkinds[1] == K"@"
+            atex, nameex = kids[1], kids[2]
+            name = EXPR(:IDENTIFIER, atex.fullspan + nameex.fullspan,
+                        atex.span + nameex.span, "@" * nameex.val)
+            rest, restk = kids[3:end], kkinds[3:end]
+        else
+            name = kids[1]
+            rest, restk = kids[2:end], kkinds[2:end]
+        end
+        args, trivia, groups = collect_arglist(rest, restk, K"(", K")")
+        args = EXPR[name, EXPR(:NOTHING, 0, 0, nothing), args...]
+        isempty(groups) || insert!(args, 3, merge_params!(groups))
+        return EXPR(:macrocall, args, isempty(trivia) ? nothing : trivia, 0, 0)
+    elseif k == K"do"
+        # `f(x) do y ... end` desugars to a call plus a synthetic zero-width
+        # `->` operator wrapping the (params-tuple, body-block) pair — no
+        # literal `->` token exists in the source.
+        call_ex = tuple_ex = block_ex = nothing
+        trivia = EXPR[]
+        for (ex, ck) in zip(kids, kkinds)
+            if ck == K"do" || ck == K"end"
+                push!(trivia, ex)
+            elseif ck == K"tuple"
+                tuple_ex = ex
+            elseif ck == K"block"
+                block_ex = ex
+            else
+                call_ex = ex
+            end
+        end
+        fullspan = tuple_ex.fullspan + block_ex.fullspan
+        span = fullspan - (block_ex.fullspan - block_ex.span)
+        op = EXPR(:OPERATOR, 0, 0, "->")
+        body = EXPR(op, EXPR[tuple_ex, block_ex], EXPR[], fullspan, span)
+        return EXPR(:do, EXPR[call_ex, body], trivia, 0, 0)
+    elseif k == K"..." && length(kids) == 2
+        # x... (splat) → (:..., [x]) — postfix unary, operator is the 2nd kid.
+        return EXPR(kids[2], EXPR[kids[1]], nothing, 0, 0)
+    elseif k == K"::" && length(kids) == 2
+        # ::T (bare type assertion, e.g. an unnamed call parameter) →
+        # (:::, [T]) — prefix unary, operator is the 1st kid.
+        return EXPR(kids[1], EXPR[kids[2]], nothing, 0, 0)
     elseif k == K"parameters"
         # `; z, w=1` after a call's semicolon → (:parameters, [z, kw(w=1)], trivia=[,]).
         # The `;` is dropped entirely (not even trivia); its width folds
@@ -145,10 +240,32 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         end
         return EXPR(:where, args, trivia, 0, 0)
     elseif k == K"block"
+        # `;`-separated statements drop the `;` entirely, same as toplevel's:
+        # its width folds onto the rightmost leaf of the preceding statement.
         args = EXPR[]
         trivia = EXPR[]
-        for (ex, ck) in zip(kids, kkinds)
-            (ck == K"begin" || ck == K"end" || ck == K";") ? push!(trivia, ex) : push!(args, ex)
+        for (j, (ex, ck)) in enumerate(zip(kids, kkinds))
+            if ck == K"begin" || ck == K"end"
+                push!(trivia, ex)
+            elseif ck == K";"
+                semi_i = first(cur.kid_ranges[j])
+                if widen_at_leaf!(cur, semi_i - 1, ex.fullspan)
+                    # A leading `;` (e.g. a do-block's params/body separator)
+                    # widens a leaf OUTSIDE this block; exclude that width
+                    # from the block's own leaf-range-computed span too.
+                    j == 1 && (cur.trim += ex.fullspan)
+                    # A trailing `;` (e.g. `do y; y; end`'s body terminator)
+                    # widens this block's OWN last leaf, so it's still the
+                    # node's leaf-range-computed last leaf — its own (never
+                    # folded-away) span still inflates the auto span calc;
+                    # exclude just that span-only, fullspan stays correct.
+                    j == length(kids) && (cur.trim_span += ex.span)
+                else
+                    isempty(args) || (args[end].fullspan += ex.fullspan)
+                end
+            else
+                push!(args, ex)
+            end
         end
         return EXPR(:block, args, isempty(trivia) ? nothing : trivia, 0, 0)
     elseif k == K"parens"

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -134,7 +134,9 @@ function collect_arglist(kids::Vector{EXPR}, kkinds::Vector{Kind}, open::Kind, c
             push!(trivia, ex)
         elseif ck == K"parameters"
             push!(groups, ex)
-        elseif ck == K"=" && kw
+        elseif ck == K"=" && kw && ex.head isa EXPR && ex.head.val == "="
+            # only a plain `=` kwarg converts to :kw; a dotted `.=` broadcast
+            # assignment (same green kind K"=") stays operator-headed.
             push!(args, to_kw(ex))
         else
             push!(args, ex)

--- a/src/cst_conversion/forms.jl
+++ b/src/cst_conversion/forms.jl
@@ -370,10 +370,12 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # Inside parens, only a dotted assignment (`:(.=)`) fuses to an
         # OPERATOR atom; a dotted broadcast operator (`:(.+)`) stays a
         # composite (a broadcast call), so it remains a :quote.
+        is_assign(v) = endswith(v, "=") &&
+            (length(v) == 1 || !(v[prevind(v, lastindex(v))] in ('=', '!', '<', '>')))
         if args[1].head === :brackets && args[1].args !== nothing &&
            length(args[1].args) == 1 && args[1].args[1].head isa EXPR &&
            args[1].args[1].args !== nothing && !isempty(args[1].args[1].args) &&
-           args[1].args[1].args[1].head === :OPERATOR && args[1].args[1].args[1].val == "="
+           args[1].args[1].args[1].head === :OPERATOR && is_assign(args[1].args[1].args[1].val)
             args[1].args[1] = fuse_dotop(args[1].args[1])
         end
         inner = args[1]
@@ -729,8 +731,12 @@ function assemble_form(k::Kind, node::GreenNode, kids::Vector{EXPR}, kkinds::Vec
         # (`f()::T = ...`) — but NOT a plain typed assignment (`x::T = 5`).
         typed_def = kkinds[1] == K"::" && lhs.args !== nothing &&
                     !isempty(lhs.args) && lhs.args[1].head === :call
+        # `(f(x)) = body` / `(f(x) where T) = body` — a parenthesized signature
+        # is still a function def (block-wrapped body); `(x) = y` is not.
+        parens_def = kkinds[1] == K"parens" && lhs.args !== nothing &&
+                     !isempty(lhs.args) && lhs.args[1].head in (:call, :where)
         needs_block = (k == K"->" || kkinds[1] == K"call" || kkinds[1] == K"where" ||
-                       typed_def) && kkinds[3] != K"block"
+                       typed_def || parens_def) && kkinds[3] != K"block"
         body = needs_block ? EXPR(:block, EXPR[rhs], nothing, rhs.fullspan, rhs.span) : rhs
         # Span is measured to the last arg; grow when that arg's span already
         # reaches its fullspan (bare `return`, qualified-macrocall RHS).

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -3,16 +3,19 @@
 # triple JuliaSyntax emits for these is merged before terminal_expr ever sees
 # the content leaf in isolation (see merge_quoted below).
 const TERMINAL_HEADS = Dict{Kind,Symbol}(
-    K"Identifier" => :IDENTIFIER,
-    K"Integer"    => :INTEGER,
-    K"Float"      => :FLOAT,
-    K"HexInt"     => :HEXINT,
-    K"BinInt"     => :BININT,
-    K"OctInt"     => :OCTINT,
-    K"Char"       => :CHAR,
-    K"String"     => :STRING,
-    K"true"       => :TRUE,
-    K"false"      => :FALSE,
+    K"Identifier"      => :IDENTIFIER,
+    K"MacroName"       => :IDENTIFIER,
+    K"StringMacroName" => :IDENTIFIER,
+    K"CmdMacroName"    => :IDENTIFIER,
+    K"Integer"         => :INTEGER,
+    K"Float"           => :FLOAT,
+    K"HexInt"          => :HEXINT,
+    K"BinInt"          => :BININT,
+    K"OctInt"          => :OCTINT,
+    K"Char"            => :CHAR,
+    K"String"          => :STRING,
+    K"true"            => :TRUE,
+    K"false"           => :FALSE,
 )
 
 token_text(leaf::Leaf, source::String) = source[leaf.pos:prevind(source, leaf.pos + leaf.span)]
@@ -28,6 +31,11 @@ function terminal_expr(leaf::Leaf, source::String)
         return EXPR(Symbol(uppercase(string(k))), leaf.fullspan, leaf.span, token_text(leaf, source))
     elseif haskey(TERMINAL_HEADS, k)
         return EXPR(TERMINAL_HEADS[k], leaf.fullspan, leaf.span, token_text(leaf, source))
+    elseif JuliaSyntax.is_error(k)
+        # Zero-width diagnostic marker for a missing/unexpected token in
+        # broken code; mirrors CSTParser's errortoken so recovery keeps spans
+        # consistent instead of crashing the whole corpus file.
+        return EXPR(:errortoken, leaf.fullspan, leaf.span, token_text(leaf, source))
     else
         return EXPR(punctuation_head(k), leaf.fullspan, leaf.span, token_text(leaf, source))
     end

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -28,6 +28,11 @@ function terminal_expr(leaf::Leaf, source::String)
         # context (`a[end]`) — real block-closing `end` is its own keyword
         # kind. CSTParser treats both spellings as the same END literal.
         return EXPR(:END, leaf.fullspan, leaf.span, "end")
+    elseif k == K"core_@cmd"
+        # Zero-width marker for an unprefixed backtick literal (implicit
+        # Core.@cmd) — CSTParser wraps it in a dedicated :globalrefcmd head
+        # instead of an IDENTIFIER macro name (see the K"macrocall" branch).
+        return EXPR(:globalrefcmd, leaf.fullspan, leaf.span, nothing)
     elseif k == K"StringMacroName" || k == K"CmdMacroName"
         # `m"str"`/`c\`cmd\`` desugar to calling `@m_str`/`@c_cmd`; the
         # green leaf only carries the bare name, oracle wants the mangled one.
@@ -90,4 +95,304 @@ function merge_quoted(leaves::Vector{Leaf}, i::Int, source::String)
         val = source[open.pos:prevind(source, close.pos + close.span)]
         return EXPR(:CHAR, fullspan, span, val), j + 1
     end
+end
+
+# --- interpolated/triple-quoted strings and cmd literals --------------------
+#
+# JuliaSyntax's green tree already decomposes an interpolated K"string" node
+# into real children (content leaves, a `$` leaf, the interpolated
+# subexpression), so merge_quoted's simple single-content-leaf assumption
+# breaks down for: (a) real interpolation, (b) escaped-newline continuations
+# that split one logical chunk across multiple String leaves joined by a
+# Whitespace trivia leaf (merge_quoted only kept the LAST such leaf), and (c)
+# triple-quote dedent. All three are handled uniformly here by re-slicing raw
+# source between quote/interpolation boundaries instead of trusting any
+# single leaf's own .val — CSTParser's own chunk spans fall out of that
+# re-slice plus its own escape/dedent post-processing (ported below since
+# it's a local closure in CSTParser, not reusable directly).
+#
+# K"cmdstring" is a genuine parser divergence at the LEXER level: JuliaSyntax
+# never splits cmd-literal interpolation into green children at all (real
+# Julia defers `$`-splitting in backtick literals to the @cmd macro at
+# expansion time) — a plain CmdString leaf's raw text can contain a literal
+# unescaped `$` with no corresponding child node. CSTParser's own tokenizer
+# eagerly splits it instead, so matching its output requires a manual
+# re-scan of the leaf's raw text (bare-identifier interpolation only;
+# `$(...)` inside a cmd literal is not attempted).
+
+# Longest-common-prefix dedent, ported from CSTParser's parse_string_or_cmd
+# (the `adjust_lcp` closure) — operates on plain chunk text instead of EXPRs
+# since our chunks come from re-sliced source, threading the shared `lcp`
+# state via a Ref instead of a closure variable.
+function adjust_lcp!(lcp::Base.RefValue{Union{Nothing,String}}, str::String, islast::Bool)
+    (isempty(str) || (lcp[] !== nothing && isempty(lcp[]))) && return
+    if islast && str[end] == '\n'
+        lcp[] = ""
+        return
+    end
+    idxstart, idxend = 2, 1
+    while nextind(str, idxend) - 1 < sizeof(str) && (lcp[] === nothing || !isempty(lcp[]))
+        idxend = CSTParser.skip_to_nl(str, idxend)
+        idxstart = nextind(str, idxend)
+        while nextind(str, idxend) - 1 < sizeof(str)
+            c = str[nextind(str, idxend)]
+            if c == ' ' || c == '\t'
+                idxend += 1
+            elseif c == '\n'
+                idxend += 1
+                idxstart = idxend + 1
+            else
+                prefix = str[idxstart:idxend]
+                lcp[] = lcp[] === nothing ? prefix : CSTParser.longest_common_prefix(lcp[], prefix)
+                break
+            end
+        end
+    end
+    if idxstart != nextind(str, idxend)
+        prefix = str[idxstart:idxend]
+        lcp[] = lcp[] === nothing ? prefix : CSTParser.longest_common_prefix(lcp[], prefix)
+    end
+end
+
+rm_escaped_newlines_str(s::String) = (e = EXPR(:STRING, 0, 0, s); CSTParser._rm_escaped_newlines(e); e.val)
+unescape_str(s::String) = (e = EXPR(:STRING, 0, 0, s); CSTParser._unescape_string_expr(e); e.val)
+
+# Plain byte-range slice, unlike `source[a:b]` which additionally demands `b`
+# itself start a valid character (Julia's String indexing is codepoint-
+# aware) — our chunk boundaries are byte positions immediately before the
+# NEXT real token, which is only guaranteed to be a valid character-END
+# (not necessarily -START) when the preceding content ends in a multi-byte
+# char (e.g. a docstring containing non-ASCII text).
+byteslice(s::String, a::Int, b::Int) = a <= b ? String(@view codeunits(s)[a:b]) : ""
+
+DOLLAR_TRIVIA() = EXPR[EXPR(:OPERATOR, 1, 1, "\$")]
+
+# Manual re-scan of a cmdstring leaf's raw text for interpolation (`$foo` or
+# `$(...)`) — JuliaSyntax gives no green children to walk here (see
+# module-level note above). `\`-escapes are skipped over without inspection,
+# matching CSTParser's own scan. `s` is the absolute source position of
+# `text[1]`. `$(...)` bracket matching is naive (paren-depth only, no
+# awareness of nested strings/comments containing parens) but sufficient for
+# real command-construction code.
+function split_cmd_dollar(text::String, s::Int)
+    out = Any[]
+    len = ncodeunits(text)
+    i = 1
+    lastpos = 1
+    while i <= len
+        c = text[i]
+        if c == '\\'
+            i = i < len ? nextind(text, i, 2) : nextind(text, i)
+        elseif c == '$' && nextind(text, i) <= len && text[nextind(text, i)] == '('
+            depth = 1
+            j = nextind(text, i, 2)
+            open_j = j
+            while j <= len && depth > 0
+                text[j] == '(' && (depth += 1)
+                text[j] == ')' && (depth -= 1)
+                depth > 0 && (j = nextind(text, j))
+            end
+            # Only commit the pending literal run once a real split point is
+            # confirmed — an unterminated `$(` (depth never hits 0) leaves
+            # the whole rest as literal text instead.
+            inner = depth == 0 ? text[open_j:prevind(text, j)] : ""
+            iex = depth == 0 ? build_cst(inner) : nothing
+            if depth == 0 && !isempty(iex.args)
+                push!(out, (:lit, s + lastpos - 1, s + i - 2))
+                leading, real = if iex.args[1].head === :NOTHING && length(iex.args) > 1
+                    iex.args[1].fullspan, iex.args[2]
+                else
+                    0, iex.args[1]
+                end
+                trailing = real.fullspan - real.span
+                real.fullspan -= trailing
+                lparen = EXPR(:LPAREN, 1 + leading, 1, nothing)
+                rparen = EXPR(:RPAREN, 1 + trailing, 1, nothing)
+                trivia = EXPR[EXPR(:OPERATOR, 1, 1, "\$"), lparen, rparen]
+                push!(out, (:interp, real, trivia))
+                lastpos = nextind(text, j)
+                i = lastpos
+            else
+                i = nextind(text, i)
+            end
+        elseif c == '$'
+            j = nextind(text, i)
+            idstart = j
+            if j <= len && Base.is_id_start_char(text[j])
+                j = nextind(text, j)
+                while j <= len && Base.is_id_char(text[j])
+                    j = nextind(text, j)
+                end
+            end
+            if j > idstart
+                # Only commit the pending literal run once a real split point
+                # is confirmed — pushing it eagerly (before knowing whether
+                # `$` is followed by an identifier) would re-push/duplicate
+                # the same run on every subsequent `$(...)` that turns out
+                # not to be a bare-identifier interpolation.
+                push!(out, (:lit, s + lastpos - 1, s + i - 2))
+                idtext = text[idstart:prevind(text, j)]
+                clen = sizeof(idtext)
+                push!(out, (:interp, EXPR(:IDENTIFIER, clen, clen, idtext), DOLLAR_TRIVIA()))
+                lastpos = j
+                i = j
+            else
+                i = nextind(text, i)
+            end
+        else
+            i = nextind(text, i)
+        end
+    end
+    push!(out, (:lit, s + lastpos - 1, s + len - 1))
+    return out
+end
+
+# Walks a K"string"/K"cmdstring" green node's children, consuming the
+# whole run via `cur` (quote/content leaves manually, interpolation
+# subexpressions via ordinary recursive `assemble`), producing a flat list
+# of (:lit, start_pos, end_pos) / (:interp, EXPR) pieces in source order.
+# `start_pos > end_pos` marks an empty literal run at that position (still
+# needed downstream to fold quote width onto an edge piece with no content).
+function collect_quoted_pieces(node::GreenNode, cur::Cursor, iscmd::Bool)
+    kids = [c for c in children(node) if !is_ws_trivia(kind(c))]
+    open_leaf = cur.leaves[cur.i]
+    cur.i += 1
+    pieces = Any[]
+    have_run = false
+    run_start = 0
+    close_leaf = open_leaf
+    n = length(kids)
+    j = 2
+    while j <= n
+        c = kids[j]
+        k = kind(c)
+        if k == K"String" || k == K"CmdString"
+            leaf = cur.leaves[cur.i]
+            have_run || (run_start = leaf.pos; have_run = true)
+            cur.i += 1
+            j += 1
+        elseif k == K"$"
+            leaf = cur.leaves[cur.i]
+            chunk_start = have_run ? run_start : leaf.pos
+            push!(pieces, (:lit, chunk_start, leaf.pos - 1))
+            have_run = false
+            dollar_ex = assemble(c, cur)
+            j += 1
+            sub = kids[j]
+            trivia_here = EXPR[dollar_ex]
+            if kind(sub) == K"parens"
+                pex = assemble(sub, cur)   # :brackets(args=[inner], trivia=[lparen,rparen])
+                # CSTParser hand-builds these two (parse_string_or_cmd's own
+                # `$(...)` path), unlike an ordinary parens grouping which
+                # goes through the general tokenizer path — val is nothing
+                # here, not the real "("/")" text.
+                for t in pex.trivia
+                    t.val = nothing
+                end
+                append!(trivia_here, pex.trivia)
+                push!(pieces, (:interp, pex.args[1], trivia_here))
+            else
+                push!(pieces, (:interp, assemble(sub, cur), trivia_here))
+            end
+            j += 1
+        else
+            close_leaf = cur.leaves[cur.i]
+            chunk_start = have_run ? run_start : close_leaf.pos
+            push!(pieces, (:lit, chunk_start, close_leaf.pos - 1))
+            cur.i += 1
+            j += 1
+        end
+    end
+    if iscmd
+        @assert length(pieces) == 1 && pieces[1][1] == :lit
+        _, s, e = pieces[1]
+        pieces = s <= e ? split_cmd_dollar(byteslice(cur.src, s, e), s) : pieces
+    end
+    return pieces, open_leaf, close_leaf
+end
+
+# Builds the final EXPR for a K"string"/K"cmdstring" node from its pieces —
+# folds quote width onto the edge pieces (same convention as merge_quoted's
+# single-chunk case), applies triple-quote dedent + leading-newline-drop
+# (istrip-gated) and escape unescaping (skipped for cmd literals, which
+# CSTParser leaves raw beyond the manual `$`-scan above), then collapses to
+# a bare STRING/TRIPLESTRING when there was no real interpolation.
+function assemble_quoted(node::GreenNode, cur::Cursor, iscmd::Bool)
+    source = cur.src
+    pieces, open_leaf, close_leaf = collect_quoted_pieces(node, cur, iscmd)
+    istrip = open_leaf.kind == K"\"\"\"" || open_leaf.kind == K"```"
+    n = length(pieces)
+
+    lit_idx = [i for i in 1:n if pieces[i][1] == :lit]
+    raw = Dict{Int,String}()
+    for i in lit_idx
+        _, s, e = pieces[i]
+        raw[i] = byteslice(source, s, e)
+    end
+    last_lit_raw = raw[lit_idx[end]]
+
+    texts = iscmd ? copy(raw) : Dict(i => rm_escaped_newlines_str(t) for (i, t) in raw)
+    if istrip
+        lcp = Base.RefValue{Union{Nothing,String}}(nothing)
+        for i in lit_idx
+            adjust_lcp!(lcp, texts[i], i == lit_idx[end])
+        end
+        if lcp[] !== nothing && !isempty(lcp[])
+            for i in lit_idx
+                texts[i] = replace(texts[i], "\n" * lcp[] => "\n")
+            end
+        end
+        first_i = lit_idx[1]
+        if !startswith(last_lit_raw, "\\n") && startswith(texts[first_i], "\n")
+            texts[first_i] = texts[first_i][2:end]
+        end
+    end
+    if !iscmd
+        for i in lit_idx
+            texts[i] = unescape_str(texts[i])
+        end
+    end
+
+    exprs = Vector{EXPR}(undef, n)
+    for i in 1:n
+        p = pieces[i]
+        if p[1] == :interp
+            exprs[i] = p[2]
+        else
+            _, s, e = p
+            if i == 1 && i == n
+                fullspan = close_leaf.pos + close_leaf.fullspan - open_leaf.pos
+                span = close_leaf.pos + close_leaf.span - open_leaf.pos
+            elseif i == 1
+                endpos = s <= e ? e : s - 1
+                fullspan = span = endpos - open_leaf.pos + 1
+            elseif i == n
+                fullspan = close_leaf.pos + close_leaf.fullspan - s
+                span = close_leaf.pos + close_leaf.span - s
+            else
+                fullspan = span = e - s + 1
+            end
+            head = (n == 1 && istrip) ? :TRIPLESTRING : :STRING
+            exprs[i] = EXPR(head, fullspan, span, texts[i])
+        end
+    end
+
+    n == 1 && return exprs[1]
+
+    args = EXPR[]
+    trivia = EXPR[]
+    for i in 1:n
+        if pieces[i][1] == :interp
+            append!(trivia, pieces[i][3])
+            push!(args, exprs[i])
+        elseif !isempty(exprs[i].val)
+            push!(args, exprs[i])
+        elseif i == 1 || i == n
+            push!(trivia, exprs[i])   # empty edge chunk: still carries the folded quote width
+        end
+        # empty non-edge chunk: dropped entirely (CSTParser never emits it)
+    end
+    fullspan = close_leaf.pos + close_leaf.fullspan - open_leaf.pos
+    span = close_leaf.pos + close_leaf.span - open_leaf.pos
+    return EXPR(:string, args, trivia, fullspan, span)
 end

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -165,6 +165,27 @@ unescape_str(s::String) = (e = EXPR(:STRING, 0, 0, s); CSTParser._unescape_strin
 # char (e.g. a docstring containing non-ASCII text).
 byteslice(s::String, a::Int, b::Int) = a <= b ? String(@view codeunits(s)[a:b]) : ""
 
+# var"..." nonstandard identifier: JuliaSyntax splits it into var/quote/
+# content/quote leaves; CSTParser sees a NONSTDIDENTIFIER wrapping
+# IDENTIFIER("var") and a STRING of the (raw) quoted content.
+function merge_var(leaves::Vector{Leaf}, i::Int, source::String)
+    var_leaf = leaves[i]
+    var_id = EXPR(:IDENTIFIER, var_leaf.fullspan, var_leaf.span, "var")
+    open = leaves[i+1]
+    j = i + 2
+    while leaves[j].kind != open.kind
+        j += 1
+    end
+    close = leaves[j]
+    str = EXPR(:STRING, close.pos + close.fullspan - open.pos,
+               close.pos + close.span - open.pos,
+               byteslice(source, open.pos + open.span, close.pos - 1))
+    ex = EXPR(:NONSTDIDENTIFIER, EXPR[var_id, str], nothing,
+              close.pos + close.fullspan - var_leaf.pos,
+              close.pos + close.span - var_leaf.pos)
+    return ex, j + 1
+end
+
 DOLLAR_TRIVIA() = EXPR[EXPR(:OPERATOR, 1, 1, "\$")]
 
 # A BARE string literal as the whole `$(...)` subexpression keeps its

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -167,6 +167,18 @@ byteslice(s::String, a::Int, b::Int) = a <= b ? String(@view codeunits(s)[a:b]) 
 
 DOLLAR_TRIVIA() = EXPR[EXPR(:OPERATOR, 1, 1, "\$")]
 
+# A BARE string literal as the whole `$(...)` subexpression keeps its
+# :string wrapper in CSTParser (parse_string_or_cmd explicitly re-wraps,
+# since the usual single-chunk unwrap "is not supposed to happen in
+# interpolations") — our single-chunk collapse must be undone here. Wrapper
+# is oracle-pinned: trivia is EXPR[] (empty, not nothing), spans copied.
+function rewrap_string_interp(ex::EXPR)
+    if ex.head === :STRING || ex.head === :TRIPLESTRING
+        return EXPR(:string, EXPR[ex], EXPR[], ex.fullspan, ex.span)
+    end
+    return ex
+end
+
 # Manual re-scan of a cmdstring leaf's raw text for interpolation (`$foo` or
 # `$(...)`) — JuliaSyntax gives no green children to walk here (see
 # module-level note above). `\`-escapes are skipped over without inspection,
@@ -209,7 +221,7 @@ function split_cmd_dollar(text::String, s::Int)
                 lparen = EXPR(:LPAREN, 1 + leading, 1, nothing)
                 rparen = EXPR(:RPAREN, 1 + trailing, 1, nothing)
                 trivia = EXPR[EXPR(:OPERATOR, 1, 1, "\$"), lparen, rparen]
-                push!(out, (:interp, real, trivia))
+                push!(out, (:interp, rewrap_string_interp(real), trivia))
                 lastpos = nextind(text, j)
                 i = lastpos
             else
@@ -290,7 +302,7 @@ function collect_quoted_pieces(node::GreenNode, cur::Cursor, iscmd::Bool)
                     t.val = nothing
                 end
                 append!(trivia_here, pex.trivia)
-                push!(pieces, (:interp, pex.args[1], trivia_here))
+                push!(pieces, (:interp, rewrap_string_interp(pex.args[1]), trivia_here))
             else
                 push!(pieces, (:interp, assemble(sub, cur), trivia_here))
             end
@@ -331,7 +343,19 @@ function assemble_quoted(node::GreenNode, cur::Cursor, iscmd::Bool)
     end
     last_lit_raw = raw[lit_idx[end]]
 
-    texts = iscmd ? copy(raw) : Dict(i => rm_escaped_newlines_str(t) for (i, t) in raw)
+    # Macro-wrapped strings (raw"", r"", b"", ...) carry RAW_STRING_FLAG on
+    # the K"string" node itself — exactly CSTParser's `prefixed != false`
+    # path, which skips escape processing entirely except for halving
+    # backslash runs before a quote/chunk-end (unescape_prefixed). Same
+    # istrip dedent order as CSTParser's: prefixed-unescape BEFORE lcp.
+    israw = JuliaSyntax.has_flags(JuliaSyntax.head(node), JuliaSyntax.RAW_STRING_FLAG)
+    texts = if iscmd
+        copy(raw)
+    elseif israw
+        Dict(i => String(CSTParser.unescape_prefixed(t)) for (i, t) in raw)
+    else
+        Dict(i => rm_escaped_newlines_str(t) for (i, t) in raw)
+    end
     if istrip
         lcp = Base.RefValue{Union{Nothing,String}}(nothing)
         for i in lit_idx
@@ -347,7 +371,7 @@ function assemble_quoted(node::GreenNode, cur::Cursor, iscmd::Bool)
             texts[first_i] = texts[first_i][2:end]
         end
     end
-    if !iscmd
+    if !iscmd && !israw
         for i in lit_idx
             texts[i] = unescape_str(texts[i])
         end

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -23,13 +23,14 @@ token_text(leaf::Leaf, source::String) = source[leaf.pos:prevind(source, leaf.po
 function terminal_expr(leaf::Leaf, source::String)
     k = leaf.kind
     if k == K"Identifier" && token_text(leaf, source) == "end"
-        # "end" is only ever an Identifier-kinded leaf inside index/range
-        # context (`a[end]`) — real block-closing `end` is its own keyword
-        # kind. CSTParser treats both spellings as the same END literal.
+        # "end" is Identifier-kinded both inside index/range context
+        # (`a[end]`, wants CSTParser's END literal) and as a dot-getfield
+        # field name (`a.end`, wants plain IDENTIFIER) — real block-closing
+        # `end` is its own keyword kind either way. Default to END here;
+        # the getfield/quotenode forms demote it back to IDENTIFIER.
         return EXPR(:END, leaf.fullspan, leaf.span, "end")
     elseif k == K"Identifier" && token_text(leaf, source) == "begin"
-        # `a[begin]` — `begin` as an index is an Identifier leaf; CSTParser
-        # maps it to a BEGIN literal (mirrors the `end`→END case).
+        # Same story as `end` above (`a[begin]` vs `a.begin`).
         return EXPR(:BEGIN, leaf.fullspan, leaf.span, "begin")
     elseif k == K"Bool"
         # true/false share one Kind; CSTParser distinguishes by literal text.

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -1,0 +1,89 @@
+# Mirrors CSTParser's literalmap/tokenkindtoheadmap, keyed by JuliaSyntax kind.
+# K"String"/K"Char" are here for documentation only: the quote-content-quote
+# triple JuliaSyntax emits for these is merged before terminal_expr ever sees
+# the content leaf in isolation (see merge_quoted below).
+const TERMINAL_HEADS = Dict{Kind,Symbol}(
+    K"Identifier" => :IDENTIFIER,
+    K"Integer"    => :INTEGER,
+    K"Float"      => :FLOAT,
+    K"HexInt"     => :HEXINT,
+    K"BinInt"     => :BININT,
+    K"OctInt"     => :OCTINT,
+    K"Char"       => :CHAR,
+    K"String"     => :STRING,
+    K"true"       => :TRUE,
+    K"false"      => :FALSE,
+)
+
+token_text(leaf::Leaf, source::String) = source[leaf.pos:prevind(source, leaf.pos + leaf.span)]
+
+# Oracle-pinned: keyword- and punctuation-headed EXPRs carry the raw token
+# text as val (CSTParser's tokenkindtoheadmap path always calls val(ps.t,ps)),
+# not nothing.
+function terminal_expr(leaf::Leaf, source::String)
+    k = leaf.kind
+    if JuliaSyntax.is_operator(k)
+        return EXPR(:OPERATOR, leaf.fullspan, leaf.span, token_text(leaf, source))
+    elseif JuliaSyntax.is_keyword(k)
+        return EXPR(Symbol(uppercase(string(k))), leaf.fullspan, leaf.span, token_text(leaf, source))
+    elseif haskey(TERMINAL_HEADS, k)
+        return EXPR(TERMINAL_HEADS[k], leaf.fullspan, leaf.span, token_text(leaf, source))
+    else
+        return EXPR(punctuation_head(k), leaf.fullspan, leaf.span, token_text(leaf, source))
+    end
+end
+
+# Mirrors tokenkindtoheadmap's punctuation entries; extend as kinds show up
+# in oracle diffs (unmapped kinds fail loudly with a KeyError, which is wanted
+# during burn-down — the corpus runner catches and reports it).
+const PUNCTUATION_HEADS = Dict{Kind,Symbol}(
+    K"(" => :LPAREN,   K")" => :RPAREN,
+    K"[" => :LSQUARE,  K"]" => :RSQUARE,
+    K"{" => :LBRACE,   K"}" => :RBRACE,
+    K"," => :COMMA,
+    K"@" => :ATSIGN,   K"." => :DOT,
+)
+punctuation_head(k::Kind) = PUNCTUATION_HEADS[k]
+
+# JuliaSyntax splits quoted literals into open-quote/content/close-quote
+# leaves; CSTParser sees them as one STRING or CHAR token. Merges a run of
+# leaves starting at a quote leaf into a single EXPR, returning the next
+# unconsumed index. Interpolation and triple-quoted/cmd literals are out of
+# scope here (Task 4 territory).
+function merge_quoted(leaves::Vector{Leaf}, i::Int, source::String)
+    open = leaves[i]
+    j = i + 1
+    content = nothing
+    while leaves[j].kind != open.kind
+        content = leaves[j]
+        j += 1
+    end
+    close = leaves[j]
+    fullspan = close.pos - open.pos + close.fullspan
+    span = close.pos - open.pos + close.span
+    if open.kind == K"\""
+        val = content === nothing ? "" : token_text(content, source)
+        return EXPR(:STRING, fullspan, span, val), j + 1
+    else # K"'"
+        val = source[open.pos:prevind(source, close.pos + close.span)]
+        return EXPR(:CHAR, fullspan, span, val), j + 1
+    end
+end
+
+# Converts a flat leaf run into EXPRs, merging quote-delimited literals.
+function terminal_exprs(leaves::Vector{Leaf}, source::String)
+    exprs = EXPR[]
+    i = 1
+    n = length(leaves)
+    while i <= n
+        leaf = leaves[i]
+        if leaf.kind == K"\"" || leaf.kind == K"'"
+            expr, i = merge_quoted(leaves, i, source)
+            push!(exprs, expr)
+        else
+            push!(exprs, terminal_expr(leaf, source))
+            i += 1
+        end
+    end
+    return exprs
+end

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -66,9 +66,11 @@ function terminal_expr(leaf::Leaf, source::String)
     end
 end
 
-# Mirrors tokenkindtoheadmap's punctuation entries; extend as kinds show up
-# in oracle diffs (unmapped kinds fail loudly with a KeyError, which is wanted
-# during burn-down — the corpus runner catches and reports it).
+# Mirrors tokenkindtoheadmap's punctuation entries. Unmapped kinds map to
+# :errortoken instead of a KeyError: with full oracle parity on valid code
+# the only unmapped leaves left are recovery shapes (e.g. a bare quote leaf
+# under an error node for `x = "`), and a wrong head there still shows up
+# loudly in oracle diffs while a throw would kill the whole file.
 const PUNCTUATION_HEADS = Dict{Kind,Symbol}(
     K"(" => :LPAREN,   K")" => :RPAREN,
     K"[" => :LSQUARE,  K"]" => :RSQUARE,
@@ -77,7 +79,7 @@ const PUNCTUATION_HEADS = Dict{Kind,Symbol}(
     K"@" => :ATSIGN,   K"." => :DOT,
     K";" => :SEMICOLON,
 )
-punctuation_head(k::Kind) = PUNCTUATION_HEADS[k]
+punctuation_head(k::Kind) = get(PUNCTUATION_HEADS, k, :errortoken)
 
 # JuliaSyntax splits quoted literals into open-quote/content/close-quote
 # leaves; CSTParser sees them as one STRING or CHAR token. Merges a run of
@@ -317,6 +319,7 @@ function collect_quoted_pieces(node::GreenNode, cur::Cursor, iscmd::Bool)
     have_run = false
     run_start = 0
     close_leaf = open_leaf
+    saw_close = false
     n = length(kids)
     j = 2
     while j <= n
@@ -326,6 +329,19 @@ function collect_quoted_pieces(node::GreenNode, cur::Cursor, iscmd::Bool)
             leaf = cur.leaves[cur.i]
             have_run || (run_start = leaf.pos; have_run = true)
             cur.i += 1
+            j += 1
+        elseif JuliaSyntax.is_error(k)
+            # Error kids inside a broken string (invalid escape, the
+            # zero-width missing-close marker, a recovery-wrapped region)
+            # are literal content bytes — extend the run instead of falling
+            # into the close-quote branch below, which emits overlapping
+            # chunks when visited more than once.
+            nl = leaf_count(c)
+            if nl > 0
+                leaf = cur.leaves[cur.i]
+                have_run || (run_start = leaf.pos; have_run = true)
+                cur.i += nl
+            end
             j += 1
         elseif k == K"$"
             leaf = cur.leaves[cur.i]
@@ -342,6 +358,7 @@ function collect_quoted_pieces(node::GreenNode, cur::Cursor, iscmd::Bool)
                 # `leaf` (the `$` itself) becomes the effective close, since
                 # cur.i has already advanced past it and nothing follows.
                 close_leaf = leaf
+                saw_close = true
                 push!(pieces, (:interp, EXPR(:errortoken, 0, 0, nothing), trivia_here))
                 break
             end
@@ -370,11 +387,22 @@ function collect_quoted_pieces(node::GreenNode, cur::Cursor, iscmd::Bool)
             j += 1
         else
             close_leaf = cur.leaves[cur.i]
+            saw_close = true
             chunk_start = have_run ? run_start : close_leaf.pos
             push!(pieces, (:lit, chunk_start, close_leaf.pos - 1))
+            have_run = false
             cur.i += 1
             j += 1
         end
+    end
+    if !saw_close
+        # Truncated literal at EOF: no closing-quote leaf exists. Synthesize
+        # a zero-width close at the node's end so the edge-fold arithmetic
+        # (and the node's own span) stays correct, and emit any pending run.
+        last_leaf = cur.leaves[cur.i - 1]
+        endpos = last_leaf.pos + last_leaf.fullspan
+        close_leaf = Leaf(open_leaf.kind, endpos, 0, 0)
+        push!(pieces, (:lit, have_run ? run_start : endpos, endpos - 1))
     end
     if iscmd
         @assert length(pieces) == 1 && pieces[1][1] == :lit

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -54,6 +54,13 @@ function terminal_expr(leaf::Leaf, source::String)
         # broken code; mirrors CSTParser's errortoken so recovery keeps spans
         # consistent instead of crashing the whole corpus file.
         return EXPR(:errortoken, leaf.fullspan, leaf.span, token_text(leaf, source))
+    elseif leaf.span == 0
+        # Zero-width marker kind with no punctuation mapping (e.g.
+        # K"TOMBSTONE", an internal deleted-token placeholder that
+        # shouldn't normally reach the built tree but might under
+        # recovery) — no real punctuation has zero width, so treat this
+        # like any other error marker instead of a KeyError.
+        return EXPR(:errortoken, leaf.fullspan, leaf.span, token_text(leaf, source))
     else
         return EXPR(punctuation_head(k), leaf.fullspan, leaf.span, token_text(leaf, source))
     end
@@ -77,15 +84,21 @@ punctuation_head(k::Kind) = PUNCTUATION_HEADS[k]
 # leaves starting at a quote leaf into a single EXPR, returning the next
 # unconsumed index. Interpolation and triple-quoted/cmd literals are out of
 # scope here (Task 4 territory).
-function merge_quoted(leaves::Vector{Leaf}, i::Int, source::String)
+function merge_quoted(leaves::Vector{Leaf}, i::Int, source::String, hi::Int)
     open = leaves[i]
+    n = min(hi, length(leaves))
     j = i + 1
     content = nothing
-    while leaves[j].kind != open.kind
+    while j <= n && leaves[j].kind != open.kind
         content = leaves[j]
         j += 1
     end
-    close = leaves[j]
+    # Unterminated literal at EOF (broken input): no closing quote leaf
+    # exists — fall back to the last consumed leaf instead of indexing
+    # past the end; there's nothing left to consume either way.
+    closed = j <= n
+    close = closed ? leaves[j] : leaves[n]
+    next_i = closed ? j + 1 : n + 1
     fullspan = close.pos - open.pos + close.fullspan
     span = close.pos - open.pos + close.span
     if open.kind == K"\""
@@ -95,10 +108,10 @@ function merge_quoted(leaves::Vector{Leaf}, i::Int, source::String)
                     content === nothing ? "" : token_text(content, source))
         CSTParser._rm_escaped_newlines(expr)
         CSTParser._unescape_string_expr(expr)
-        return expr, j + 1
+        return expr, next_i
     else # K"'"
         val = source[open.pos:prevind(source, close.pos + close.span)]
-        return EXPR(:CHAR, fullspan, span, val), j + 1
+        return EXPR(:CHAR, fullspan, span, val), next_i
     end
 end
 
@@ -173,22 +186,27 @@ byteslice(s::String, a::Int, b::Int) = a <= b ? String(@view codeunits(s)[a:b]) 
 # var"..." nonstandard identifier: JuliaSyntax splits it into var/quote/
 # content/quote leaves; CSTParser sees a NONSTDIDENTIFIER wrapping
 # IDENTIFIER("var") and a STRING of the (raw) quoted content.
-function merge_var(leaves::Vector{Leaf}, i::Int, source::String)
+function merge_var(leaves::Vector{Leaf}, i::Int, source::String, hi::Int)
     var_leaf = leaves[i]
     var_id = EXPR(:IDENTIFIER, var_leaf.fullspan, var_leaf.span, "var")
     open = leaves[i+1]
+    n = min(hi, length(leaves))
     j = i + 2
-    while leaves[j].kind != open.kind
+    while j <= n && leaves[j].kind != open.kind
         j += 1
     end
-    close = leaves[j]
+    # Unterminated var"..." at EOF (broken input): no closing quote leaf —
+    # fall back to the last consumed leaf instead of indexing past it.
+    closed = j <= n
+    close = closed ? leaves[j] : leaves[n]
+    next_i = closed ? j + 1 : n + 1
     str = EXPR(:STRING, close.pos + close.fullspan - open.pos,
                close.pos + close.span - open.pos,
                byteslice(source, open.pos + open.span, close.pos - 1))
     ex = EXPR(:NONSTDIDENTIFIER, EXPR[var_id, str], nothing,
               close.pos + close.fullspan - var_leaf.pos,
               close.pos + close.span - var_leaf.pos)
-    return ex, j + 1
+    return ex, next_i
 end
 
 DOLLAR_TRIVIA() = EXPR[EXPR(:OPERATOR, 1, 1, "\$")]
@@ -316,8 +334,18 @@ function collect_quoted_pieces(node::GreenNode, cur::Cursor, iscmd::Bool)
             have_run = false
             dollar_ex = assemble(c, cur)
             j += 1
-            sub = kids[j]
             trivia_here = EXPR[dollar_ex]
+            if j > n
+                # Broken input: `$` with nothing after it at all (e.g.
+                # truncated right at EOF) — no sub-expression child exists
+                # to descend into; keep the `$` itself reachable and stop.
+                # `leaf` (the `$` itself) becomes the effective close, since
+                # cur.i has already advanced past it and nothing follows.
+                close_leaf = leaf
+                push!(pieces, (:interp, EXPR(:errortoken, 0, 0, nothing), trivia_here))
+                break
+            end
+            sub = kids[j]
             if kind(sub) == K"parens"
                 pex = assemble(sub, cur)   # :brackets(args=[inner], trivia=[lparen,rparen])
                 # CSTParser hand-builds these two (parse_string_or_cmd's own
@@ -327,8 +355,15 @@ function collect_quoted_pieces(node::GreenNode, cur::Cursor, iscmd::Bool)
                 for t in pex.trivia
                     t.val = nothing
                 end
-                append!(trivia_here, pex.trivia)
-                push!(pieces, (:interp, rewrap_string_interp(pex.args[1]), trivia_here))
+                if isempty(pex.args)
+                    # Broken interpolation (`$(` with no inner expression
+                    # before EOF/recovery) — keep the whole brackets node
+                    # instead of indexing into empty args.
+                    push!(pieces, (:interp, pex, trivia_here))
+                else
+                    append!(trivia_here, pex.trivia)
+                    push!(pieces, (:interp, rewrap_string_interp(pex.args[1]), trivia_here))
+                end
             else
                 push!(pieces, (:interp, assemble(sub, cur), trivia_here))
             end

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -42,6 +42,7 @@ const PUNCTUATION_HEADS = Dict{Kind,Symbol}(
     K"{" => :LBRACE,   K"}" => :RBRACE,
     K"," => :COMMA,
     K"@" => :ATSIGN,   K"." => :DOT,
+    K";" => :SEMICOLON,
 )
 punctuation_head(k::Kind) = PUNCTUATION_HEADS[k]
 
@@ -73,22 +74,4 @@ function merge_quoted(leaves::Vector{Leaf}, i::Int, source::String)
         val = source[open.pos:prevind(source, close.pos + close.span)]
         return EXPR(:CHAR, fullspan, span, val), j + 1
     end
-end
-
-# Converts a flat leaf run into EXPRs, merging quote-delimited literals.
-function terminal_exprs(leaves::Vector{Leaf}, source::String)
-    exprs = EXPR[]
-    i = 1
-    n = length(leaves)
-    while i <= n
-        leaf = leaves[i]
-        if leaf.kind == K"\"" || leaf.kind == K"'"
-            expr, i = merge_quoted(leaves, i, source)
-            push!(exprs, expr)
-        else
-            push!(exprs, terminal_expr(leaf, source))
-            i += 1
-        end
-    end
-    return exprs
 end

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -29,6 +29,10 @@ function terminal_expr(leaf::Leaf, source::String)
         # context (`a[end]`) — real block-closing `end` is its own keyword
         # kind. CSTParser treats both spellings as the same END literal.
         return EXPR(:END, leaf.fullspan, leaf.span, "end")
+    elseif k == K"Identifier" && token_text(leaf, source) == "begin"
+        # `a[begin]` — `begin` as an index is an Identifier leaf; CSTParser
+        # maps it to a BEGIN literal (mirrors the `end`→END case).
+        return EXPR(:BEGIN, leaf.fullspan, leaf.span, "begin")
     elseif k == K"core_@cmd"
         # Zero-width marker for an unprefixed backtick literal (implicit
         # Core.@cmd) — CSTParser wraps it in a dedicated :globalrefcmd head

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -5,8 +5,6 @@
 const TERMINAL_HEADS = Dict{Kind,Symbol}(
     K"Identifier"      => :IDENTIFIER,
     K"MacroName"       => :IDENTIFIER,
-    K"StringMacroName" => :IDENTIFIER,
-    K"CmdMacroName"    => :IDENTIFIER,
     K"Integer"         => :INTEGER,
     K"Float"           => :FLOAT,
     K"HexInt"          => :HEXINT,
@@ -25,7 +23,17 @@ token_text(leaf::Leaf, source::String) = source[leaf.pos:prevind(source, leaf.po
 # not nothing.
 function terminal_expr(leaf::Leaf, source::String)
     k = leaf.kind
-    if JuliaSyntax.is_operator(k)
+    if k == K"Identifier" && token_text(leaf, source) == "end"
+        # "end" is only ever an Identifier-kinded leaf inside index/range
+        # context (`a[end]`) — real block-closing `end` is its own keyword
+        # kind. CSTParser treats both spellings as the same END literal.
+        return EXPR(:END, leaf.fullspan, leaf.span, "end")
+    elseif k == K"StringMacroName" || k == K"CmdMacroName"
+        # `m"str"`/`c\`cmd\`` desugar to calling `@m_str`/`@c_cmd`; the
+        # green leaf only carries the bare name, oracle wants the mangled one.
+        suffix = k == K"StringMacroName" ? "_str" : "_cmd"
+        return EXPR(:IDENTIFIER, leaf.fullspan, leaf.span, "@" * token_text(leaf, source) * suffix)
+    elseif JuliaSyntax.is_operator(k)
         return EXPR(:OPERATOR, leaf.fullspan, leaf.span, token_text(leaf, source))
     elseif JuliaSyntax.is_keyword(k)
         return EXPR(Symbol(uppercase(string(k))), leaf.fullspan, leaf.span, token_text(leaf, source))

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -62,8 +62,13 @@ function merge_quoted(leaves::Vector{Leaf}, i::Int, source::String)
     fullspan = close.pos - open.pos + close.fullspan
     span = close.pos - open.pos + close.span
     if open.kind == K"\""
-        val = content === nothing ? "" : token_text(content, source)
-        return EXPR(:STRING, fullspan, span, val), j + 1
+        # CSTParser stores unescaped content (parse_string_or_cmd runs
+        # _rm_escaped_newlines + _unescape_string_expr); reuse its routines.
+        expr = EXPR(:STRING, fullspan, span,
+                    content === nothing ? "" : token_text(content, source))
+        CSTParser._rm_escaped_newlines(expr)
+        CSTParser._unescape_string_expr(expr)
+        return expr, j + 1
     else # K"'"
         val = source[open.pos:prevind(source, close.pos + close.span)]
         return EXPR(:CHAR, fullspan, span, val), j + 1

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -427,7 +427,10 @@ function assemble_quoted(node::GreenNode, cur::Cursor, iscmd::Bool)
         end
     end
 
-    n == 1 && return exprs[1]
+    if n == 1
+        cur.terminals[cur.i - 1] = exprs[1]
+        return exprs[1]
+    end
 
     args = EXPR[]
     trivia = EXPR[]
@@ -444,5 +447,10 @@ function assemble_quoted(node::GreenNode, cur::Cursor, iscmd::Bool)
     end
     fullspan = close_leaf.pos + close_leaf.fullspan - open_leaf.pos
     span = close_leaf.pos + close_leaf.span - open_leaf.pos
-    return EXPR(:string, args, trivia, fullspan, span)
+    str = EXPR(:string, args, trivia, fullspan, span)
+    # The trailing chunk owns the closing quote; register it at the close
+    # leaf's slot so a later `;`-fold (`f("$x"; k=1)`) widens the chunk (and,
+    # via its parent, the string) — keeping childsums balanced.
+    cur.terminals[cur.i - 1] = exprs[n]
+    return str
 end

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -13,8 +13,6 @@ const TERMINAL_HEADS = Dict{Kind,Symbol}(
     K"OctInt"          => :OCTINT,
     K"Char"            => :CHAR,
     K"String"          => :STRING,
-    K"true"            => :TRUE,
-    K"false"           => :FALSE,
 )
 
 token_text(leaf::Leaf, source::String) = source[leaf.pos:prevind(source, leaf.pos + leaf.span)]
@@ -33,16 +31,25 @@ function terminal_expr(leaf::Leaf, source::String)
         # `a[begin]` — `begin` as an index is an Identifier leaf; CSTParser
         # maps it to a BEGIN literal (mirrors the `end`→END case).
         return EXPR(:BEGIN, leaf.fullspan, leaf.span, "begin")
-    elseif k == K"core_@cmd"
-        # Zero-width marker for an unprefixed backtick literal (implicit
-        # Core.@cmd) — CSTParser wraps it in a dedicated :globalrefcmd head
-        # instead of an IDENTIFIER macro name (see the K"macrocall" branch).
-        return EXPR(:globalrefcmd, leaf.fullspan, leaf.span, nothing)
+    elseif k == K"Bool"
+        # true/false share one Kind; CSTParser distinguishes by literal text.
+        txt = token_text(leaf, source)
+        return EXPR(txt == "true" ? :TRUE : :FALSE, leaf.fullspan, leaf.span, txt)
+    elseif k == K"Placeholder"
+        # Absent-catch-var marker (zero-width). 0.4 spelled this leaf's kind
+        # "false"; CSTParser still expects a FALSE literal there.
+        return EXPR(:FALSE, leaf.fullspan, leaf.span, token_text(leaf, source))
     elseif k == K"StringMacroName" || k == K"CmdMacroName"
         # `m"str"`/`c\`cmd\`` desugar to calling `@m_str`/`@c_cmd`; the
         # green leaf only carries the bare name, oracle wants the mangled one.
         suffix = k == K"StringMacroName" ? "_str" : "_cmd"
         return EXPR(:IDENTIFIER, leaf.fullspan, leaf.span, "@" * token_text(leaf, source) * suffix)
+    elseif k == K"Identifier" && Base.isoperator(Symbol(token_text(leaf, source)))
+        # 1.x reclassifies an operator token used in "value" position (call
+        # target, bare `(+)`, etc.) as plain Identifier — the AST doesn't
+        # distinguish an operator symbol from any other Symbol there. Text
+        # is the only remaining way to tell; oracle still wants OPERATOR.
+        return EXPR(:OPERATOR, leaf.fullspan, leaf.span, token_text(leaf, source))
     elseif JuliaSyntax.is_operator(k)
         return EXPR(:OPERATOR, leaf.fullspan, leaf.span, token_text(leaf, source))
     elseif JuliaSyntax.is_keyword(k)

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -438,10 +438,12 @@ function assemble_quoted(node::GreenNode, cur::Cursor, iscmd::Bool)
         if pieces[i][1] == :interp
             append!(trivia, pieces[i][3])
             push!(args, exprs[i])
-        elseif !isempty(exprs[i].val)
+        elseif pieces[i][2] <= pieces[i][3]
+            # chunk with real raw content stays an arg even if its val is
+            # "" after triple-quote dedent / leading-newline drop.
             push!(args, exprs[i])
         elseif i == 1 || i == n
-            push!(trivia, exprs[i])   # empty edge chunk: still carries the folded quote width
+            push!(trivia, exprs[i])   # empty edge chunk: carries the folded quote width
         end
         # empty non-edge chunk: dropped entirely (CSTParser never emits it)
     end

--- a/src/cst_conversion/terminals.jl
+++ b/src/cst_conversion/terminals.jl
@@ -7,6 +7,7 @@ const TERMINAL_HEADS = Dict{Kind,Symbol}(
     K"MacroName"       => :IDENTIFIER,
     K"Integer"         => :INTEGER,
     K"Float"           => :FLOAT,
+    K"Float32"         => :FLOAT,
     K"HexInt"          => :HEXINT,
     K"BinInt"          => :BININT,
     K"OctInt"          => :OCTINT,

--- a/src/cst_conversion/tokens.jl
+++ b/src/cst_conversion/tokens.jl
@@ -35,3 +35,13 @@ function _flatten!(leaves::Vector{Leaf}, leading::Int, node::GreenNode, pos::Int
     end
     return pos, leading
 end
+
+# Number of non-ws leaves flatten_leaves would assign to this subtree.
+# merge_quoted/merge_var scan cur.leaves by KIND (looking for the closing
+# quote) with no other stopping condition; on broken (unterminated) input
+# that scan can otherwise run past this node's own leaves into a
+# sibling/ancestor's — this bounds it to exactly what the node owns.
+function leaf_count(node::GreenNode)
+    haschildren(node) || return is_ws_trivia(kind(node)) ? 0 : 1
+    return sum(leaf_count(c) for c in children(node); init=0)
+end

--- a/src/cst_conversion/tokens.jl
+++ b/src/cst_conversion/tokens.jl
@@ -1,0 +1,37 @@
+struct Leaf
+    kind::Kind
+    pos::Int       # absolute first byte, 1-based
+    span::Int      # bytes of the token itself
+    fullspan::Int  # span + trailing trivia bytes
+end
+
+is_ws_trivia(k::Kind) = k == K"Whitespace" || k == K"NewlineWs" || k == K"Comment"
+
+# Flattens the green tree into non-trivia tokens, folding each trivia token's
+# width into the preceding token's fullspan (CSTParser's trivia model).
+function flatten_leaves(green::GreenNode, source::AbstractString)
+    leaves = Leaf[]
+    leading = _flatten!(leaves, 0, green, 1)[2]
+    return leaves, leading
+end
+
+function _flatten!(leaves::Vector{Leaf}, leading::Int, node::GreenNode, pos::Int)
+    if !haschildren(node)
+        w = Int(span(node))
+        if is_ws_trivia(kind(node))
+            if isempty(leaves)
+                leading += w
+            else
+                l = leaves[end]
+                leaves[end] = Leaf(l.kind, l.pos, l.span, l.fullspan + w)
+            end
+        else
+            push!(leaves, Leaf(kind(node), pos, w, w))
+        end
+        return pos + w, leading
+    end
+    for c in children(node)
+        pos, leading = _flatten!(leaves, leading, c, pos)
+    end
+    return pos, leading
+end

--- a/src/layer_syntax_trees.jl
+++ b/src/layer_syntax_trees.jl
@@ -97,7 +97,9 @@ Salsa.@derived function derived_julia_syntax_diagnostics(rt, uri)
     return diag_results
 end
 
-# Backend escape hatch while the converter soaks; read once at load time.
+# Backend escape hatch while the converter soaks. The env var is read once
+# at load time only — a runtime withenv is a no-op; set CST_BACKEND[]
+# directly for in-process flips.
 const CST_BACKEND = Ref(get(ENV, "JW_CST_BACKEND", "juliasyntax"))
 
 Salsa.@derived function derived_julia_legacy_syntax_tree(rt, uri)

--- a/src/layer_syntax_trees.jl
+++ b/src/layer_syntax_trees.jl
@@ -1,21 +1,77 @@
-Salsa.@derived function derived_julia_parse_result(rt, uri)
-    @debug "derived_julia_parse_result" uri=uri
+# JuliaSyntax's recursive-descent parser (and the recursive tree builders
+# that walk its output: SyntaxNode construction and CSTConversion.build_cst)
+# can StackOverflow on deeply nested, typically machine-generated, input
+# (e.g. long `||` chains) at the default task stack size, even though
+# CSTParser handles the same input fine. Run each recursive step on a Task
+# with a large reserved stack to close that gap.
+const PARSE_TASK_STACK_SIZE = 512 * 1024 * 1024
 
+# Runs `f` on an enlarged-stack Task and reports success/failure instead of
+# throwing, so callers can fall back to a safe minimal tree.
+function _run_on_enlarged_stack(f)
+    t = Task(PARSE_TASK_STACK_SIZE) do
+        try
+            (:ok, f())
+        catch e
+            (:error, e, catch_backtrace())
+        end
+    end
+    schedule(t)
+    try
+        return fetch(t)
+    catch e
+        return (:error, e, catch_backtrace())
+    end
+end
+
+# Never-throw fallback: a single :toplevel node wrapping one error leaf that
+# spans the whole file, so downstream consumers (SyntaxNode / CSTConversion)
+# still see a well-formed, fully-tiled tree instead of a query throw. Shallow
+# by construction, so building/converting it never itself overflows.
+function _error_fallback_green(content::AbstractString)
+    n = sizeof(content)
+    leaf = JuliaSyntax.GreenNode(JuliaSyntax.SyntaxHead(K"error", JuliaSyntax.EMPTY_FLAGS), n)
+    return JuliaSyntax.GreenNode(JuliaSyntax.SyntaxHead(K"toplevel", JuliaSyntax.EMPTY_FLAGS), n, [leaf])
+end
+
+Salsa.@derived function derived_julia_green_tree(rt, uri)
+    @debug "derived_julia_green_tree" uri=uri
     tf = derived_text_file_content(rt, uri)
-
     content = tf.content.content
+    status = _run_on_enlarged_stack() do
+        stream = JuliaSyntax.ParseStream(content; version=VERSION)
+        JuliaSyntax.parse!(stream; rule=:all)
+        green = JuliaSyntax.build_tree(JuliaSyntax.GreenNode, stream)
+        (green, stream.diagnostics)
+    end
+    if status[1] == :ok
+        green, diagnostics = status[2]
+        return green, diagnostics, content
+    else
+        @error "JuliaSyntax parse failed; using error-fallback tree" uri=uri exception=(status[2], status[3])
+        green = _error_fallback_green(content)
+        diag = JuliaSyntax.Diagnostic(1, max(1, sizeof(content)); error="parse failed: $(sprint(showerror, status[2]))")
+        return green, [diag], content
+    end
+end
 
-    stream = JuliaSyntax.ParseStream(content; version=VERSION)
-    JuliaSyntax.parse!(stream; rule=:all)
-    tree = JuliaSyntax.build_tree(SyntaxNode, stream)
-
-    return tree, stream.diagnostics
+Salsa.@derived function derived_julia_parse_result(rt, uri)
+    green, diagnostics, content = derived_julia_green_tree(rt, uri)
+    status = _run_on_enlarged_stack() do
+        SyntaxNode(JuliaSyntax.SourceFile(content), green)
+    end
+    if status[1] == :ok
+        return status[2], diagnostics
+    else
+        @error "SyntaxNode construction failed; using error-fallback tree" uri=uri exception=(status[2], status[3])
+        tree = SyntaxNode(JuliaSyntax.SourceFile(content), _error_fallback_green(content))
+        diag = JuliaSyntax.Diagnostic(1, max(1, sizeof(content)); error="SyntaxNode construction failed: $(sprint(showerror, status[2]))")
+        return tree, vcat(diagnostics, [diag])
+    end
 end
 
 Salsa.@derived function derived_julia_syntax_tree(rt, uri)
-    parse_result = derived_julia_parse_result(rt, uri)
-
-    return parse_result[1]
+    return derived_julia_parse_result(rt, uri)[1]
 end
 
 @static if isdefined(JuliaSyntax, :byte_range)
@@ -41,16 +97,34 @@ Salsa.@derived function derived_julia_syntax_diagnostics(rt, uri)
     return diag_results
 end
 
+# Backend escape hatch while the converter soaks; read once at load time.
+const CST_BACKEND = Ref(get(ENV, "JW_CST_BACKEND", "juliasyntax"))
+
 Salsa.@derived function derived_julia_legacy_syntax_tree(rt, uri)
     @debug "derived_julia_legacy_syntax_tree" uri=uri
-
-    tf = derived_text_file_content(rt, uri)
-
-    content = tf.content.content
-
-    cst = CSTParser.parse(content, true)
-
-    return cst
+    if CST_BACKEND[] == "cstparser"
+        tf = derived_text_file_content(rt, uri)
+        content = tf.content.content
+        status = _run_on_enlarged_stack() do
+            CSTParser.parse(content, true)
+        end
+        if status[1] == :ok
+            return status[2]
+        else
+            @error "CSTParser.parse failed; using error-fallback tree" uri=uri exception=(status[2], status[3])
+            return CSTConversion.build_cst(_error_fallback_green(content), content)
+        end
+    end
+    green, _, content = derived_julia_green_tree(rt, uri)
+    status = _run_on_enlarged_stack() do
+        CSTConversion.build_cst(green, content)
+    end
+    if status[1] == :ok
+        return status[2]
+    else
+        @error "CSTConversion.build_cst failed; using error-fallback tree" uri=uri exception=(status[2], status[3])
+        return CSTConversion.build_cst(_error_fallback_green(content), content)
+    end
 end
 
 Salsa.@derived function derived_toml_parse_result(rt, uri)

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -23,6 +23,7 @@ include("types.jl")
 include("sourcetext.jl")
 include("inputs.jl")
 include("layer_files.jl")
+include("cst_conversion/CSTConversion.jl")
 include("layer_syntax_trees.jl")
 include("layer_includes.jl")
 

--- a/src/public.jl
+++ b/src/public.jl
@@ -465,12 +465,19 @@ function get_julia_syntax_tree(jw::JuliaWorkspace, uri::URI)
 end
 
 """
-    syntax_node_at(node::SyntaxNode, byte::Int)
+    syntax_node_at(node::SyntaxNode, offset::Int)
 
 Return the deepest `SyntaxNode` in the subtree rooted at `node` that contains
-`byte`. The `SyntaxNode` counterpart of `get_expr1` for cross-tree migration.
+`offset`. The `SyntaxNode` counterpart of `get_expr1` for cross-tree migration.
+
+`offset` is a 0-based byte offset, matching `get_expr1`. Throws `ArgumentError`
+for an offset outside `[0, sizeof)`.
 """
-function syntax_node_at(node::SyntaxNode, byte::Int)
+function syntax_node_at(node::SyntaxNode, offset::Int)
+    node_size = last_byte(node) - first_byte(node) + 1
+    (offset < 0 || offset >= node_size) &&
+        throw(ArgumentError("byte offset $offset out of range [0, $node_size)"))
+    byte = first_byte(node) + offset   # 0-based offset → 1-based absolute byte
     while haschildren(node)
         found = false
         for c in children(node)

--- a/src/public.jl
+++ b/src/public.jl
@@ -19,6 +19,7 @@ export JuliaWorkspace,
     has_file,
     get_text_file,
     get_julia_syntax_tree,
+    syntax_node_at,
     get_toml_syntax_tree,
     get_diagnostic,
     get_diagnostics,
@@ -461,6 +462,27 @@ function get_julia_syntax_tree(jw::JuliaWorkspace, uri::URI)
     process_from_dynamic(jw)
 
     return derived_julia_syntax_tree(jw.runtime, uri)
+end
+
+"""
+    syntax_node_at(node::SyntaxNode, byte::Int)
+
+Return the deepest `SyntaxNode` in the subtree rooted at `node` that contains
+`byte`. The `SyntaxNode` counterpart of `get_expr1` for cross-tree migration.
+"""
+function syntax_node_at(node::SyntaxNode, byte::Int)
+    while haschildren(node)
+        found = false
+        for c in children(node)
+            if first_byte(c) <= byte <= last_byte(c)
+                node = c
+                found = true
+                break
+            end
+        end
+        found || break
+    end
+    return node
 end
 
 """

--- a/test/cst_corpus.jl
+++ b/test/cst_corpus.jl
@@ -1,0 +1,60 @@
+module CSTCorpus
+
+using CSTParser
+using JuliaWorkspaces: CSTConversion
+
+# One corpus file's outcome: :pass, or a diff signature for grouping.
+function check_file(path::String)
+    src = read(path, String)
+    ours = try
+        CSTConversion.build_cst(src)
+    catch err
+        return (:errored, "converter threw: $(typeof(err))")
+    end
+    oracle = try
+        CSTParser.parse(src, true)
+    catch err
+        return (:pass, nothing)   # oracle itself fails: out of scope
+    end
+    d = CSTConversion.first_tree_diff(ours, oracle)
+    d === nothing && return (:pass, nothing)
+    # signature = diff with indices stripped, so identical shapes group together
+    return (:failed, replace(d, r"\[\d+\]" => "[]", r"\d+" => "N"))
+end
+
+function run_corpus(files::Vector{String}; report_path::String)
+    empty!(CSTConversion.UNHANDLED_KINDS)
+    passed = 0; failures = Dict{String,Vector{String}}(); errors = Dict{String,Vector{String}}()
+    for f in files
+        outcome, sig = check_file(f)
+        if outcome == :pass
+            passed += 1
+        elseif outcome == :failed
+            push!(get!(Vector{String}, failures, sig), f)
+        else
+            push!(get!(Vector{String}, errors, sig), f)
+        end
+    end
+    open(report_path, "w") do io
+        total = length(files)
+        println(io, "# CST conversion corpus report\n")
+        println(io, "$passed / $total files identical to oracle\n")
+        println(io, "## Unhandled kinds\n")
+        for k in sort!(string.(collect(CSTConversion.UNHANDLED_KINDS)))
+            println(io, "- `", k, "`")
+        end
+        for (title, group) in (("Diffs", failures), ("Converter errors", errors))
+            println(io, "\n## $title\n")
+            for (sig, fs) in sort!(collect(group); by=p -> -length(p.second))
+                println(io, "- **$(length(fs))×** `$sig`\n  - e.g. `$(first(fs))`")
+            end
+        end
+    end
+    return (total=length(files), passed=passed,
+            failed=sum(length, values(failures); init=0),
+            errored=sum(length, values(errors); init=0))
+end
+
+julia_files(dir::String) = String[joinpath(r, f) for (r, _, fs) in walkdir(dir) for f in fs if endswith(f, ".jl")]
+
+end

--- a/test/staticlint/test_inference.jl
+++ b/test/staticlint/test_inference.jl
@@ -231,11 +231,13 @@ end
 
 @testitem "error_list_comp_incorrect_iter_specs" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: errorof
+    # comprehensions take no `end`; the old fixture's stray `end` made every
+    # line invalid Julia, which the parser now rejects outright
     let (cst, meta_dict) = parse_and_pass("""
-        [i for i in length(1) end]
-        [i for i in 1.1 end]
-        [i for i in 1 end]
-        [i for i in 1:1 end]
+        [i for i in length(1)]
+        [i for i in 1.1]
+        [i for i in 1]
+        [i for i in 1:1]
         """)
         @test errorof(cst[1][2][3], meta_dict) === JuliaWorkspaces.StaticLint.IncorrectIterSpec
         @test errorof(cst[2][2][3], meta_dict) === JuliaWorkspaces.StaticLint.IncorrectIterSpec

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -888,6 +888,19 @@ end
 end
 
 
+# Direct coverage of the EqInIfConditional check: the default backend rejects
+# `if x = 1 end`, so this exercises the JW_CST_BACKEND=cstparser escape-hatch
+# path where the lenient parse still reaches the check.
+@testitem "check_if_conds assignment direct" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: check_if_conds, errorof, EqInIfConditional, Meta
+
+    cst = JuliaWorkspaces.CSTParser.parse("if x = 1 end", true)
+    ifx = cst.args[1]
+    meta_dict = Dict{UInt64,Meta}()
+    check_if_conds(ifx, meta_dict)
+    @test errorof(ifx.args[1], meta_dict) == EqInIfConditional
+end
+
 @testitem "check_farg_unused unused second argument" setup=[shared_static_lint] begin
     import CSTParser
     using JuliaWorkspaces.StaticLint: errorof, UnusedFunctionArgument

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -11,6 +11,7 @@ using StaticLint: scopeof, bindingof, refof, errorof, check_all, getenv
 
     export parse_and_pass, check_resolved, get_hints, get_env, collect_hints
     export module_name, find_module_by_name, find_first
+    export TEST_URI
 
     const TEST_URI = JuliaWorkspaces.URIs2.uri"file://test.jl"
 
@@ -850,34 +851,40 @@ end
     @test getmeta(cst.args[1].args[1], meta_dict).error == ConstIfCondition
 end
 
+# An unbracketed `=` in an `if` condition is invalid Julia (`Meta.parse`
+# rejects it); the parser reports a syntax error, so the EqInIfConditional
+# lint check never sees the pattern anymore.
 @testitem "check_if_conds assignment in condition" setup=[shared_static_lint] begin
-    using JuliaWorkspaces.StaticLint: getmeta, EqInIfConditional
+    using JuliaWorkspaces
 
-    cst, meta_dict = parse_and_pass("""
+    cst, meta_dict, jw = parse_and_pass("""
         if x = 1 end
         """)
 
-    @test getmeta(cst.args[1].args[1], meta_dict).error == EqInIfConditional
+    diags = JuliaWorkspaces.derived_julia_syntax_diagnostics(jw.runtime, TEST_URI)
+    @test any(d -> d.severity == :error, diags)
 end
 
 @testitem "check_if_conds assignment in or-condition" setup=[shared_static_lint] begin
-    using JuliaWorkspaces.StaticLint: getmeta, EqInIfConditional
+    using JuliaWorkspaces
 
-    cst, meta_dict = parse_and_pass("""
+    cst, meta_dict, jw = parse_and_pass("""
         if a || x = 1 end
         """)
 
-    @test getmeta(cst.args[1].args[1], meta_dict).error == EqInIfConditional
+    diags = JuliaWorkspaces.derived_julia_syntax_diagnostics(jw.runtime, TEST_URI)
+    @test any(d -> d.severity == :error, diags)
 end
 
 @testitem "check_if_conds assignment in and-condition" setup=[shared_static_lint] begin
-    using JuliaWorkspaces.StaticLint: getmeta, EqInIfConditional
+    using JuliaWorkspaces
 
-    cst, meta_dict = parse_and_pass("""
+    cst, meta_dict, jw = parse_and_pass("""
         if x = 1 && b end
         """)
 
-    @test getmeta(cst.args[1].args[1], meta_dict).error == EqInIfConditional
+    diags = JuliaWorkspaces.derived_julia_syntax_diagnostics(jw.runtime, TEST_URI)
+    @test any(d -> d.severity == :error, diags)
 end
 
 

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -48,7 +48,7 @@ end
 
     # invariant: leaves tile the file
     for src in ["f(a; b=1) do x\n  x\nend", "\"str\\n\" * `cmd`", ""]
-        ls, lead = leaves_of(src)
+        local ls, lead = leaves_of(src)
         @test lead + sum(l -> l.fullspan, ls; init=0) == sizeof(src)
     end
 end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -592,6 +592,16 @@ end
         "a ? b",
         "[1, 2",
         "module A function g() end",
+        # truncated triple-quoted docstrings: error kids inside a K"string"
+        # node must extend the content run, not double as close quotes
+        # (overlapping-chunk childsum bug found by a depot prefix sweep)
+        "\"\"\"\n\\",
+        "\"\"\"",
+        "\"\"\"\n    doc\n\n```julia\nf(\"# x\\\"",
+        "\"\"\"\n```\n\\\"",
+        # bare quote leaf under an error node (no wrapping string node)
+        "= \"",
+        "= \"abc",
     ]
         ex = CSTConversion.build_cst(src)
         @test ex isa CSTParser.EXPR

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -115,6 +115,13 @@ end
         # explicit begin-block bodies are not wrapped a second time
         "x -> begin x end",
         "f() = begin x end",
+        # sibling `;` groups nest recursively; empty groups get nothing trivia
+        "f(a; b; c)",
+        "f(;)",
+        "f(x;)",
+        # toplevel `;` width lands on the preceding statement's rightmost leaf
+        "f(); b",
+        "g(); h()",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end
@@ -131,10 +138,27 @@ end
         @test CSTConversion.check_spans(ex) === nothing
     end
 
+    # `;` width must land somewhere even under parent forms whose oracle
+    # layout isn't implemented yet — sums have to stay balanced regardless
+    for src in ["(; a=1)", "f.(x; y=1)", "@m(x; y=1)", "T{a; b}"]
+        @test CSTConversion.check_spans(CSTConversion.build_cst(src)) === nothing
+    end
+
     # corpus runner runs end to end on this package's own test file
     report = joinpath(mktempdir(), "report.md")
     stats = CSTCorpus.run_corpus([@__FILE__]; report_path=report)
     @test stats.total == 1
     @test stats.errored == 0
     @test isfile(report)
+
+    # invariant sweep: every src/ file the converter can parse must satisfy
+    # check_spans, whatever its oracle-diff status
+    for f in CSTCorpus.julia_files(normpath(joinpath(@__DIR__, "..", "src")))
+        ex = try
+            CSTConversion.build_cst(read(f, String))
+        catch
+            continue   # converter errors are tracked by the corpus report
+        end
+        @test (f, CSTConversion.check_spans(ex)) == (f, nothing)
+    end
 end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -167,6 +167,53 @@ end
         # (a single empty group survives only when all groups are empty)
         "f(a;;b)",
         "f(;;)",
+        # pre-existing gap found via Task 8 corpus probing: a parenless
+        # prefix-op call never gets any trivia, so it must be `nothing`
+        "!x",
+        "!f(x)",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+
+@testitem "cst-conv: control flow and containers via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "if a\nb\nend",
+        "if a\nb\nelse\nc\nend",
+        "if a\nb\nelseif c\nd\nelse\ne\nend",
+        "a ? b : c",
+        "while a\nb\nend",
+        "for i in xs\ni\nend",
+        "for i = 1:10, j in ys\nend",
+        "for (a, b) in xs end",
+        "try\na\ncatch\nend",
+        "try\na\ncatch err\nb\nfinally\nc\nend",
+        "try\na\ncatch e\nb\nelse\nc\nend",
+        "let x = 1\nx\nend",
+        "let\nend",
+        "return",
+        "return x",
+        "break",
+        "continue",
+        "(a, b)",
+        "(a,)",
+        "(;a=1)",
+        "[1, 2]",
+        "[1 2]",
+        "[1 2; 3 4]",
+        "[1; 2;; 3; 4]",
+        "Int[1, 2]",
+        "[x for x in xs]",
+        "[x for x in xs if x > 0]",
+        "(x for x in xs)",
+        "[x + y for x in xs, y in ys]",
+        "Dict(a => b)",
+        "a:b",
+        "a:b:c",
+        # inherited concerns: paren-block and trailing-`;` vcat
+        "(a; b)",
+        "[a;]",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -486,6 +486,10 @@ end
         "f(x) do; y end",
         "f(x) do; end",
         "f(a) do; g(b) do; z end end",
+        # a dotted `.=` broadcast as a call arg stays operator-headed (not :kw)
+        "f(x .= y)",
+        "Matrix(C .= 2.0 .* A) ≈ B ≈ D",
+        "@m(a .= b)",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -51,3 +51,11 @@ end
         @test lead + sum(l -> l.fullspan, ls; init=0) == sizeof(src)
     end
 end
+
+@testitem "cst-conv: terminals via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in ["x", "1", "1.5", "0x1f", "0b101", "0o17", "true", "false",
+                "'a'", "\"str\"", "x ", "  x", "# only a comment", ""]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -471,6 +471,13 @@ end
         "f(\"\$x\"; k=1)",
         "printstyled(\" x\$flags \"; color=:y)",
         "pipeline(`a \$b`; c)",
+        # `let bindings ; body end`: the `;` folds onto the bindings
+        "let x=1; y end",
+        "let s; x end",
+        "let i=1; f(); end",
+        # `;`-fold onto a qualified macrocall inside a paren-block
+        "(Base.@m; x)",
+        "(Base.@_inline_meta; f(x))",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -123,6 +123,37 @@ end
         # toplevel `;` width lands on the preceding statement's rightmost leaf
         "f(); b",
         "g(); h()",
+        # `;` before `end` in end-terminated, non-block-bodied type decls folds
+        # onto the preceding leaf (no block body to hold it)
+        "abstract type A; end",
+        "primitive type P 8; end",
+        "abstract type A end;",
+        # short-form def whose RHS is itself an anon `function`: the def
+        # discriminator keys on a genuine `function` keyword LEAF, not a nested
+        # K"function" child
+        "f(x) = function (y) y end",
+        "f(x) = function g() end",
+        # bare unary `::T` (call-shaped T) kwarg default is not a return-type
+        # def; its wrapped body block keeps EXPR[] trivia
+        "f(::typeof(x) = x) = 1",
+        "g(::typeof(sin) = sin) = 1",
+        "f(x::Int)::Int = x",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+
+@testitem "cst-conv: word-operator reclassification via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        # comparison-chain word operators label OPERATOR, not IDENTIFIER
+        "p isa typeinfo <: Pair",
+        "a in b in c",
+        "a isa B",
+        # export/public name lists reclassify word operators too
+        "export isa",
+        "export in, isa",
+        "export a, b",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end
@@ -586,6 +617,12 @@ end
         x.args === nothing || foreach(a -> walk(a, count), x.args)
     end
 
+    # Full CSTParser iterate/getindex traversal (the exact protocol StaticLint's
+    # include walker uses); it must not throw on any broken shape — an
+    # arity/slot mismatch (e.g. an errortoken misfiled into args) surfaces here
+    # as a BoundsError even when check_spans is clean.
+    iterate_walk(x) = (for c in x; iterate_walk(c); end)
+
     for src in [
         "function f(",
         "a +",
@@ -599,6 +636,15 @@ end
         "a ? b",
         "[1, 2",
         "module A function g() end",
+        # unterminated end-keyword forms: the missing `end` must land as a
+        # trivia END-placeholder, not a spurious extra arg that breaks iterate
+        "for i in 1:10\n",
+        "while true\n",
+        "try\nfoo(\n",
+        "function f()\n",
+        "macro m()\n",
+        "begin\nfor i in xs\n",
+        "module M\nwhile c\n",
         # truncated triple-quoted docstrings: error kids inside a K"string"
         # node must extend the content run, not double as close quotes
         # (overlapping-chunk childsum bug found by a depot prefix sweep)
@@ -618,6 +664,8 @@ end
         count = Ref(0)
         walk(ex, count)
         @test count[] > 0
+        # and by CSTParser's own iterate protocol
+        @test (iterate_walk(ex); true)
     end
 
     # three degenerate whole-file shapes from the divergence log: must
@@ -655,8 +703,32 @@ end
     @test JuliaWorkspaces.CSTConversion.trees_equal(cst, CSTParser.parse(content, true))
 
     sn = JuliaWorkspaces.get_julia_syntax_tree(jw, uri)
-    @test JuliaWorkspaces.syntax_node_at(sn, 1) isa JuliaSyntax.SyntaxNode
-    @test kind(JuliaWorkspaces.syntax_node_at(sn, 8)) == K"Identifier"  # byte 8 = 'x'
+    # syntax_node_at takes a 0-based offset (matching get_expr1): offset 7 is
+    # byte 8, the RHS 'x'.
+    @test JuliaWorkspaces.syntax_node_at(sn, 0) isa JuliaSyntax.SyntaxNode
+    @test kind(JuliaWorkspaces.syntax_node_at(sn, 7)) == K"Identifier"
+
+    # Boundary contract: 0-based, in-range only.
+    sn2 = JuliaSyntax.parseall(JuliaSyntax.SyntaxNode, "x + 1")  # sizeof 5
+    @test kind(JuliaWorkspaces.syntax_node_at(sn2, 0)) == K"Identifier"   # first leaf
+    @test kind(JuliaWorkspaces.syntax_node_at(sn2, 4)) == K"Integer"      # last leaf
+    @test_throws ArgumentError JuliaWorkspaces.syntax_node_at(sn2, -1)
+    @test_throws ArgumentError JuliaWorkspaces.syntax_node_at(sn2, 5)     # == sizeof
+end
+
+@testitem "cst-conv: unterminated block diagnostics never throw" begin
+    using JuliaWorkspaces
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, URI,
+        get_diagnostics_blocking
+
+    # An unterminated for/while/try leaked an errortoken into args, breaking
+    # CSTParser's iterate protocol; StaticLint's include walker then threw a
+    # BoundsError and killed diagnostics for the whole workspace.
+    for src in ["for i in 1:10\n", "while true\n", "try\nfoo(\n", "function f()\n"]
+        jw = JuliaWorkspace()
+        add_file!(jw, TextFile(URI("file:///a.jl"), SourceText(src, "julia")))
+        @test (get_diagnostics_blocking(jw); true)
+    end
 end
 
 @testitem "cst-conv: deep nesting never throws (enlarged parse stack)" begin

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -459,6 +459,13 @@ end
         # right-nested juxtaposition of 3+ factors
         "4A'B'",
         "2A'B'C'",
+        # bare qualified macrocall (no args) grows span to fullspan
+        "function g()\nBase.@_inline_meta\nx\nend",
+        "Base.@inline_meta\ny",
+        # dotted assignment quotes to an OPERATOR atom; dotted broadcast stays a quote
+        ":(.=)",
+        ":(.+)",
+        ":(.==)",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -418,6 +418,28 @@ end
         # Float32 literal
         "2f0",
         "1.0f0",
+        # while/for with a keyword-kinded condition
+        "while let x=1\nx\nend\ny\nend",
+        "while c\nx\nend",
+        "for i in x\ni\nend",
+        # row span with spaces around the `;`
+        "[1 2 ; 3 4]",
+        "[a b ; c d]",
+        # `begin` as an index literal → BEGIN; as a field/symbol → IDENTIFIER
+        "a[begin]",
+        "a[begin:end]",
+        "a.begin",
+        ":begin",
+        # return-type-annotated short function def wraps its body in a block
+        "f()::T = a, b",
+        "g()::Tuple{Int,Int} = a, b",
+        "x::Int = 5",
+        # var\"...\" quoted as a symbol keeps :quotenode
+        ":var\"@x\"",
+        # a bare `@m` macrocall followed by `;` grows its span to fullspan
+        "@m;x",
+        "begin @m; x end",
+        ":(@_inline_meta; det(x))",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -466,6 +466,11 @@ end
         ":(.=)",
         ":(.+)",
         ":(.==)",
+        # interpolated-string call arg followed by `;` params: the `;` folds
+        # onto the trailing chunk (childsums stay balanced)
+        "f(\"\$x\"; k=1)",
+        "printstyled(\" x\$flags \"; color=:y)",
+        "pipeline(`a \$b`; c)",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -399,6 +399,25 @@ end
         "x = M.@m(a)\ny",
         "if a\nb = M.@m(\"v\")\nend",
         "x = M.@m(a) + z",
+        # operator-as-callee: `+(x)` unwraps to a call, `-`/`!`/`~` keep the
+        # bracketed operand
+        "+(x)",
+        "*(x)",
+        "+(::T) = x",
+        "-(x)",
+        "!(x)",
+        "+(::Infinity) = R()",
+        # vect element keeps `=` as assignment
+        "[a=b]",
+        # word operators in selective imports become OPERATOR
+        "import Base: in",
+        "import Base: +, in, -",
+        # interpolated getfield field name (K\"inert\") → quotenode
+        "Base.\$f",
+        "f.\$g",
+        # Float32 literal
+        "2f0",
+        "1.0f0",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -60,3 +60,23 @@ end
         @test CSTConversion.oracle_diff(src) === nothing
     end
 end
+
+@testitem "cst-conv: core forms via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "a = 1",                 # binary syntax: op is the EXPR head
+        "a + b",                 # infix call: op moves to args[1]
+        "a + b + c",             # chained infix
+        "a * b",
+        "a == b",
+        "(a)",                   # brackets with paren trivia
+        "begin\na\nend",         # block with keyword trivia
+        "a\nb\nc",               # multi-expression file
+        "a; b",
+        "f(x)",                  # prefix call
+        "f()",
+        "f(x, y)",               # comma trivia
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -81,6 +81,35 @@ end
     end
 end
 
+@testitem "cst-conv: definitions via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "function f() end",
+        "function f(x, y=1; z) x end",
+        "function f(x::Int)::Int x end",
+        "f(x) = x",
+        "x -> x + 1",
+        "function (x) x end",
+        "struct A end",
+        "struct A{T} <: B\n    x::T\nend",
+        "mutable struct A x end",
+        "abstract type A end",
+        "abstract type A{T} <: B end",
+        "primitive type A 8 end",
+        "macro m(x) x end",
+        "module A\nf() = 1\nend",
+        "baremodule A end",
+        "f(x::T) where T = x",
+        "f(x::T) where {T <: Number} = x",
+        "const x = 1",
+        "global x = 1",
+        "local x = 1",
+        "mutable struct A\n    const x::Int\nend",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+
 @testitem "cst-conv: span invariants and corpus smoke" begin
     using JuliaWorkspaces: CSTConversion
     include(joinpath(@__DIR__, "cst_corpus.jl"))

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -447,6 +447,18 @@ end
         "macro -(ex)\nend",
         "macro ~(ex)\nend",
         "function -(x) end",
+        # operator-as-function-call for <: / >: / ::
+        "<:(a, b)",
+        "<:(a, b, c)",
+        ">:(a, b)",
+        # string getfield field name is used directly (no quotenode)
+        "a.\"prop\"",
+        # global/const nesting: const is outermost
+        "global const x = 1",
+        "const global x = 1",
+        # right-nested juxtaposition of 3+ factors
+        "4A'B'",
+        "2A'B'C'",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -504,9 +504,12 @@ end
         "quote try; f(); catch; false; finally; end; end",
         # triple-string leading chunk with content (dedented to "") stays an arg
         "\"\"\"\n\$(a)\nb\"\"\"",
-        # empty catch body + else clause → degenerate catch block (args nothing, val "")
+        # empty catch body: degenerate block before else, FALSE (var-less)
+        # before finally, plain block when it has a var
         "try\ncatch\nelse\nend",
         "try\nx\ncatch\ny\nelse\nz\nend",
+        "try\nf()\ncatch\nfinally\nend",
+        "try\nf()\ncatch E\nfinally\nend",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -105,6 +105,16 @@ end
         "global x = 1",
         "local x = 1",
         "mutable struct A\n    const x::Int\nend",
+        # `;` width folds onto the rightmost leaf (often trivia) of the
+        # preceding sibling, not its last positional arg
+        "f(g(a; b=1); c=2)",
+        "f(a, g(b; c=1); d=2)",
+        "f((a); b=1)",
+        "f([a]; b=1)",
+        "f(a[1]; b=1)",
+        # explicit begin-block bodies are not wrapped a second time
+        "x -> begin x end",
+        "f() = begin x end",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -13,3 +13,41 @@
     @test CSTConversion.first_tree_diff(a, c) isa String
     @test !CSTConversion.trees_equal(a, d)      # fullspans must be compared
 end
+
+@testitem "cst-conv: leaf flattening" begin
+    using JuliaSyntax
+    using JuliaSyntax: @K_str
+    using JuliaWorkspaces: CSTConversion
+
+    function leaves_of(src)
+        stream = JuliaSyntax.ParseStream(src)
+        JuliaSyntax.parse!(stream; rule=:all)
+        green = JuliaSyntax.build_tree(JuliaSyntax.GreenNode, stream)
+        CSTConversion.flatten_leaves(green, src)
+    end
+
+    # "x + 1" → tokens x,+,1 ; ws folded into preceding token's fullspan
+    ls, leading = leaves_of("x + 1")
+    @test leading == 0
+    @test [l.kind for l in ls] == [K"Identifier", K"+", K"Integer"]
+    @test [l.pos for l in ls] == [1, 3, 5]
+    @test [l.span for l in ls] == [1, 1, 1]
+    @test [l.fullspan for l in ls] == [2, 2, 1]
+
+    # comments are trivia too
+    ls, _ = leaves_of("x # hi\ny")
+    @test [l.kind for l in ls] == [K"Identifier", K"Identifier"]
+    @test ls[1].fullspan == 7     # "x # hi\n"
+    @test ls[2].pos == 8
+
+    # file-leading trivia is reported separately
+    ls, leading = leaves_of("  x")
+    @test leading == 2
+    @test ls[1].pos == 3
+
+    # invariant: leaves tile the file
+    for src in ["f(a; b=1) do x\n  x\nend", "\"str\\n\" * `cmd`", ""]
+        ls, lead = leaves_of(src)
+        @test lead + sum(l -> l.fullspan, ls; init=0) == sizeof(src)
+    end
+end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -214,6 +214,21 @@ end
         # inherited concerns: paren-block and trailing-`;` vcat
         "(a; b)",
         "[a;]",
+        # nested ternary: K"?" reuses the kind for the nested composite node
+        # (same trap as if/elseif), which must stay in args, not trivia
+        "a ? b : c ? d : e",
+        "a ? b ? c : d : e",
+        # bare `return` span extends over the keyword's trailing trivia
+        # (span = fullspan via the synthetic NOTHING arg), incl. the
+        # enclosing trivia-less block measured to it
+        "function f()\n    return\nend",
+        "while c\n    return\nend",
+        "function f()\n    return\n    g()\nend",
+        # multi-`for` generators nest inverted under :flatten wrappers
+        "[x for x in xs for y in x]",
+        "[x for a in as for b in bs for c in cs]",
+        "(x for a in as for b in bs)",
+        "[x for a in as, b in bs for c in cs]",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end
@@ -233,6 +248,12 @@ end
     # `;` width must land somewhere even under parent forms whose oracle
     # layout isn't implemented yet — sums have to stay balanced regardless
     for src in ["(; a=1)", "f.(x; y=1)", "@m(x; y=1)", "T{a; b}"]
+        @test CSTConversion.check_spans(CSTConversion.build_cst(src)) === nothing
+    end
+
+    # matrix literals: bare cells carry empty (not nothing) args/trivia with
+    # real width — check_spans must not demand a childsum there
+    for src in ["[1 2; 3 4]", "[1; 2;; 3; 4]"]
         @test CSTConversion.check_spans(CSTConversion.build_cst(src)) === nothing
     end
 

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -440,6 +440,13 @@ end
         "@m;x",
         "begin @m; x end",
         ":(@_inline_meta; det(x))",
+        # quoted dotted operator fuses to one OPERATOR
+        ":.&",
+        ":.+",
+        # -/!/~ operator defs keep a directly-parenthesized operand as brackets
+        "macro -(ex)\nend",
+        "macro ~(ex)\nend",
+        "function -(x) end",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -510,6 +510,9 @@ end
         "try\nx\ncatch\ny\nelse\nz\nend",
         "try\nf()\ncatch\nfinally\nend",
         "try\nf()\ncatch E\nfinally\nend",
+        # global-const with a multi-line RHS: span measured to the last arg
+        "global const x = if a\nb\nend",
+        "const global pkgio = verbose ? y : z",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -80,3 +80,22 @@ end
         @test CSTConversion.oracle_diff(src) === nothing
     end
 end
+
+@testitem "cst-conv: span invariants and corpus smoke" begin
+    using JuliaWorkspaces: CSTConversion
+    include(joinpath(@__DIR__, "cst_corpus.jl"))
+
+    # invariants hold on converter output for valid and broken code
+    for src in ["f(x) = x + 1", "function f(", "a +", ""]
+        ex = CSTConversion.build_cst(src)
+        @test ex.fullspan == sizeof(src)
+        @test CSTConversion.check_spans(ex) === nothing
+    end
+
+    # corpus runner runs end to end on this package's own test file
+    report = joinpath(mktempdir(), "report.md")
+    stats = CSTCorpus.run_corpus([@__FILE__]; report_path=report)
+    @test stats.total == 1
+    @test stats.errored == 0
+    @test isfile(report)
+end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -234,6 +234,51 @@ end
     end
 end
 
+@testitem "cst-conv: strings and operators via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "\"a\$b c\"",            # interpolation: CSTParser splits chunks differently
+        "\"a\$(b + c)d\"",
+        "\"\"\"\ntriple \$x\n\"\"\"",
+        "`cmd \$x`",
+        "```\ncmd\n```",
+        "raw\"no \$interp\"",
+        "'\\n'",
+        "\"esc\\\"aped\"",
+        "-x",                    # unary call
+        "!x",
+        "+x",
+        "x'",                    # postfix adjoint
+        "x''",
+        "a .+ b",                # broadcast infix
+        ".!x",
+        "a && b",
+        "a || b && c",
+        "a <: B",
+        "a >: B",
+        "a === b",
+        "x...",
+        "&x",
+        "::Int",
+        "2x",                    # juxtaposition
+        "2(x + 1)",
+        "a = b = c",             # right-assoc chained assignment
+        "a += 1",
+        "a .= b",
+        "x = \"\"\"\n a\n\"\"\"",
+        # inherited concerns
+        "\"a\\\n b\"",           # line continuation: multi-chunk string
+        "m`c`",                  # cmd macro
+        "a && return",
+        "A.@m x",                # dotted macrocall
+        "@m.n x",                # qualified macrocall name
+        "a < b < c",             # comparison chain
+        "{a, b}",                # standalone braces
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+
 @testitem "cst-conv: span invariants and corpus smoke" begin
     using JuliaWorkspaces: CSTConversion
     include(joinpath(@__DIR__, "cst_corpus.jl"))

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -645,6 +645,15 @@ end
         "macro m()\n",
         "begin\nfor i in xs\n",
         "module M\nwhile c\n",
+        # trailing trivia folded into a dropped error marker must not
+        # materialize as a width-bearing filler arg (ternary arity break)
+        "a ? b\n",
+        "a ? b \n",
+        "x = a ? b\n",
+        "a ? b :\n",
+        "if a \n",
+        "struct \n",
+        "while true \n",
         # truncated triple-quoted docstrings: error kids inside a K"string"
         # node must extend the content run, not double as close quotes
         # (overlapping-chunk childsum bug found by a depot prefix sweep)
@@ -724,7 +733,8 @@ end
     # An unterminated for/while/try leaked an errortoken into args, breaking
     # CSTParser's iterate protocol; StaticLint's include walker then threw a
     # BoundsError and killed diagnostics for the whole workspace.
-    for src in ["for i in 1:10\n", "while true\n", "try\nfoo(\n", "function f()\n"]
+    for src in ["for i in 1:10\n", "while true\n", "try\nfoo(\n", "function f()\n",
+                "a ? b\n"]
         jw = JuliaWorkspace()
         add_file!(jw, TextFile(URI("file:///a.jl"), SourceText(src, "julia")))
         @test (get_diagnostics_blocking(jw); true)

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -513,6 +513,9 @@ end
         # global-const with a multi-line RHS: span measured to the last arg
         "global const x = if a\nb\nend",
         "const global pkgio = verbose ? y : z",
+        # inherited deferred: bare return + explicit `;` in begin/do blocks
+        "begin return; end",
+        "f(x) do y; return; end",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -55,7 +55,8 @@ end
 @testitem "cst-conv: terminals via oracle" begin
     using JuliaWorkspaces: CSTConversion
     for src in ["x", "1", "1.5", "0x1f", "0b101", "0o17", "true", "false",
-                "'a'", "\"str\"", "x ", "  x", "# only a comment", ""]
+                "'a'", "\"str\"", "\"a\\nb\"", "\"\\t\"", "\"\\\\\"", "\"\\\"\"",
+                "x ", "  x", "# only a comment", ""]
         @test CSTConversion.oracle_diff(src) === nothing
     end
 end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -27,9 +27,10 @@ end
     end
 
     # "x + 1" → tokens x,+,1 ; ws folded into preceding token's fullspan
+    # (the infix `+` leaf reclassifies to Identifier in JuliaSyntax 1.x)
     ls, leading = leaves_of("x + 1")
     @test leading == 0
-    @test [l.kind for l in ls] == [K"Identifier", K"+", K"Integer"]
+    @test [l.kind for l in ls] == [K"Identifier", K"Identifier", K"Integer"]
     @test [l.pos for l in ls] == [1, 3, 5]
     @test [l.span for l in ls] == [1, 1, 1]
     @test [l.fullspan for l in ls] == [2, 2, 1]

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -127,6 +127,42 @@ end
     end
 end
 
+@testitem "cst-conv: call syntax via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "f(x; y=1)",             # parameters node
+        "f(x, y=1; z=2, w)",
+        "f(x...)",
+        "f(; x)",
+        "f.(x)",                 # dotcall
+        "a.b",                   # getfield with quotenode
+        "a.b.c",
+        "a.:b",
+        "A{T}",                  # curly
+        "A{T} where T",
+        "a[1]",                  # ref
+        "a[1, 2]",
+        "a[end]",
+        "@m x y",                # macrocall
+        "@m(x)",
+        "m\"str\"",              # string macro
+        "f(x) do y\n    y\nend", # do
+        "g(f, xs) do y; y; end",
+        "x |> f",
+        "a ∘ b",
+        "f(g(x))",
+        "(f)(x)",
+        # inherited from Task 6 concerns: parameters under non-call parents
+        "f.(x; y=1)",
+        "@m(x; y=1)",
+        "T{a; b}",
+        "f(a; b...)",
+        "f(::Int)",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+
 @testitem "cst-conv: span invariants and corpus smoke" begin
     using JuliaWorkspaces: CSTConversion
     include(joinpath(@__DIR__, "cst_corpus.jl"))

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -504,6 +504,9 @@ end
         "quote try; f(); catch; false; finally; end; end",
         # triple-string leading chunk with content (dedented to "") stays an arg
         "\"\"\"\n\$(a)\nb\"\"\"",
+        # empty catch body + else clause → degenerate catch block (args nothing, val "")
+        "try\ncatch\nelse\nend",
+        "try\nx\ncatch\ny\nelse\nz\nend",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -1,0 +1,15 @@
+@testitem "cst-conv: tree diff basics" begin
+    using CSTParser
+    using JuliaWorkspaces: CSTConversion
+
+    a = CSTParser.parse("f(x) = x + 1", true)
+    b = CSTParser.parse("f(x) = x + 1", true)
+    c = CSTParser.parse("f(x) = x + 2", true)
+    d = CSTParser.parse("f(x) = x +  1", true)   # same tree, different trivia width
+
+    @test CSTConversion.trees_equal(a, b)
+    @test CSTConversion.first_tree_diff(a, b) === nothing
+    @test !CSTConversion.trees_equal(a, c)
+    @test CSTConversion.first_tree_diff(a, c) isa String
+    @test !CSTConversion.trees_equal(a, d)      # fullspans must be compared
+end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -292,6 +292,118 @@ end
     end
 end
 
+@testitem "cst-conv: imports and docstrings via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        "using A",
+        "using A, B",
+        "using A: x, y",
+        "using A.B.C",
+        "import A",
+        "import A as B",
+        "import A: x as y",
+        "import ..A",
+        "export a, b",
+        "\"\"\"\ndoc\n\"\"\"\nf(x) = x",
+        "\"doc\"\nmodule A end",
+        "@doc \"x\" f",
+        "quote\nx\nend",
+        ":(x + y)",
+        ":x",
+        "\$x",
+        "\$(x)",
+        "x where {T, S}",
+        "GC.@preserve a f(a)",
+        "if VERSION > v\"1.6\" end",
+        # more import/export shapes found in the corpus
+        "import A.@m",
+        "import A.B.@m",
+        "using A: @m",
+        "import Base: +, -",
+        "export @uri_str",
+        "export a, @m",
+        "using A.B: c",
+        # quote-form taxonomy: :quotenode vs :quote vs block form
+        ":foo",
+        ":(x)",
+        ":(if x end)",
+        "quote\nend",
+        "quote\na\nb\nend",
+        # word operators quote as OPERATOR only when colon-prefixed
+        ":where", ":in", ":isa",
+        "p.in", "p.:in", "a.where",
+        # docstring on various targets
+        "\"d\"\nf() = 1",
+        "\"d\"\nstruct A end",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+
+@testitem "cst-conv: containers and burn-down via oracle" begin
+    using JuliaWorkspaces: CSTConversion
+    for src in [
+        # tuple / vect / ref / braces / typed forms carrying keyword-kinded args
+        "(a, :b)",
+        "(a,)",
+        "(;a=1)",
+        "(a=b,)",              # named-tuple field keeps `=` (not `:kw`)
+        "(start=x, stop=y)",
+        "[a, :b]",
+        "a[i, :b]",
+        "a[end]",
+        "{a, :b}",
+        "T[x for x in xs]",
+        "T[1 2]",
+        "T[1;2]",
+        "T[1 2; 3 4]",
+        "T[1;;2]",
+        "a[i; j]",
+        "for Typ in (:Ldiv, :Rdiv)\nend",
+        # composite matrix cells get empty (not nothing) trivia
+        "[\"a\" => 1\n\"b\" => 2]",
+        "[a -b]",
+        "[a -b; -c -d]",
+        "[a+b c]",
+        "[f(x) c]",
+        # dotted comparison chains fuse `.`+op into one OPERATOR
+        "a .== b .== c",
+        "a .=== b",
+        # var\"...\" nonstandard identifiers
+        "var\"foo\"",
+        "var\"@x\"",
+        "esc(var\"@m\")",
+        # macro args keep `=` as assignment, never `:kw`
+        "Base.@propagate_inbounds f() = 1",
+        "@m a=1",
+        "@m f()=1",
+        # nested where clauses (kind-reuse trap)
+        "f() where {T} where {N} = x",
+        # global/local/const with multiple comma-separated names
+        "local a, b",
+        "global a, b",
+        "local pipe, fork, dup2",
+        # bare `return` in a short-circuit grows the operator/block span
+        "c && return",
+        "function f()\nc && return\nend",
+        "a && b",
+        # file-level and toplevel `;` bookkeeping
+        "x = 1;",
+        "1;",
+        ";;",
+        "f();",
+        "return\n",
+        # empty-body elseif measures span to its (empty) block
+        "if r isa X\nelseif r isa Y\nend",
+        # qualified macrocall with parens has span == fullspan
+        "x = M.@m(a)\ny",
+        "if a\nb = M.@m(\"v\")\nend",
+        "x = M.@m(a) + z",
+    ]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+
 @testitem "cst-conv: span invariants and corpus smoke" begin
     using JuliaWorkspaces: CSTConversion
     include(joinpath(@__DIR__, "cst_corpus.jl"))

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -502,6 +502,8 @@ end
         # one-line `try; ...; end;` in a quote: the trailing `;` after END is
         # excluded from the try's span (END-terminated)
         "quote try; f(); catch; false; finally; end; end",
+        # triple-string leading chunk with content (dedented to "") stays an arg
+        "\"\"\"\n\$(a)\nb\"\"\"",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -158,6 +158,15 @@ end
         "T{a; b}",
         "f(a; b...)",
         "f(::Int)",
+        # consecutive `;`: widths of ALL adjacent separators fold onto the
+        # last real preceding leaf (BEGIN itself when nothing else precedes)
+        "begin a;; b end",
+        "begin ;; end",
+        "a;; b",
+        # bare extra `;` in an arg list: the empty group collapses away
+        # (a single empty group survives only when all groups are empty)
+        "f(a;;b)",
+        "f(;;)",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -478,6 +478,10 @@ end
         # `;`-fold onto a qualified macrocall inside a paren-block
         "(Base.@m; x)",
         "(Base.@_inline_meta; f(x))",
+        # a lone bare cell in a multi-row matrix still gets the cell quirk
+        "[1 2; 3]",
+        "Float64[1 2; 3]",
+        "T[1 2; 3]",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -490,6 +490,13 @@ end
         "f(x .= y)",
         "Matrix(C .= 2.0 .* A) ≈ B ≈ D",
         "@m(a .= b)",
+        # quoted dotted compound assignment fuses to an OPERATOR atom
+        ":(.+=)",
+        ":(.*=)",
+        # parenthesized signature is a function def (block-wrapped body)
+        "(f(x)) = y",
+        "(f(x) where T) = y",
+        "(x) = y",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -274,6 +274,19 @@ end
         "@m.n x",                # qualified macrocall name
         "a < b < c",             # comparison chain
         "{a, b}",                # standalone braces
+        # raw-flagged (macro-wrapped) strings skip escape processing except
+        # for halving backslash runs before a quote/chunk-end
+        "r\"\\d+\"",
+        "raw\"a\\nb\"",
+        "b\"\\x00\"",
+        "r\"[/\\\\]+\"",
+        "raw\"tr\\\\\\\\\"",
+        "raw\"a\\\\\\\"b\"",
+        # a BARE string literal as the whole $(...) keeps its :string wrapper
+        "\"\$(\"nested\")\"",
+        "\"pre\$(\"lit\")post\"",
+        "\"\"\"triple \$(\"a\")\"\"\"",
+        "`x \$(\"a\")`",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -426,11 +426,17 @@ end
         # row span with spaces around the `;`
         "[1 2 ; 3 4]",
         "[a b ; c d]",
-        # `begin` as an index literal → BEGIN; as a field/symbol → IDENTIFIER
+        # `begin`/`end` as an index literal → BEGIN/END; as a field/symbol
+        # or quoted name → IDENTIFIER (regression: `.end` was wrongly kept
+        # as the END literal, matched only for `.begin`)
         "a[begin]",
         "a[begin:end]",
         "a.begin",
+        "a.end",
+        "(a).end",
+        "f().end",
         ":begin",
+        ":end",
         # return-type-annotated short function def wraps its body in a block
         "f()::T = a, b",
         "g()::Tuple{Int,Int} = a, b",
@@ -621,4 +627,56 @@ end
         @test ex.fullspan == sizeof(src)
         @test CSTConversion.check_spans(ex) === nothing
     end
+
+    # regression: a module missing its closing `end` entirely (the getfield
+    # completion trigger shape, `module M\nBase.\nend\n`, where the dangling
+    # `Base.` consumes the literal `end` as its field name) must match
+    # CSTParser's own missing-token convention (errortoken wrapping a
+    # zero-width END in trivia[2]), not leak a 4th :module arg — the leak
+    # broke CSTParser's own iterate protocol with a BoundsError downstream.
+    for src in ["module CompDot\nBase.\nend\n", "module A\nBase.\nend\n"]
+        @test CSTConversion.oracle_diff(src) === nothing
+    end
+end
+
+@testitem "cst-conv: single-parse salsa integration" begin
+    using CSTParser, JuliaSyntax
+    using JuliaSyntax: kind, @K_str
+    using JuliaWorkspaces
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, URI
+
+    content = "f(x) = x + 1\n"
+    jw = JuliaWorkspace()
+    uri = URI("file:///a.jl")
+    add_file!(jw, TextFile(uri, SourceText(content, "julia")))
+
+    cst = JuliaWorkspaces.get_legacy_cst(jw, uri)
+    @test cst isa CSTParser.EXPR
+    @test JuliaWorkspaces.CSTConversion.trees_equal(cst, CSTParser.parse(content, true))
+
+    sn = JuliaWorkspaces.get_julia_syntax_tree(jw, uri)
+    @test JuliaWorkspaces.syntax_node_at(sn, 1) isa JuliaSyntax.SyntaxNode
+    @test kind(JuliaWorkspaces.syntax_node_at(sn, 8)) == K"Identifier"  # byte 8 = 'x'
+end
+
+@testitem "cst-conv: deep nesting never throws (enlarged parse stack)" begin
+    using CSTParser
+    using JuliaWorkspaces
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, URI
+
+    # Machine-generated deeply-nested `||` chain: overflows JuliaSyntax's
+    # recursive-descent parser at the default task stack size.
+    n = 50_000
+    content = "x = " * join(fill("a", n), " || ") * "\n"
+
+    jw = JuliaWorkspace()
+    uri = URI("file:///deep.jl")
+    add_file!(jw, TextFile(uri, SourceText(content, "julia")))
+
+    sn = JuliaWorkspaces.get_julia_syntax_tree(jw, uri)
+    @test sn !== nothing
+
+    cst = JuliaWorkspaces.get_legacy_cst(jw, uri)
+    @test cst isa CSTParser.EXPR
+    @test cst.fullspan == sizeof(content)
 end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -482,6 +482,10 @@ end
         "[1 2; 3]",
         "Float64[1 2; 3]",
         "T[1 2; 3]",
+        # do-block with no params: the `;` folds onto the DO keyword
+        "f(x) do; y end",
+        "f(x) do; end",
+        "f(a) do; g(b) do; z end end",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -569,3 +569,45 @@ end
         @test (f, CSTConversion.check_spans(ex)) == (f, nothing)
     end
 end
+
+@testitem "cst-conv: broken code invariants" begin
+    using CSTParser
+    using JuliaWorkspaces: CSTConversion
+
+    walk(x, count) = begin
+        count[] += 1
+        x.args === nothing || foreach(a -> walk(a, count), x.args)
+    end
+
+    for src in [
+        "function f(",
+        "a +",
+        "f(x,",
+        "if a",
+        "struct",
+        "a.b.",
+        "\"unterminated",
+        "x = @",
+        "function f() en",
+        "a ? b",
+        "[1, 2",
+        "module A function g() end",
+    ]
+        ex = CSTConversion.build_cst(src)
+        @test ex isa CSTParser.EXPR
+        @test ex.fullspan == sizeof(src)
+        @test CSTConversion.check_spans(ex) === nothing
+        # error subtrees must be traversable by StaticLint-style recursion
+        count = Ref(0)
+        walk(ex, count)
+        @test count[] > 0
+    end
+
+    # three degenerate whole-file shapes from the divergence log: must
+    # never throw even though they carry no real statement content
+    for src in [";", ";; a", "\"just a docstring\""]
+        ex = CSTConversion.build_cst(src)
+        @test ex.fullspan == sizeof(src)
+        @test CSTConversion.check_spans(ex) === nothing
+    end
+end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -516,6 +516,13 @@ end
         # inherited deferred: bare return + explicit `;` in begin/do blocks
         "begin return; end",
         "f(x) do y; return; end",
+        # qualified-macrocall span quirk propagates through a nesting macrocall
+        "x = @eval M.@m(a)\n\ny",
+        "@eval M.@m(a)\ny",
+        # dotted-operator prefix calls unwrap parens like the non-dotted path
+        ".+(x)",
+        ".+(a,b)",
+        ".!(x)",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -654,6 +654,33 @@ end
         "if a \n",
         "struct \n",
         "while true \n",
+        # juxtaposition errors (`1 x`): the stray error sibling after a body
+        # block must fold into the block, not become an arity-breaking extra
+        # arg of the terminated container
+        "function f() 1 x end",
+        "function f()\n1 x\nend",
+        "begin 1 x end",
+        "if a\n1 x\nend",
+        "if a\n1 x\nelse\nend",
+        "let\n1 x\nend",
+        "let x=1\n1 x\nend",
+        "module M\n1 x\nend",
+        "baremodule M\n1 x\nend",
+        "struct S\n1 x\nend",
+        "mutable struct S\n1 x\nend",
+        "while c\n1 x\nend",
+        "for i in xs\n1 x\nend",
+        "macro m()\n1 x\nend",
+        "quote\n1 x\nend",
+        "try\n1 x\ncatch\nend",
+        "(1 x)",
+        "f(1 x)",
+        "1 x",
+        "1 x\n",
+        # juxtaposition + missing `end` combined
+        "function f()\n1 x\n",
+        "while c\n1 x\n",
+        "if a\n1 x\n",
         # truncated triple-quoted docstrings: error kids inside a K"string"
         # node must extend the content run, not double as close quotes
         # (overlapping-chunk childsum bug found by a depot prefix sweep)
@@ -734,7 +761,7 @@ end
     # CSTParser's iterate protocol; StaticLint's include walker then threw a
     # BoundsError and killed diagnostics for the whole workspace.
     for src in ["for i in 1:10\n", "while true\n", "try\nfoo(\n", "function f()\n",
-                "a ? b\n"]
+                "a ? b\n", "function f() 1 x end"]
         jw = JuliaWorkspace()
         add_file!(jw, TextFile(URI("file:///a.jl"), SourceText(src, "julia")))
         @test (get_diagnostics_blocking(jw); true)

--- a/test/test_cst_conversion.jl
+++ b/test/test_cst_conversion.jl
@@ -497,6 +497,11 @@ end
         "(f(x)) = y",
         "(f(x) where T) = y",
         "(x) = y",
+        # var\"...\" as a module name keeps EXPR[] trivia
+        "module var\"#I\"\nend",
+        # one-line `try; ...; end;` in a quote: the trailing `;` after END is
+        # excluded from the try's span (END-terminated)
+        "quote try; f(); catch; false; finally; end; end",
     ]
         @test CSTConversion.oracle_diff(src) === nothing
     end


### PR DESCRIPTION
This is basically just Fable doing its thing. Haven't reviewed any of this in-depth, but generally seems to be sensible. This should allow for a gradual cutover of the static analysis passes to pure JuliaSyntax trees (presumably just the green tree?).