### PR TITLE
fix: don't hoist shadowing params into enclosing scopes

### DIFF
--- a/src/StaticLint/bindings.jl
+++ b/src/StaticLint/bindings.jl
@@ -391,10 +391,13 @@ function add_binding(x, state, scope=state.scope)
             scope.names[name] = b
         elseif is_soft_scope(scope) && parentof(scope) isa Scope && isidentifier(b.name) && scopehasbinding(parentof(scope), valofid(b.name)) && !enforce_hard_scope(x, scope)
             add_binding(x, state, scope.parent)
-        elseif isidentifier(b.name) && !enforce_hard_scope(x, scope) &&
+        elseif isidentifier(b.name) && b.val isa EXPR && CSTParser.isassignment(b.val) &&
+                !enforce_hard_scope(x, scope) &&
                 (outer_scope = enclosing_local_binding_scope(scope, valofid(b.name))) !== nothing
             # Assigning to a name already local in an enclosing local scope
             # (let block / closure) reassigns it rather than introducing a new local.
+            # Only plain assignments qualify: function params (args, kwargs, where
+            # params) always introduce fresh locals in their own scope.
             add_binding(x, state, outer_scope)
         else
             scope.names[name] = b
@@ -416,6 +419,8 @@ end
 function enclosing_local_binding_scope(scope, name::String)
     p = parentof(scope)
     while p isa Scope && !is_toplevel_scope(p)
+        # inner constructor bodies don't close over the struct scope
+        CSTParser.defines_struct(p.expr) && return nothing
         scopehasbinding(p, name) && return p
         p = parentof(p)
     end

--- a/src/layer_completions.jl
+++ b/src/layer_completions.jl
@@ -678,6 +678,29 @@ function _is_rebinding_of_module(x, meta_dict)
     CSTParser.defines_module(StaticLint.refof(StaticLint.refof(x, meta_dict).val.args[2], meta_dict).val)
 end
 
+# Field names of a workspace struct definition, mirroring the field-marking
+# logic in `mark_bindings!`: skips inner constructors, unwraps `const` and
+# @kwdef defaults.
+function _struct_field_names(x::CSTParser.EXPR)
+    names = String[]
+    for arg in x.args[3].args
+        CSTParser.defines_function(arg) && continue
+        if CSTParser.headof(arg) === :const
+            arg = arg.args[1]
+        end
+        if CSTParser.isassignment(arg)
+            arg = arg.args[1]
+        end
+        if CSTParser.isdeclaration(arg)
+            arg = arg.args[1]
+        end
+        if CSTParser.isidentifier(arg) && CSTParser.valof(arg) isa String
+            push!(names, CSTParser.valof(arg))
+        end
+    end
+    return names
+end
+
 function _get_dot_completion(px, spartial, state::_CompletionState) end
 function _get_dot_completion(px::CSTParser.EXPR, spartial, state::_CompletionState)
     px === nothing && return
@@ -707,8 +730,16 @@ function _get_dot_completion(px::CSTParser.EXPR, spartial, state::_CompletionSta
                         _texteditfor(state, spartial, a)))
                 end
             end
-        elseif r.type isa StaticLint.Binding && r.type.val isa CSTParser.EXPR && CSTParser.defines_struct(r.type.val) && StaticLint.scopeof(r.type.val, state.meta_dict) isa StaticLint.Scope
-            _collect_completions(StaticLint.scopeof(r.type.val, state.meta_dict), spartial, state, true)
+        elseif r.type isa StaticLint.Binding && r.type.val isa CSTParser.EXPR && CSTParser.defines_struct(r.type.val)
+            # only the fields: the struct scope also holds type params and
+            # inner constructor names
+            for a in _struct_field_names(r.type.val)
+                if is_completion_match(a, spartial)
+                    _add_completion_item(state, CompletionResultItem(
+                        a, CompletionKinds.Field, nothing, a,
+                        _texteditfor(state, spartial, a)))
+                end
+            end
         end
     elseif r isa SymbolServer.ModuleStore
         _collect_completions(r, spartial, state, true)

--- a/src/layer_completions.jl
+++ b/src/layer_completions.jl
@@ -1027,10 +1027,12 @@ function _get_completions(rt, uri, offset, completion_mode, workspace)
     elseif state.x isa CSTParser.EXPR && _is_in_import_statement(state.x) || _relative_dot_depth_at(st.content, offset) > 0
         _import_completions(ppt, pt, t, is_at_end, state.x, state)
     elseif t isa CSTParser.Tokens.Token && t.kind == Tokens.DOT && pt isa CSTParser.Tokens.Token && pt.kind == Tokens.IDENTIFIER
-        px = _get_expr(cst, offset - (1 + t.endbyte - t.startbyte))
+        px = _get_expr(cst, t.startbyte)
         _get_dot_completion(px, "", state)
     elseif t isa CSTParser.Tokens.Token && t.kind == Tokens.IDENTIFIER && pt isa CSTParser.Tokens.Token && pt.kind == Tokens.DOT && ppt isa CSTParser.Tokens.Token && ppt.kind == Tokens.IDENTIFIER
