### PR TITLE
fix: disable StaticLint inside `@test_throws`

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -108,6 +108,10 @@ LintOptions(options::Vararg{Union{Bool,Nothing},length(default_options)}) =
     LintOptions(something.(options, default_options)...)
 
 function check_all(x::EXPR, opts::LintOptions, env::ExternalEnv, meta_dict)
+    # Linting is disabled inside `@test_throws`: its body is expected to error and
+    # may contain invalid code
+    is_test_throws_macrocall(x, env, meta_dict) && return
+
     # Do checks
     opts.call && check_call(x, env, meta_dict)
     opts.iter && check_loop_iter(x, env, meta_dict)
@@ -742,6 +746,21 @@ function is_nospecialize_call(x)
 end
 
 """
+    is_test_throws_macrocall(x::EXPR, env, meta_dict)
+
+True if `x` is a call to `Test.@test_throws`, resolved through the environment
+(so `using Test`, qualified `Test.@test_throws`, and renamed imports are handled,
+while an unrelated user-defined `@test_throws` is not matched). Its body
+deliberately contains code that is expected to error - often intentionally
+invalid - so linting is disabled there (issue #3682).
+"""
+function is_test_throws_macrocall(x::EXPR, env, meta_dict)
+    CSTParser.ismacrocall(x) || return false
+    (x.args !== nothing && length(x.args) > 0) || return false
+    return _points_to_arbitrary_macro(x.args[1], :Test, Symbol("@test_throws"), env, meta_dict)
+end
+
+"""
     in_macrocall_arg(x::EXPR)
 
 True if walking up from `x` we reach a macrocall (with `x` in its argument list,
@@ -776,6 +795,10 @@ Collect hints and errors from an expression. `missingrefs` = (:none, :id, :all) 
 identifiers are marked, the :all option will mark identifiers used in getfield calls."
 """
 function collect_hints(x::EXPR, env, workspace_packages, meta_dict, missingrefs=:all, isquoted=false, errs=Tuple{Int,EXPR}[], pos=0)
+    # Linting is disabled inside `@test_throws` (see `check_all`), so skip its body
+    # here too - otherwise deliberately undefined references would still be flagged.
+    is_test_throws_macrocall(x, env, meta_dict) && return errs
+
     if quoted(x)
         isquoted = true
     elseif isquoted && unquoted(x)

--- a/src/StaticLint/macros.jl
+++ b/src/StaticLint/macros.jl
@@ -198,12 +198,18 @@ function _points_to_Base_macro(x::EXPR, name, env::ExternalEnv, meta_dict)
     (ref == targetmacro || (ref isa Binding && ref.val == targetmacro))
 end
 
-function _points_to_arbitrary_macro(x::EXPR, module_name::Symbol, name::Symbol, state)
-    CSTParser.is_getfield_w_quotenode(x) && return _points_to_arbitrary_macro(x.args[2].args[1], module_name, name, state)
-    haskey(getsymbols(state), module_name) || return false
-    haskey(getsymbols(state)[module_name], name) || return false
-    targetmacro = maybe_lookup(getsymbols(state)[module_name][name], state)
-    isidentifier(x) && Symbol(valofid(x)) == name && (ref = refof(x, state.meta_dict)) !== nothing &&
+# `state` carries both the env and meta_dict; delegate to the env + meta_dict
+# variant, which is also usable in the check phase (where no `state` exists).
+_points_to_arbitrary_macro(x::EXPR, module_name::Symbol, name::Symbol, state) =
+    _points_to_arbitrary_macro(x, module_name, name, state.env, state.meta_dict)
+
+function _points_to_arbitrary_macro(x::EXPR, module_name::Symbol, name::Symbol, env::ExternalEnv, meta_dict)
+    CSTParser.is_getfield_w_quotenode(x) && return _points_to_arbitrary_macro(x.args[2].args[1], module_name, name, env, meta_dict)
+    syms = getsymbols(env)
+    haskey(syms, module_name) || return false
+    haskey(syms[module_name], name) || return false
+    targetmacro = maybe_lookup(syms[module_name][name], env)
+    isidentifier(x) && Symbol(valofid(x)) == name && (ref = refof(x, meta_dict)) !== nothing &&
     (ref == targetmacro || (ref isa Binding && ref.val == targetmacro))
 end
 

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -1813,6 +1813,75 @@ end
     @test errorof(cst.args[9].args[3], meta_dict) === JuliaWorkspaces.StaticLint.InappropriateUseOfLiteral
 end
 
