### PR TITLE
fix: handle non-standard var"..." identifiers across language features

### DIFF
--- a/src/StaticLint/bindings.jl
+++ b/src/StaticLint/bindings.jl
@@ -146,13 +146,16 @@ function mark_binding!(x::EXPR, meta_dict, val=x)
     return x
 end
 
+# valofid also covers var"..." parameter names, where valof is nothing
+_param_name(b) = b isa Binding && b.name isa EXPR && isidentifier(b.name) ? valofid(b.name) : nothing
+
 function mark_parameters(sig::EXPR, meta_dict, params = String[])
     if CSTParser.issubtypedecl(sig)
         mark_parameters(sig.args[1], meta_dict, params)
     elseif iswhere(sig)
         for i = 2:length(sig.args)
             x = mark_binding!(sig.args[i], meta_dict)
-            val = valof(bindingof(x, meta_dict).name)
+            val = _param_name(bindingof(x, meta_dict))
             if val isa String
                 push!(params, val)
             end
@@ -161,7 +164,7 @@ function mark_parameters(sig::EXPR, meta_dict, params = String[])
     elseif CSTParser.iscurly(sig)
         for i = 2:length(sig.args)
             x = mark_binding!(sig.args[i], meta_dict)
-            if bindingof(x, meta_dict) isa Binding && valof(bindingof(x, meta_dict).name) in params
+            if bindingof(x, meta_dict) isa Binding && _param_name(bindingof(x, meta_dict)) in params
                 # Don't mark a new binding if a parameter has already been
                 # introduced from a :where
                 getmeta(x, meta_dict).binding = nothing

--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -661,9 +661,14 @@ end
 function check_modulename(x::EXPR, meta_dict)
     if CSTParser.defines_module(x) && # x is a module
         scopeof(x, meta_dict) isa Scope && parentof(scopeof(x, meta_dict)) isa Scope && # it has a scope and a parent scope
-        CSTParser.defines_module(parentof(scopeof(x, meta_dict)).expr) && # the parent scope is a module
-        valof(CSTParser.get_name(x)) == valof(CSTParser.get_name(parentof(scopeof(x, meta_dict)).expr)) # their names match
-        seterror!(CSTParser.get_name(x), InvalidModuleName, meta_dict)
+        CSTParser.defines_module(parentof(scopeof(x, meta_dict)).expr) # the parent scope is a module
+        # valofid also covers var"..." names, where valof is nothing (and
+        # would spuriously compare equal for two distinct var"..." names)
+        name = _module_name_or_nothing(CSTParser.get_name(x))
+        parent_name = _module_name_or_nothing(CSTParser.get_name(parentof(scopeof(x, meta_dict)).expr))
+        if name !== nothing && name == parent_name # their names match
+            seterror!(CSTParser.get_name(x), InvalidModuleName, meta_dict)
+        end
     end
 end
 
@@ -714,11 +719,12 @@ function check_farg_unused_(arg, arg_names, meta_dict)
         seterror!(arg, UnusedFunctionArgument, meta_dict)
     end
 
-    if valof(b.name) === nothing
-    elseif valof(b.name) in arg_names
+    argname = b.name isa EXPR && isidentifier(b.name) ? valofid(b.name) : valof(b.name)
+    if argname === nothing
+    elseif argname in arg_names
         seterror!(arg, DuplicateFuncArgName, meta_dict)
     else
-        push!(arg_names, valof(b.name))
+        push!(arg_names, argname)
     end
     true
 end
@@ -854,8 +860,8 @@ function try_resolve_getfield_ref!(x, env, workspace_packages, meta_dict)
             lhsref = get_root_method(lhsref)
             if lhsref isa Binding && lhsref.type isa Binding && lhsref.type.val isa EXPR && CSTParser.defines_struct(lhsref.type.val) && !has_getproperty_method(lhsref.type)
                 # We may have infered the lhs type after the semantic pass that was resolving references. Copied from `resolve_getfield(x::EXPR, parent_type::EXPR, state::TraverseState)::Bool`.
-                if scopehasbinding(scopeof(lhsref.type.val, meta_dict), valof(x))
-                    setref!(x, scopeof(lhsref.type.val, meta_dict).names[valof(x)], meta_dict)
+                if scopehasbinding(scopeof(lhsref.type.val, meta_dict), valofid(x))
+                    setref!(x, scopeof(lhsref.type.val, meta_dict).names[valofid(x)], meta_dict)
                 end
             end
         end
@@ -885,7 +891,7 @@ function should_mark_missing_getfield_ref(x, env, workspace_packages, meta_dict)
                 return true
             elseif lhsref.type isa Binding && lhsref.type.val isa EXPR && CSTParser.defines_struct(lhsref.type.val) && !has_getproperty_method(lhsref.type)
                 # We may have infered the lhs type after the semantic pass that was resolving references.
-                return !scopehasbinding(scopeof(lhsref.type.val, meta_dict), valof(x))
+                return !scopehasbinding(scopeof(lhsref.type.val, meta_dict), valofid(x))
             end
         end
     end
@@ -1217,9 +1223,12 @@ function is_overwritten_in_loop(x, meta_dict)
     if loop !== nothing
         s = scopeof(loop, meta_dict)
         if s isa Scope && parentof(s) isa Scope
-            s2 = check_parent_scopes_for(s, valof(x))
+            # valofid also covers var"..." names, where valof is nothing
+            xname = isidentifier(x) ? valofid(x) : valof(x)
+            xname === nothing && return false
+            s2 = check_parent_scopes_for(s, xname)
             if s2 isa Scope
-                prev_binding = parentof(s2).names[valof(x)]
+                prev_binding = parentof(s2).names[xname]
                 if prev_binding isa Binding
                     return true
                     # s = ComesBefore(prev_binding.name, s2.expr, 0)
@@ -1288,8 +1297,10 @@ function check_parent_scopes_for(s::Scope, name)
 end
 
 function is_overwritten_subsequently(b::Binding, scope::Scope, meta_dict)
-    valof(b.name) === nothing && return false
-    s = BoundAfter(b.name, valof(b.name), 0, meta_dict)
+    # valofid also covers var"..." names, where valof is nothing
+    bname = b.name isa EXPR && isidentifier(b.name) ? valofid(b.name) : valof(b.name)
+    bname === nothing && return false
+    s = BoundAfter(b.name, bname, 0, meta_dict)
     traverse(scope.expr, s)
     return s.result == 2
 end

