### PR TITLE
fix: don't report `@label` as an unused binding

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1181,7 +1181,7 @@ function check_unused_binding(b::Binding, scope::Scope, meta_dict)
         if (isempty(refs) || length(refs) == 1 && refs[1] == b.name) &&
                 !is_sig_arg(b.name) && !is_overwritten_in_loop(b.name, meta_dict) &&
                 !is_overwritten_subsequently(b, scope, meta_dict) && !is_kw_of_macrocall(b) &&
-                !captures_outer_local(b, scope)
+                !captures_outer_local(b, scope) && !is_label_binding(b)
             seterror!(b.name, UnusedBinding, meta_dict)
         end
     end
@@ -1206,6 +1206,17 @@ end
 
 function is_kw_of_macrocall(b::Binding)
     b.val isa EXPR && isassignment(b.val) && parentof(b.val) isa EXPR && CSTParser.ismacrocall(parentof(b.val))
+end
+
+# `@label name` introduces a jump target for `@goto`, not a variable, so it
+# should never be reported as an unused binding (julia-vscode#3844).
+function is_label_binding(b::Binding)
+    (b.val isa EXPR && isidentifier(b.val) && parentof(b.val) isa EXPR) || return false
+    p = parentof(b.val)
+    (CSTParser.ismacrocall(p) && length(p.args) == 3 && p.args[3] === b.val) || return false
+    mname = p.args[1]
+    return valof(mname) == "@label" ||
+        (CSTParser.is_getfield_w_quotenode(mname) && valof(rhs_of_getfield(mname)) == "@label")
 end
 
 function is_overwritten_in_loop(x, meta_dict)

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -2938,6 +2938,40 @@ end
         end""")
 end
 
+@testitem "@label is not an unused binding (julia-vscode#3844)" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, UnusedBinding
+
+    function has_unused(src)
+        cst, meta_dict, jw = parse_and_pass(src)
+        any(errorof(x, meta_dict) === UnusedBinding for (_, x) in collect_hints(cst, meta_dict, jw))
+    end
+
+    # A label targeted by @goto is not an unused variable.
+    @test !has_unused("""
+        function f(n)
+            @label loop
+            n -= 1
+            println(n)
+            n > 0 && @goto loop
+        end""")
+
+    # Labels aren't variables, so even one without a matching @goto isn't
+    # flagged as an unused binding.
+    @test !has_unused("""
+        function f(n)
+            @label out
+            return n
+        end""")
+
+    # An ordinary unused variable next to a label is still flagged.
+    @test has_unused("""
+        function f(n)
+            unused_var = 1
+            @label loop
+            n > 0 && @goto loop
+        end""")
+end
+
 @testitem "function params don't rebind enclosing scope names" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: errorof, scopeof, InvalidRedefofConst
     using JuliaWorkspaces.CSTParser: isassignment, EXPR


### PR DESCRIPTION
`@label name` introduces a jump target for `@goto`, not a variable, but StaticLint marked the label identifier as a normal binding and then flagged it with UnusedBinding when no ordinary reference pointed at it. Skip the unused-binding check for label bindings.

Fixes julia-vscode/julia-vscode#3844