+@testitem "linting disabled inside @test_throws (#3682)" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, haserror, isidentifier, InappropriateUseOfLiteral
+    SL = JuliaWorkspaces.StaticLint
+    SS = JuliaWorkspaces.SymbolServer
+    URIs2 = JuliaWorkspaces.URIs2
+
+    # `@test_throws` is resolved through the environment (like `_points_to_Base_macro`),
+    # and `Test` is not part of the stdlib-only env the bare test harness uses, so we
+    # build an env that additionally contains an exported `Test.@test_throws`.
+    function env_with_test(; with_test::Bool)
+        store = SS.recursive_copy(SS.stdlibs)
+        if with_test
+            tn = Symbol("@test_throws")
+            ref = SS.VarRef(SS.VarRef(nothing, :Test), tn)
+            fs = SS.FunctionStore(ref, SS.MethodStore[], "", ref, true)
+            store[:Test] = SS.ModuleStore(SS.VarRef(nothing, :Test), Dict{Symbol,Any}(tn => fs), "", true, [tn], Symbol[])
+        end
+        return SL.ExternalEnv(store, SS.collect_extended_methods(store), collect(keys(store)))
+    end
+
+    # Run the full semantic + lint pass with a custom env, returning (lint_codes, missing_refs).
+    function lint(src; with_test::Bool=true)
+        uri = URIs2.uri"file://test.jl"
+        env = env_with_test(; with_test)
+        jw = JuliaWorkspaces.JuliaWorkspace()
+        JuliaWorkspaces.add_file!(jw, JuliaWorkspaces.TextFile(uri, JuliaWorkspaces.SourceText(src, "julia")))
+        cst = JuliaWorkspaces.derived_julia_legacy_syntax_tree(jw.runtime, uri)
+        meta_dict = Dict{UInt64, SL.Meta}()
+        SL.ensuremeta(cst, meta_dict)
+        SL.semantic_pass(uri, cst, env, meta_dict, jw.runtime)
+        SL.check_all(cst, SL.LintOptions(), env, meta_dict)
+
+        codes = SL.LintCodes[]
+        walk(x) = (errorof(x, meta_dict) isa SL.LintCodes && push!(codes, errorof(x, meta_dict)); x.args !== nothing && foreach(walk, x.args))
+        walk(cst)
+        hints = SL.collect_hints(cst, env, Dict{String,Any}(), meta_dict, :all)
+        missing = [x for (_, x) in hints if isidentifier(x) && !haserror(x, meta_dict)]
+        return codes, missing
+    end
+
+    # Deliberately invalid definitions inside `@test_throws` must not be linted - its
+    # body is expected to error. Both the bare and qualified macro forms are covered.
+    for src in ("using Test\n@test_throws ErrorException (@eval primitive type 0 SPJa12023 end)\n",
+                "using Test\nTest.@test_throws ErrorException (@eval primitive type 4294967312 SPJb end)\n")
+        codes, _ = lint(src)
+        @test isempty(codes)
+    end
+
+    # Intentionally undefined references inside `@test_throws` must not be flagged.
+    let (_, missing) = lint("using Test\n@test_throws UndefVarError some_undefined_thing()\n")
+        @test isempty(missing)
+    end
+
+    # A `@test_throws` that does not resolve to `Test` is still linted normally: when
+    # `Test` is not in the environment, and when it is a user's own local macro.
+    let (codes, _) = lint("@test_throws ErrorException (@eval primitive type 0 C end)\n"; with_test=false)
+        @test InappropriateUseOfLiteral in codes
+    end
+    let (codes, _) = lint("macro test_throws(a, b) end\n@test_throws ErrorException (@eval primitive type 0 D end)\n")
+        @test InappropriateUseOfLiteral in codes
+    end
+
+    # The same misuse outside `@test_throws` is still flagged.
+    let (codes, missing) = lint("using Test\nprimitive type 1 8 end\nsome_undefined_thing()\n")
+        @test InappropriateUseOfLiteral in codes
+        @test !isempty(missing)
+    end
+end
+
 @testitem "check_break_continue" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: errorof
 


### PR DESCRIPTION
The body of `@test_throws` is expected to error and often contains deliberately invalid code (e.g. `@eval primitive type 0 Name end`), which previously produced false-positive lint hints such as InappropriateUseOfLiteral and spurious missing-reference warnings.

Skip both `check_all` and `collect_hints` for the body of a `@test_throws` macrocall. The macro is identified by resolving it through the environment (via `_points_to_arbitrary_macro`), so `using Test`, qualified `Test.@test_throws`, and renamed imports are recognized, while an unrelated user-defined `@test_throws` is not.

Also unify the two `_points_to_arbitrary_macro` methods: the `state` variant now delegates to the `env`+`meta_dict` variant (usable in the check phase).

Fixes https://github.com/julia-vscode/julia-vscode/issues/3682.