--- a/src/StaticLint/macros.jl
+++ b/src/StaticLint/macros.jl
@@ -390,7 +390,7 @@ function _parse_testitem_kwargs(x::EXPR)
                 if kwval isa EXPR && headof(kwval) === :vect && kwval.args !== nothing
                     for s in kwval.args
                         if isidentifier(s)
-                            push!(setup_names, Symbol(valof(s)))
+                            push!(setup_names, Symbol(valofid(s)))
                         end
                     end
                 end
@@ -513,7 +513,9 @@ function _handle_testmodule(x::EXPR, state::Toplevel)
     body === nothing && return
     !isidentifier(name_expr) && return
 
-    mod_name = valof(name_expr)
+    # valofid also covers var"..." names, where valof is nothing
+    mod_name = valofid(name_expr)
+    mod_name isa String || return
 
     # Create a module-like scope
     setscope!(x, Scope(x), meta_dict)

--- a/src/StaticLint/references.jl
+++ b/src/StaticLint/references.jl
@@ -146,18 +146,18 @@ function resolve_ref_from_module(x1::EXPR, m::SymbolServer.ModuleStore, state::T
             return true
         end
 
-        mn = Symbol(valof(x))
+        mn = Symbol(valofid(x))
         if isexportedby(mn, m)
             setref!(x, maybe_lookup(m[mn], state), meta_dict)
             return true
         end
     elseif isidentifier(x1)
         x = x1
-        if Symbol(valof(x)) == m.name.name
+        if Symbol(valofid(x)) == m.name.name
             setref!(x, m, meta_dict)
             return true
         elseif isexportedby(x, m)
-            setref!(x, maybe_lookup(m[Symbol(valof(x))], state), meta_dict)
+            setref!(x, maybe_lookup(m[Symbol(valofid(x))], state), meta_dict)
             return true
         end
     end
@@ -174,7 +174,7 @@ function resolve_ref_from_module(x::EXPR, scope::Scope, state::TraverseState)::B
     # 1) If the scope is a module, allow resolving the module name itself
     if CSTParser.defines_module(scope.expr)
         n = CSTParser.get_name(scope.expr)
-        if CSTParser.isidentifier(n) && mn == CSTParser.valof(n)
+        if CSTParser.isidentifier(n) && mn == valofid(n)
             b = bindingof(scope.expr, meta_dict)  # module’s binding
             if b isa Binding
                 setref!(x, b, meta_dict)
@@ -221,7 +221,7 @@ function initial_pass_on_exports(x::EXPR, name, state)
     for a in x.args[3] # module block expressions
         if headof(a) === :export
             for i = 1:length(a.args)
-                if isidentifier(a.args[i]) && valof(a.args[i]) == name && !hasref(a.args[i], meta_dict)
+                if isidentifier(a.args[i]) && valofid(a.args[i]) == name && !hasref(a.args[i], meta_dict)
                     process_EXPR(a.args[i], Delayed(scopeof(x, meta_dict), state.env, state.workspace_packages, meta_dict))
                 end
             end
@@ -324,8 +324,8 @@ function resolve_getfield(x::EXPR, m::SymbolServer.ModuleStore, state::TraverseS
         #     return true
         # end
         vr = val.name isa SymbolServer.FakeTypeName ? val.name.name : val.name
-        if haskey(tls.names, valof(x)) && tls.names[valof(x)] isa Binding && tls.names[valof(x)].val isa SymbolServer.FunctionStore
-            setref!(x, tls.names[valof(x)], meta_dict)
+        if haskey(tls.names, valofid(x)) && tls.names[valofid(x)] isa Binding && tls.names[valofid(x)].val isa SymbolServer.FunctionStore
+            setref!(x, tls.names[valofid(x)], meta_dict)
             return true
         elseif tls.overloaded !== nothing && haskey(tls.overloaded, vr)
             setref!(x, tls.overloaded[vr], meta_dict)
@@ -341,8 +341,8 @@ function resolve_getfield(x::EXPR, parent::SymbolServer.DataTypeStore, state::Tr
     meta_dict = state.meta_dict
     hasref(x, meta_dict) && return true
     resolved = false
-    if isidentifier(x) && Symbol(valof(x)) in parent.fieldnames
-        fi = findfirst(f -> Symbol(valof(x)) == f, parent.fieldnames)
+    if isidentifier(x) && Symbol(valofid(x)) in parent.fieldnames
+        fi = findfirst(f -> Symbol(valofid(x)) == f, parent.fieldnames)
         ft = parent.types[fi]
         val = SymbolServer._lookup(ft, getsymbols(state), true)
         # TODO: Need to handle the case where we get back a FakeUnion, etc.

--- a/src/StaticLint/scope.jl
+++ b/src/StaticLint/scope.jl
@@ -47,8 +47,12 @@ end
 # type. It is typed to exclude `Symbol`, keeping these distinct from the
 # `(s, m, mname::Symbol)` storage method above.
 addmoduletoscope!(s::Scope, m::SymbolServer.ModuleStore, meta_dict::Union{Nothing,AbstractDict}=nothing) = addmoduletoscope!(s, m, m.name.name)
-addmoduletoscope!(s::Scope, m::EXPR, meta_dict::AbstractDict) = CSTParser.defines_module(m) && addmoduletoscope!(s, scopeof(m, meta_dict), Symbol(valof(CSTParser.get_name(m))))
-addmoduletoscope!(s::Scope, s1::Scope, meta_dict::Union{Nothing,AbstractDict}=nothing) = CSTParser.defines_module(s1.expr) && addmoduletoscope!(s, s1, Symbol(valof(CSTParser.get_name(s1.expr))))
+addmoduletoscope!(s::Scope, m::EXPR, meta_dict::AbstractDict) = CSTParser.defines_module(m) && addmoduletoscope!(s, scopeof(m, meta_dict), Symbol(_module_name_or_nothing(CSTParser.get_name(m))))
+addmoduletoscope!(s::Scope, s1::Scope, meta_dict::Union{Nothing,AbstractDict}=nothing) = CSTParser.defines_module(s1.expr) && addmoduletoscope!(s, s1, Symbol(_module_name_or_nothing(CSTParser.get_name(s1.expr))))
+
+# valofid also covers var"..." module names, where valof is nothing; guard
+# against malformed names (e.g. errortokens), for which valofid would throw
+_module_name_or_nothing(n) = n isa EXPR && isidentifier(n) ? valofid(n) : nothing
 
 
 getscopemodule(s::Scope, m::Symbol) = s.modules[m]

--- a/src/StaticLint/utils.jl
+++ b/src/StaticLint/utils.jl
@@ -187,7 +187,7 @@ _is_macrocall_to_BaseDIR(arg) = headof(arg) === :macrocall && length(arg.args) =
 
 isexportedby(k::Symbol, m::SymbolServer.ModuleStore) = haskey(m, k) && k in m.exportednames
 isexportedby(k::String, m::SymbolServer.ModuleStore) = isexportedby(Symbol(k), m)
-isexportedby(x::EXPR, m::SymbolServer.ModuleStore) = isexportedby(valof(x), m)
+isexportedby(x::EXPR, m::SymbolServer.ModuleStore) = isexportedby(isidentifier(x) ? valofid(x) : valof(x), m)
 isexportedby(k, m::SymbolServer.ModuleStore) = false
 
 function retrieve_toplevel_scope(x::EXPR, meta_dict)

--- a/src/layer_actions.jl
+++ b/src/layer_actions.jl
@@ -147,7 +147,12 @@ function _explicitly_import_used_variables(x::CSTParser.EXPR, runtime, uri::URI,
         if CSTParser.parentof(r) isa CSTParser.EXPR && CSTParser.is_getfield_w_quotenode(CSTParser.parentof(r)) && CSTParser.parentof(r).args[1] == r
             childname = CSTParser.parentof(r).args[2].args[1]
             StaticLint.hasref(childname, meta_dict) && StaticLint.refof(childname, meta_dict) isa StaticLint.Binding && continue
-            !haskey(ref.val.vals, Symbol(CSTParser.valof(childname))) && continue
+            # str_value also covers var"..." names, where valof is nothing;
+            # names written as var"..." keep their quoting in the emitted code
+            cn = CSTParser.str_value(childname)
+            cn isa AbstractString || continue
+            !haskey(ref.val.vals, Symbol(cn)) && continue
+            cn_label = something(_name_expr_label(childname), String(cn))
 
             loc = _get_file_loc(r, runtime)
             loc === nothing && continue
@@ -155,8 +160,8 @@ function _explicitly_import_used_variables(x::CSTParser.EXPR, runtime, uri::URI,
             if !haskey(edits_by_uri, ruri)
                 edits_by_uri[ruri] = TextEditResult[]
             end
-            push!(edits_by_uri[ruri], TextEditResult(_offset_to_position(runtime, ruri, roffset), _offset_to_position(runtime, ruri, roffset + CSTParser.parentof(r).span), CSTParser.valof(childname)))
-            push!(vars, CSTParser.valof(childname))
+            push!(edits_by_uri[ruri], TextEditResult(_offset_to_position(runtime, ruri, roffset), _offset_to_position(runtime, ruri, roffset + CSTParser.parentof(r).span), cn_label))
+            push!(vars, cn_label)
         end
     end
     isempty(edits_by_uri) && return WorkspaceFileEdit[]

--- a/src/layer_completions.jl
+++ b/src/layer_completions.jl
@@ -237,7 +237,7 @@ end
 # ============================================================================
 
 function _texteditfor(state::_CompletionState, partial, new_text)
-    start_off = max(state.start_offset - length(partial), 0)
+    start_off = max(state.start_offset - sizeof(partial), 0)
     CompletionEdit(position_at(state.st, start_off + 1), position_at(state.st, state.end_offset + 1), new_text, nothing)
 end
 
@@ -297,6 +297,92 @@ function _string_macro_altname(s)
     else
         return nothing
     end
+end
+
+# ============================================================================
+# Non-standard (`var"..."`) identifier helpers
+# ============================================================================
+
+"""
+    _var_wrap(n)
+
+Wrap a name in `var"..."` quoting. Names that can't be represented that way
+(containing `"` or `\\`) are returned as is.
+"""
+function _var_wrap(n::AbstractString)
+    if occursin('"', n) || occursin('\\', n)
+        return n
+    end
+    return string("var\"", n, '"')
+end
+
+"""
+    _var_quoted_label(n)
+
+Return the completion label/insert text for a name `n` whose definition syntax
+is unknown (e.g. field names from the symbol store): names that are not plain
+valid identifiers (or that start with `@`) are wrapped in `var"..."` quoting
+so that inserting them produces valid code. Use [`_name_expr_label`](@ref)
+instead when the defining EXPR is available.
+"""
+function _var_quoted_label(n::AbstractString)
+    if isempty(n) || (Base.isidentifier(n) && !startswith(n, '@'))
+        return n
+    end
+    return _var_wrap(n)
+end
+
+"""
+    _name_expr_label(x)
+
+Label/insert text for a name written as expr `x` in the source: names defined
+with `var"..."` syntax always keep their quoting, everything else stays raw
+(in particular macro names). Returns `nothing` if `x` has no name.
+"""
+function _name_expr_label(x::CSTParser.EXPR)
+    n = CSTParser.str_value(x)
+    (n isa AbstractString && !isempty(n)) || return nothing
+    return CSTParser.headof(x) === :NONSTDIDENTIFIER ? _var_wrap(String(n)) : String(n)
+end
+
+_binding_defined_as_var(b) =
+    b isa StaticLint.Binding && b.name isa CSTParser.EXPR &&
+    CSTParser.headof(b.name) === :NONSTDIDENTIFIER
+
+"""
+    _strip_var_partial(s)
+
+Strip the `var"` prefix (and a trailing `"`, if present) from a partially typed
+non-standard identifier so it can be matched against raw names: `var"he` and
+`var"he"` both become `he`. Strings without the prefix are returned unchanged.
+"""
+function _strip_var_partial(s::AbstractString)
+    startswith(s, "var\"") || return s
+    stripped = chop(s, head=4, tail=0)
+    endswith(stripped, '"') && (stripped = chop(stripped))
+    return stripped
+end
+
+"""
+    _var_string_partial(pt, t, offset, content)
+
+If the cursor at byte `offset` is inside a string token `t` that directly
+follows a `var` identifier token `pt` — i.e. a partially typed non-standard
+`var"..."` identifier — return the typed text from the start of `var` up to
+the cursor (e.g. `var"he`), otherwise `nothing`.
+"""
+function _var_string_partial(pt, t, offset, content)
+    (t isa CSTParser.Tokens.Token && pt isa CSTParser.Tokens.Token) || return nothing
+    (pt.kind == Tokens.IDENTIFIER && pt.val == "var") || return nothing
+    pt.endbyte + 1 == t.startbyte || return nothing
+    if t.kind == Tokens.STRING
+        t.startbyte < offset <= t.endbyte + 1 || return nothing
+    elseif t.kind == Tokens.ERROR && t.token_error == Tokens.EOF_STRING
+        t.startbyte < offset || return nothing
+    else
+        return nothing
+    end
+    return content[pt.startbyte+1:offset]
 end
 
 # ============================================================================
@@ -530,6 +616,16 @@ function _relative_dot_depth_at(s::AbstractString, offset::Int)
     return 0
 end
 
+function _module_name_label(name::CSTParser.EXPR)
+    if CSTParser.isidentifier(name)
+        # var"..." module names keep their quoting so inserting them produces
+        # valid code
+        _name_expr_label(name)
+    else
+        String(CSTParser.to_codeobject(name))
+    end
+end
+
 function _child_module_names(x::CSTParser.EXPR)
     names = String[]
     if CSTParser.defines_module(x)
@@ -537,16 +633,16 @@ function _child_module_names(x::CSTParser.EXPR)
         if b isa CSTParser.EXPR && CSTParser.headof(b) === :block && b.args !== nothing
             for a in b.args
                 if a isa CSTParser.EXPR && CSTParser.defines_module(a)
-                    n = CSTParser.isidentifier(a.args[2]) ? CSTParser.valof(a.args[2]) : String(CSTParser.to_codeobject(a.args[2]))
-                    push!(names, String(n))
+                    n = _module_name_label(a.args[2])
+                    n !== nothing && push!(names, n)
                 end
             end
         end
     elseif CSTParser.headof(x) === :file && x.args !== nothing
         for a in x.args
             if a isa CSTParser.EXPR && CSTParser.defines_module(a)
-                n = CSTParser.isidentifier(a.args[2]) ? CSTParser.valof(a.args[2]) : String(CSTParser.to_codeobject(a.args[2]))
-                push!(names, String(n))
+                n = _module_name_label(a.args[2])
+                n !== nothing && push!(names, n)
             end
         end
     end
@@ -678,11 +774,12 @@ function _is_rebinding_of_module(x, meta_dict)
     CSTParser.defines_module(StaticLint.refof(StaticLint.refof(x, meta_dict).val.args[2], meta_dict).val)
 end
 
-# Field names of a workspace struct definition, mirroring the field-marking
-# logic in `mark_bindings!`: skips inner constructors, unwraps `const` and
-# @kwdef defaults.
+# Field `(name, label)`s of a workspace struct definition, mirroring the
+# field-marking logic in `mark_bindings!`: skips inner constructors, unwraps
+# `const` and @kwdef defaults. The label carries the var"..." quoting for
+# fields defined with non-standard names.
 function _struct_field_names(x::CSTParser.EXPR)
-    names = String[]
+    names = Tuple{String,String}[]
     for arg in x.args[3].args
         CSTParser.defines_function(arg) && continue
         if CSTParser.headof(arg) === :const
@@ -694,11 +791,32 @@ function _struct_field_names(x::CSTParser.EXPR)
         if CSTParser.isdeclaration(arg)
             arg = arg.args[1]
         end
-        if CSTParser.isidentifier(arg) && CSTParser.valof(arg) isa String
-            push!(names, CSTParser.valof(arg))
+        if CSTParser.isidentifier(arg)
+            # str_value also covers var"..." fields, where valof is nothing
+            n = CSTParser.str_value(arg)
+            label = _name_expr_label(arg)
+            if n isa AbstractString && !isempty(n) && label !== nothing
+                push!(names, (String(n), label))
+            end
         end
     end
     return names
+end
+
+"""
+    _add_field_completion(state, spartial, name, label=_var_quoted_label(name))
+
+Add a field completion for `name`, inserted as `label` (its var"..."-quoted
+form where required). `spartial` is matched against both the raw name and the
+label, so `foo.he` and `foo.var"he` both complete to `foo.var"hello world"`.
+"""
+function _add_field_completion(state::_CompletionState, spartial, name::String, label::String=_var_quoted_label(name))
+    if is_completion_match(name, _strip_var_partial(spartial)) ||
+        (label != name && is_completion_match(label, spartial))
+        _add_completion_item(state, CompletionResultItem(
+            label, CompletionKinds.Field, nothing, name,
+            _texteditfor(state, spartial, label)))
+    end
 end
 
 function _get_dot_completion(px, spartial, state::_CompletionState) end
@@ -714,31 +832,17 @@ function _get_dot_completion(px::CSTParser.EXPR, spartial, state::_CompletionSta
             _collect_completions(StaticLint.scopeof(StaticLint.refof(r.val.args[2], state.meta_dict).val, state.meta_dict), spartial, state, true)
         elseif r.type isa SymbolServer.DataTypeStore
             for a in r.type.fieldnames
-                a = String(a)
-                if is_completion_match(a, spartial)
-                    _add_completion_item(state, CompletionResultItem(
-                        a, CompletionKinds.Field, nothing, a,
-                        _texteditfor(state, spartial, a)))
-                end
+                _add_field_completion(state, spartial, String(a))
             end
         elseif r.type isa StaticLint.Binding && r.type.val isa SymbolServer.DataTypeStore
             for a in r.type.val.fieldnames
-                a = String(a)
-                if is_completion_match(a, spartial)
-                    _add_completion_item(state, CompletionResultItem(
-                        a, CompletionKinds.Field, nothing, a,
-                        _texteditfor(state, spartial, a)))
-                end
+                _add_field_completion(state, spartial, String(a))
             end
         elseif r.type isa StaticLint.Binding && r.type.val isa CSTParser.EXPR && CSTParser.defines_struct(r.type.val)
             # only the fields: the struct scope also holds type params and
             # inner constructor names
-            for a in _struct_field_names(r.type.val)
-                if is_completion_match(a, spartial)
-                    _add_completion_item(state, CompletionResultItem(
-                        a, CompletionKinds.Field, nothing, a,
-                        _texteditfor(state, spartial, a)))
-                end
+            for (a, label) in _struct_field_names(r.type.val)
+                _add_field_completion(state, spartial, a, label)
             end
         end
     elseif r isa SymbolServer.ModuleStore
@@ -819,7 +923,7 @@ function _import_has_x(expr::CSTParser.EXPR, x::String)
     if length(expr.args) == 1 && length(expr.args[1]) > 1
         for i = 2:length(expr.args[1].args)
             arg = expr.args[1].args[i]
-            if CSTParser.isoperator(arg.head) && length(arg.args) == 1 && CSTParser.isidentifier(arg.args[1]) && CSTParser.valof(arg.args[1]) == x
+            if CSTParser.isoperator(arg.head) && length(arg.args) == 1 && CSTParser.isidentifier(arg.args[1]) && CSTParser.str_value(arg.args[1]) == x
                 return true
             end
         end
@@ -843,11 +947,16 @@ end
 
 function _collect_completions(x::StaticLint.Scope, spartial, state::_CompletionState, inclexported=false, dotcomps=false)
     if x.names !== nothing
+        stripped_partial = _strip_var_partial(spartial)
         possible_names = String[]
         for n in x.names
             resize!(possible_names, 0)
-            if is_completion_match(n[1], spartial) && n[1] != spartial
-                push!(possible_names, n[1])
+            # bindings defined with var"..." syntax keep their quoting; other
+            # names (in particular macros) stay raw
+            label = _binding_defined_as_var(n[2]) ? _var_wrap(n[1]) : n[1]
+            if (is_completion_match(n[1], stripped_partial) ||
+                (label != n[1] && is_completion_match(label, spartial))) && label != spartial
+                push!(possible_names, label)
             end
             if (nn = _string_macro_altname(n[1]); nn !== nothing) && is_completion_match(nn, spartial)
                 push!(possible_names, nn)
@@ -925,7 +1034,11 @@ function _add_using_stmt(x::CSTParser.EXPR, using_stmts, workspace)
         if CSTParser.is_dot(x.args[1].args[1].head) && length(x.args[1].args[1].args) == 1
             loc = get_expr_location(workspace, x)
             if loc !== nothing
-                using_stmts[CSTParser.valof(x.args[1].args[1].args[1])] = (x, (loc.uri, loc.offset))
+                # str_value also covers var"..." module names, where valof is nothing
+                key = CSTParser.str_value(x.args[1].args[1].args[1])
+                if key isa AbstractString
+                    using_stmts[String(key)] = (x, (loc.uri, loc.offset))
+                end
             end
         end
     end
@@ -997,22 +1110,39 @@ function _get_completions(rt, uri, offset, completion_mode, workspace)
         Dict{String,Any}()
     end
 
+    ppt, pt, t = _get_toks(st.content, offset)
+    is_at_end = offset == t.endbyte + 1
+
+    # A partially typed `var"..."` identifier (e.g. `foo.var"he`)?
+    var_partial = _var_string_partial(pt, t, offset, st.content)
+    end_offset = offset
+    if var_partial !== nothing && t.kind == Tokens.STRING && offset <= t.endbyte
+        # the string is already terminated (auto-closing quotes): also replace
+        # the closing quote after the cursor
+        end_offset = t.endbyte + 1
+    end
+
     state = _CompletionState(
         offset,
         Dict{String,CompletionResultItem}(),
-        offset, offset,   # start_offset, end_offset (cursor position)
+        offset, end_offset,   # start_offset (cursor), end_offset
         x, cst, uri, st, meta_dict, env,
         completion_mode, using_stmts, workspace
     )
-
-    ppt, pt, t = _get_toks(st.content, offset)
-    is_at_end = offset == t.endbyte + 1
 
     # Update start/end offsets based on cursor position for replacement range
     # We use an immutable struct, so we track this externally in the "partial" length
     # that _texteditfor uses.
 
-    if pt isa CSTParser.Tokens.Token && pt.kind == CSTParser.Tokenize.Tokens.BACKSLASH
+    if var_partial !== nothing
+        if ppt isa CSTParser.Tokens.Token && ppt.kind == Tokens.DOT
+            # anchor on the dot token to find the expression being accessed
+            px = _get_expr(cst, ppt.startbyte)
+            _get_dot_completion(px, var_partial, state)
+        elseif state.x !== nothing
+            _collect_completions(state.x, var_partial, state, false)
+        end
+    elseif pt isa CSTParser.Tokens.Token && pt.kind == CSTParser.Tokenize.Tokens.BACKSLASH
         _latex_completions(string("\\", CSTParser.Tokenize.untokenize(t)), state)
     elseif ppt isa CSTParser.Tokens.Token && ppt.kind == CSTParser.Tokenize.Tokens.BACKSLASH && pt isa CSTParser.Tokens.Token && (pt.kind === CSTParser.Tokens.CIRCUMFLEX_ACCENT || pt.kind === CSTParser.Tokens.COLON)
         _latex_completions(string("\\", CSTParser.Tokenize.untokenize(pt), CSTParser.Tokenize.untokenize(t)), state)

--- a/src/layer_signatures.jl
+++ b/src/layer_signatures.jl
@@ -135,8 +135,9 @@ function _get_signatures(x::CSTParser.EXPR, tls::StaticLint.Scope, sigs::Vector{
             for i = 2:length(sig.args)
                 argbinding = StaticLint.bindingof(sig.args[i], meta_dict)
                 if argbinding !== nothing
-                    label = CSTParser.valof(argbinding.name) isa String ? CSTParser.valof(argbinding.name) : ""
-                    push!(params, ParameterInfo(label, nothing))
+                    # var"..." argument names keep their quoting
+                    n = argbinding.name isa CSTParser.EXPR ? _name_expr_label(argbinding.name) : nothing
+                    push!(params, ParameterInfo(something(n, ""), nothing))
                 end
             end
             push!(sigs, SignatureInfo(string(CSTParser.to_codeobject(sig)), "", params))
@@ -148,7 +149,11 @@ function _get_signatures(x::CSTParser.EXPR, tls::StaticLint.Scope, sigs::Vector{
                 params = ParameterInfo[]
                 for field in args.args
                     field_name = CSTParser.rem_decl(field)
-                    label = field_name isa CSTParser.EXPR && CSTParser.isidentifier(field_name) ? CSTParser.valof(field_name) : ""
+                    label = ""
+                    if field_name isa CSTParser.EXPR && CSTParser.isidentifier(field_name)
+                        # var"..." field names keep their quoting
+                        label = something(_name_expr_label(field_name), "")
+                    end
                     push!(params, ParameterInfo(label, nothing))
                 end
                 push!(sigs, SignatureInfo(string(CSTParser.to_codeobject(x)), "", params))

--- a/src/layer_static_lint.jl
+++ b/src/layer_static_lint.jl
@@ -31,7 +31,8 @@ function find_module_binding(cst, name::String, meta_dict::Dict{UInt64,StaticLin
         for arg in cst.args
             if CSTParser.defines_module(arg) && StaticLint.hasbinding(arg, meta_dict)
                 mod_name = CSTParser.get_name(arg)
-                if CSTParser.isidentifier(mod_name) && CSTParser.valof(mod_name) == name
+                # str_value also covers var"..." module names, where valof is nothing
+                if CSTParser.isidentifier(mod_name) && CSTParser.str_value(mod_name) == name
                     return StaticLint.bindingof(arg, meta_dict)
                 end
             end
@@ -333,7 +334,10 @@ Salsa.@derived function derived_test_setup_bindings(rt, package_folder_uri)
             length(mod_expr.args) < 3 && continue
             name_expr = mod_expr.args[2]
             CSTParser.isidentifier(name_expr) || continue
-            mod_name = Symbol(CSTParser.valof(name_expr))
+            # str_value also covers var"..." names, where valof is nothing
+            mod_name_str = CSTParser.str_value(name_expr)
+            mod_name_str isa AbstractString || continue
+            mod_name = Symbol(mod_name_str)
 
             body = _get_body_block(mod_expr)
             body === nothing && continue
@@ -366,7 +370,10 @@ Salsa.@derived function derived_test_setup_bindings(rt, package_folder_uri)
             length(snip_expr.args) < 3 && continue
             name_expr = snip_expr.args[2]
             CSTParser.isidentifier(name_expr) || continue
-            snip_name = Symbol(CSTParser.valof(name_expr))
+            # str_value also covers var"..." names, where valof is nothing
+            snip_name_str = CSTParser.str_value(name_expr)
+            snip_name_str isa AbstractString || continue
+            snip_name = Symbol(snip_name_str)
 
             body = _get_body_block(snip_expr)
             body === nothing && continue

--- a/src/layer_symbols.jl
+++ b/src/layer_symbols.jl
@@ -191,7 +191,8 @@ end
 
 function _collect_toplevel_bindings_w_loc(x::CSTParser.EXPR, meta_dict::MetaDict, pos=0, bindings=Tuple{UnitRange{Int},StaticLint.Binding}[]; query="")
     b = StaticLint.bindingof(x, meta_dict)
-    if b isa StaticLint.Binding && CSTParser.valof(b.name) isa String && b.val isa CSTParser.EXPR && startswith(CSTParser.valof(b.name), query)
+    if b isa StaticLint.Binding && b.name isa CSTParser.EXPR && _is_valid_binding_name(b.name) &&
+        b.val isa CSTParser.EXPR && startswith(_get_name_of_binding(b.name), query)
         push!(bindings, (pos .+ (0:x.span), b))
     end
     s = StaticLint.scopeof(x, meta_dict)
@@ -248,7 +249,7 @@ function _get_workspace_symbols(runtime, query::String)
         bs = _collect_toplevel_bindings_w_loc(cst, meta_dict, query=query)
         for (rng, b) in bs
             push!(results, WorkspaceSymbolResult(
-                CSTParser.valof(b.name),
+                _get_name_of_binding(b.name),
                 1, # SymbolKind.File (LS uses 1 for all workspace symbols)
                 uri,
                 _offset_to_position(runtime, uri, first(rng)),

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -1520,6 +1520,76 @@ end
     @test isempty(get_hints(jw))
 end
 
+@testitem "var\"\" getfield resolution (#3867)" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: haserror
+
+    missing_refs(cst, meta_dict, jw) =
+        [x for (_, x) in collect_hints(cst, meta_dict, jw) if !haserror(x, meta_dict)]
+
+    # A var"..." field access resolves to the struct field.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        struct Foo
+            var"hello world"::Int
+            normal::Int
+        end
+        foo = Foo(1, 2)
+        foo.var"hello world"
+        foo.normal
+        """)
+        @test isempty(missing_refs(cst, meta_dict, jw))
+    end
+
+    # An unresolvable var"..." field must not crash the late getfield
+    # resolution pass (`valof` of a NONSTDIDENTIFIER is `nothing`).
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        struct Foo
+            var"hello world"::Int
+        end
+        foo = Foo(1)
+        foo.var"nope"
+        """)
+        @test !isempty(missing_refs(cst, meta_dict, jw))
+    end
+end
+
+@testitem "var\"\" identifiers in lint checks (#3867)" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, InvalidModuleName, DuplicateFuncArgName
+
+    # two distinct var"..." module names must not be flagged as InvalidModuleName
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        module var"A A"
+        module var"B B"
+        end
+        end
+        """)
+        @test !any(x -> errorof(x[2], meta_dict) === InvalidModuleName, collect_hints(cst, meta_dict, jw))
+    end
+
+    # a nested module with the same var"..." name is still flagged
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        module var"A A"
+        module var"A A"
+        end
+        end
+        """)
+        @test any(x -> errorof(x[2], meta_dict) === InvalidModuleName, collect_hints(cst, meta_dict, jw))
+    end
+
+    # duplicated var"..." argument names are diagnosed like plain ones
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        f(var"a b", var"a b") = 1
+        """)
+        @test any(x -> errorof(x[2], meta_dict) === DuplicateFuncArgName, collect_hints(cst, meta_dict, jw))
+    end
+
+    # undefined var"..." references produce a missing-ref hint without crashing
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        x = var"undefined thing"
+        """)
+        @test any(x -> errorof(x[2], meta_dict) === nothing, collect_hints(cst, meta_dict, jw))
+    end
+end
+
 @testitem "quoted getfield" setup=[shared_static_lint] begin
     import CSTParser
     using JuliaWorkspaces.StaticLint: errorof, getmeta, bindingof, get_method

--- a/test/test_completions.jl
+++ b/test/test_completions.jl
@@ -632,6 +632,139 @@ end
     @test any(item -> item.label == "greet", result.items)
 end
 
+@testitem "Completions: var\"\" identifiers" begin
+    # https://github.com/julia-vscode/julia-vscode/issues/3867
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_completions
+    using JuliaWorkspaces.URIs2: URI
+
+    # Apply a CompletionEdit to `src` (byte-based, end-exclusive positions).
+    function apply_edit(src, edit)
+        lines = split(src, '\n'; keepempty=true)
+        lineoff(line) = sum(Int[ncodeunits(lines[l]) + 1 for l in 1:(line-1)])
+        s = lineoff(edit.start.line) + edit.start.column
+        e = lineoff(edit.stop.line) + edit.stop.column
+        cu = codeunits(src)
+        return String(vcat(cu[1:s-1], codeunits(edit.new_text), cu[e:end]))
+    end
+
+    struct_def = """
+    struct Foo
+        var"hello world"::Int
+        normal::Int
+    end
+    foo = Foo(1, 2)
+    """
+
+    # `index_str` must end with the newline right after the cursor position
+    function completions_for(trailer, index_str)
+        source = struct_def * trailer
+        uri = URI("file:///compvar/$(hash(trailer)).jl")
+        jw = JuliaWorkspace()
+        add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+        index = findfirst(index_str, source)[end]
+        return source, get_completions(jw, uri, index)
+    end
+
+    # 1) `foo.` offers the var"" field with proper quoting
+    source, result = completions_for("foo.\n", "foo.\n")
+    @test sort([i.label for i in result.items]) == ["normal", "var\"hello world\""]
+    item = only(filter(i -> i.label == "var\"hello world\"", result.items))
+    @test occursin("foo.var\"hello world\"\n", apply_edit(source, item.text_edit))
+
+    # 2) `foo.var` offers the var"" field, replacing the typed `var`
+    source, result = completions_for("foo.var\n", "foo.var\n")
+    @test any(i -> i.label == "var\"hello world\"", result.items)
+    item = only(filter(i -> i.label == "var\"hello world\"", result.items))
+    @test occursin("foo.var\"hello world\"\n", apply_edit(source, item.text_edit))
+
+    # 3) `foo.var"he` (unterminated string): no duplicated var" prefix
+    source, result = completions_for("foo.var\"he\n", "foo.var\"he\n")
+    @test any(i -> i.label == "var\"hello world\"", result.items)
+    item = only(filter(i -> i.label == "var\"hello world\"", result.items))
+    @test occursin("foo.var\"hello world\"\n", apply_edit(source, item.text_edit))
+
+    # 4) `foo.var"he"` with the cursor before the auto-closed quote: the closing
+    #    quote is part of the replaced range
+    source_t = struct_def * "foo.var\"he\"\n"
+    uri_t = URI("file:///compvar/terminated.jl")
+    jw_t = JuliaWorkspace()
+    add_file!(jw_t, TextFile(uri_t, SourceText(source_t, "julia")))
+    index_t = findfirst("foo.var\"he", source_t)[end] + 1  # cursor after `he`, before `"`
+    result_t = get_completions(jw_t, uri_t, index_t)
+    @test any(i -> i.label == "var\"hello world\"", result_t.items)
+    item_t = only(filter(i -> i.label == "var\"hello world\"", result_t.items))
+    @test occursin("foo.var\"hello world\"\n", apply_edit(source_t, item_t.text_edit))
+
+    # 5) plain fields are unaffected
+    source, result = completions_for("foo.nor\n", "foo.nor\n")
+    @test any(i -> i.label == "normal" && i.text_edit.new_text == "normal", result.items)
+
+    # 6) scope completions quote non-identifier names
+    scope_src = """
+    var"top level thing" = 1
+    top
+    """
+    uri_s = URI("file:///compvar/scope.jl")
+    jw_s = JuliaWorkspace()
+    add_file!(jw_s, TextFile(uri_s, SourceText(scope_src, "julia")))
+    index_s = findfirst("top\n", scope_src)[end]
+    result_s = get_completions(jw_s, uri_s, index_s)
+    @test any(i -> i.label == "var\"top level thing\"", result_s.items)
+    item_s = only(filter(i -> i.label == "var\"top level thing\"", result_s.items))
+    @test occursin("var\"top level thing\"\n", apply_edit(scope_src, item_s.text_edit))
+    @test !any(i -> i.text_edit.new_text == "top level thing", result_s.items)
+
+    # 7) names that are only non-standard because of var"" quoting (macro-like,
+    #    operator-like, or plain) always keep their quoting from the definition
+    at_src = """
+    struct Bar
+        var"@asd"::Int
+        var"+"::Int
+        var"plain"::Int
+    end
+    bar = Bar(1, 2, 3)
+    bar.
+    """
+    uri_at = URI("file:///compvar/atfield.jl")
+    jw_at = JuliaWorkspace()
+    add_file!(jw_at, TextFile(uri_at, SourceText(at_src, "julia")))
+    index_at = findfirst("bar.\n", at_src)[end]
+    result_at = get_completions(jw_at, uri_at, index_at)
+    labels_at = sort([i.label for i in result_at.items])
+    @test labels_at == ["var\"+\"", "var\"@asd\"", "var\"plain\""]
+    item_at = only(filter(i -> i.label == "var\"@asd\"", result_at.items))
+    @test occursin("bar.var\"@asd\"\n", apply_edit(at_src, item_at.text_edit))
+
+    # 8) genuine macros in scope are not var""-wrapped
+    macro_src = """
+    macro mymacroxyz(x)
+        x
+    end
+    @mymacr
+    """
+    uri_m = URI("file:///compvar/macros.jl")
+    jw_m = JuliaWorkspace()
+    add_file!(jw_m, TextFile(uri_m, SourceText(macro_src, "julia")))
+    index_m = findfirst("@mymacr\n", macro_src)[end]
+    result_m = get_completions(jw_m, uri_m, index_m)
+    @test any(i -> i.label == "@mymacroxyz", result_m.items)
+    @test !any(i -> i.label == "var\"@mymacroxyz\"", result_m.items)
+
+    # 9) partially typed var"" identifier in scope completions
+    scope_src2 = """
+    var"top level thing" = 1
+    var"top
+    """
+    uri_s2 = URI("file:///compvar/scope2.jl")
+    jw_s2 = JuliaWorkspace()
+    add_file!(jw_s2, TextFile(uri_s2, SourceText(scope_src2, "julia")))
+    index_s2 = findfirst("var\"top\n", scope_src2)[end]
+    result_s2 = get_completions(jw_s2, uri_s2, index_s2)
+    @test any(i -> i.label == "var\"top level thing\"", result_s2.items)
+    item_s2 = only(filter(i -> i.label == "var\"top level thing\"", result_s2.items))
+    @test occursin("var\"top level thing\"\n", apply_edit(scope_src2, item_s2.text_edit))
+end
+
 @testitem "Completions: unresolvable VarRef does not truncate module symbols" begin
     using JuliaWorkspaces: JuliaWorkspaces, SourceText
     using JuliaWorkspaces.URIs2: @uri_str
@@ -673,4 +806,43 @@ end
         @test g in labels
     end
     @test !("tst_bad" in labels)
+end
+
+@testitem "Completions: var\"\" module names don't crash import completions (#3867)" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_completions, CompletionResult
+    using JuliaWorkspaces.URIs2: URI
+
+    # relative-import completion with a var"" child module used to crash in
+    # _child_module_names
+    source = """
+    module Outer
+    module var"weird one" end
+    module Inner end
+    import .
+    end
+    """
+    uri = URI("file:///compvarmod/test.jl")
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+    index = findfirst("import .\n", source)[end]
+    result = get_completions(jw, uri, index)
+    labels = [i.label for i in result.items]
+    @test "Inner" in labels
+    @test "var\"weird one\"" in labels
+
+    # a var"" module name in an existing `using .mod: x` statement used to
+    # crash in _add_using_stmt when building import-mode completions
+    source2 = """
+    module Outer
+    module var"weird module" end
+    using .var"weird module": foo
+    somepartialname
+    end
+    """
+    uri2 = URI("file:///compvarmod/test2.jl")
+    jw2 = JuliaWorkspace()
+    add_file!(jw2, TextFile(uri2, SourceText(source2, "julia")))
+    index2 = findfirst("somepartialname\n", source2)[end]
+    result2 = get_completions(jw2, uri2, index2)
+    @test result2 isa CompletionResult
 end

--- a/test/test_signatures.jl
+++ b/test/test_signatures.jl
@@ -167,3 +167,48 @@ end
     result = get_signature_help(jw, uri, idx)
     @test !isempty(result.signatures)
 end
+
+@testitem "Signatures: struct constructor with var\"\" field (#3867)" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
+    using JuliaWorkspaces.URIs2: URI
+
+    # a var"..." field must not crash signature help and must be labeled
+    # with its quoted form
+    source = """
+    struct Foo
+        var"hello world"::Int
+        normal::Int
+    end
+    foo = Foo(
+    """
+
+    jw = JuliaWorkspace()
+    uri = URI("file:///sigvar/test.jl")
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+
+    idx = findfirst("Foo(", source)[end] + 1
+    result = get_signature_help(jw, uri, idx)
+    @test !isempty(result.signatures)
+    sig = first(result.signatures)
+    @test [p.label for p in sig.parameters] == ["var\"hello world\"", "normal"]
+end
+
+@testitem "Signatures: function with var\"\" argument (#3867)" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
+    using JuliaWorkspaces.URIs2: URI
+
+    source = """
+    func(var"weird arg", normal) = 1
+    func(
+    """
+
+    jw = JuliaWorkspace()
+    uri = URI("file:///sigvararg/test.jl")
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+
+    idx = findfirst("\nfunc(", source)[end] + 1
+    result = get_signature_help(jw, uri, idx)
+    @test !isempty(result.signatures)
+    sig = first(result.signatures)
+    @test [p.label for p in sig.parameters] == ["var\"weird arg\"", "normal"]
+end

--- a/test/test_symbols.jl
+++ b/test/test_symbols.jl
@@ -101,3 +101,26 @@ end
     results3 = get_workspace_symbols(jw, "nonexistent")
     @test isempty(results3)
 end
+
+@testitem "Symbols: var\"\" bindings are included (#3867)" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_workspace_symbols
+    using JuliaWorkspaces.URIs2: URI
+
+    source = """
+    var"top level thing" = 1
+    normal_thing = 2
+    """
+
+    jw = JuliaWorkspace()
+    uri = URI("file:///symvar/test.jl")
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+
+    results = get_workspace_symbols(jw, "")
+    names = [r.name for r in results]
+    @test "top level thing" in names
+    @test "normal_thing" in names
+
+    # query matching works against the raw name
+    results2 = get_workspace_symbols(jw, "top")
+    @test any(r -> r.name == "top level thing", results2)
+end


### PR DESCRIPTION
CSTParser.isidentifier is true for NONSTDIDENTIFIER exprs but CSTParser.valof returns nothing for them, so every consumer that pairs an isidentifier guard with bare valof either crashed on nothing or silently ignored var"..." names. This fixes that class of bug across the codebase (julia-vscode/julia-vscode#3867):

Completions:
- offer var"..." struct fields and scope bindings with proper quoting
- complete partially typed non-standard identifiers (`foo.var"he`), including the auto-inserted closing quote in the replacement range
- don't crash on var"..." module names in relative imports and existing `using .mod: x` statements
- compute replacement ranges in bytes instead of characters

Signature help:
- don't crash on var"..." struct fields; label var"..." fields and arguments with their quoted form

Symbols:
- include var"..." top-level bindings in workspace symbols

Lint:
- don't crash resolving unresolvable x.var"..." field accesses
- don't flag two distinct nested var"..." module names as InvalidModuleName
- diagnose duplicated var"..." argument names
- apply the unused-binding suppression heuristics to var"..." bindings

Reference resolution, actions, test-item discovery:
- resolve var"..." names through module stores, exports, getfield on package structs, and local overloads (valof -> valofid)
- emit quoted var"..." names in the "explicitly import used variables" code action
- register @testmodule/@testsnippet names declared as var"..." correctly