-        px = _get_expr(cst, offset - (1 + t.endbyte - t.startbyte) - (1 + pt.endbyte - pt.startbyte))
+        # anchor on the dot token, not the cursor: with the cursor mid-token,
+        # subtracting whole token lengths from `offset` overshoots to the left
+        px = _get_expr(cst, pt.startbyte)
         _get_dot_completion(px, t.val, state)
     elseif t isa CSTParser.Tokens.Token && t.kind == Tokens.IDENTIFIER
         if is_at_end && state.x !== nothing

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -2776,6 +2776,103 @@ end
         end""")
 end
 
+@testitem "function params don't rebind enclosing scope names" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, scopeof, InvalidRedefofConst
+    using JuliaWorkspaces.CSTParser: isassignment, EXPR
+
+    function const_redefs(src)
+        cst, meta_dict, jw = parse_and_pass(src)
+        [x for (_, x) in collect_hints(cst, meta_dict, jw) if errorof(x, meta_dict) === InvalidRedefofConst]
+    end
+
+    # Inner constructor args and where-params are new locals, not rebindings
+    # of the fields/type params they shadow.
+    @test isempty(const_redefs("""
+        mutable struct Foo{T}
+            const val1::Int
+            val2::T
+            Foo(val1::Integer, val2::T) where T = new{T}(Int(val1), val2)
+            Foo{T}(val1::Integer, val2::T) where T = new{T}(Int(val1), val2)
+            Bar{V}(val1::Integer, val2::V) where V = new{V}(2 * Int(val1), val2)
+            Bar{T}(val1::Integer, val2::T) where T = new{T}(Int(val1), val2)
+        end"""))
+
+    # Assignments in a constructor body don't reach the struct scope either.
+    @test isempty(const_redefs("""
+        mutable struct Baz
+            const val::Int
+            Baz() = (val = 3; new(val))
+        end"""))
+
+    # A shadowing binding stays local to its own scope: `x` in f's scope must
+    # still be the `x = 1` binding afterwards, not the shadowing binding.
+    function outer_x_intact(src)
+        cst, meta_dict, jw = parse_and_pass(src)
+        b = scopeof(cst.args[1], meta_dict).names["x"]
+        b.val isa EXPR && isassignment(b.val)
+    end
+
+    # closure arg
+    @test outer_x_intact("""
+        function f()
+            x = 1
+            g(x::Int) = x + 1
+            return g(x)
+        end""")
+
+    # kwarg default
+    @test outer_x_intact("""
+        function f()
+            x = 1
+            g(; x = 2) = x
+            return g() + x
+        end""")
+
+    # do-block arg
+    @test outer_x_intact("""
+        function f()
+            x = 1
+            map([1]) do x
+                x + 1
+            end
+            return x
+        end""")
+
+    # anonymous function arg
+    @test outer_x_intact("""
+        function f()
+            x = 1
+            g = x -> x + 1
+            return g(x)
+        end""")
+
+    # destructured arg
+    @test outer_x_intact("""
+        function f()
+            x = 1
+            g((x, y)) = x + y
+            return g((1, 2)) + x
+        end""")
+
+    # generator variable
+    @test outer_x_intact("""
+        function f()
+            x = 1
+            ys = [x^2 for x in 1:3]
+            return ys .+ x
+        end""")
+
+    # `let` with its own binding in the head
+    @test outer_x_intact("""
+        function f()
+            x = 1
+            let x = 2
+                @info x
+            end
+            return x
+        end""")
+end
+
 @testitem "@nospecialize without argument (#390)" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: func_nargs
     using JuliaWorkspaces.CSTParser: parse, EXPR

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -198,6 +198,35 @@ end
     @test any(item -> item.label == "rand", result.items)
 end
 
+@testitem "Completions: getfield completions for workspace structs" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_completions
+    using JuliaWorkspaces.URIs2: URI
+
+    source = """
+    mutable struct Foo{T}
+        const val1::Int
+        val2::T
+        Foo(val1::Integer, val2::T) where T = new{T}(Int(val1), val2)
+        Foo{T}(val1::Integer, val2::T) where T = new{T}(Int(val1), val2)
+        Bar{V}(val1::Integer, val2::V) where V = new{V}(2 * Int(val1), val2)
+        Bar{T}(val1::Integer, val2::T) where T = new{T}(Int(val1), val2)
+    end
+    x = Foo(1, 2)
+    x.
+    """
+
+    uri = URI("file:///compfield/test.jl")
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+
+    # right after "x."
+    index = findfirst("\nx.\n", source)[end]
+    result = get_completions(jw, uri, index)
+
+    # only the fields, not type params or inner constructor names
+    @test sort([item.label for item in result.items]) == ["val1", "val2"]
+end
+
 @testitem "Completions: token completions" begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_completions
     using JuliaWorkspaces.URIs2: URI

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -225,6 +225,18 @@ end
 
     # only the fields, not type params or inner constructor names
     @test sort([item.label for item in result.items]) == ["val1", "val2"]
+
+    # partial field: cursor at the end and in the middle of "va"
+    source2 = replace(source, "x.\n" => "x.va\n")
+    uri2 = URI("file:///compfield/test2.jl")
+    jw2 = JuliaWorkspace()
+    add_file!(jw2, TextFile(uri2, SourceText(source2, "julia")))
+
+    index_mid = findfirst("x.va", source2)[end]  # between "v" and "a"
+    for index in (index_mid, index_mid + 1)
+        result2 = get_completions(jw2, uri2, index)
+        @test sort([item.label for item in result2.items]) == ["val1", "val2"]
+    end
 end
 
 @testitem "Completions: token completions" begin


### PR DESCRIPTION
The enclosing-local reassignment logic from the StaticLint.jl#427 port hoisted every binding whose name exists in an enclosing local scope, not just assignments. Function params (args, kwargs, where params, do-block and anonymous-function args, destructured args) always introduce fresh locals, so hoisting them clobbered the enclosing binding — inner constructor args/where-params shadowing struct fields/type params were falsely flagged InvalidRedefofConst.

Restrict the hoist to plain assignment bindings, and stop the enclosing- scope walk at struct scopes since constructor bodies don't close over fields or type params.

Adds a regression testitem (9 cases).

Fixes https://github.com/julia-vscode/JuliaWorkspaces.jl/issues/122.