### PR TITLE
fix: resolve refs in anon functions with positional+keyword args

### DIFF
--- a/src/StaticLint/bindings.jl
+++ b/src/StaticLint/bindings.jl
@@ -136,7 +136,17 @@ function mark_binding!(x::EXPR, meta_dict, val=x)
             mark_binding!(arg, meta_dict, val)
         end
     elseif CSTParser.isbracketed(x)
-        mark_binding!(CSTParser.rem_invis(x), meta_dict, val)
+        inner = CSTParser.rem_invis(x)
+        if headof(inner) === :block
+            # A `(a; b)` signature (e.g. an anonymous `(bar; baz) -> ...`) collapses
+            # into a bracketed `:block` in the CST rather than a tuple+parameters, so
+            # mark each element of the block as its own binding.
+            for arg in inner.args
+                _mark_block_sig_arg!(arg, meta_dict, val)
+            end
+        else
+            mark_binding!(inner, meta_dict, val)
+        end
     elseif CSTParser.issplat(x)
         mark_binding!(x.args[1], meta_dict, x)
     elseif !(isunarysyntax(x) && valof(headof(x)) == "::")
@@ -204,6 +214,20 @@ function _is_nospecialize_macrocall(a::EXPR)
     CSTParser.isidentifier(a.args[1]) && valofid(a.args[1]) == "@nospecialize"
 end
 
+# Mark a single element of a `(a; b)`-style bracketed-block signature. Such a
+# block flattens the positional and keyword args together, and (like macrocalls)
+# represents a defaulted kwarg `b = default` as a plain assignment rather than a
+# `:kw` node, so unwrap that to bind the parameter name.
+function _mark_block_sig_arg!(a::EXPR, meta_dict, val)
+    if _is_nospecialize_macrocall(a)
+        _mark_nospecialize_arg!(a, meta_dict)
+    elseif CSTParser.isassignment(a)
+        mark_binding!(a.args[1], meta_dict, a)
+    else
+        mark_binding!(a, meta_dict, val)
+    end
+end
+
 function mark_sig_args!(x::EXPR, meta_dict)
     if CSTParser.iscall(x) || CSTParser.istuple(x)
         if x.args !== nothing && length(x.args) > 0
@@ -235,6 +259,13 @@ function mark_sig_args!(x::EXPR, meta_dict)
         mark_sig_args!(x.args[1], meta_dict)
     elseif CSTParser.isbracketed(x)
         mark_sig_args!(x.args[1], meta_dict)
+    elseif headof(x) === :block
+        # A `(a; b)` signature (e.g. `function (bar; baz) ... end`) collapses into a
+        # bracketed `:block` in the CST rather than a tuple+parameters; mark each
+        # element of the block as an argument binding.
+        for a in x.args
+            _mark_block_sig_arg!(a, meta_dict, a)
+        end
     elseif CSTParser.isdeclaration(x)
         mark_sig_args!(x.args[1], meta_dict)
     elseif CSTParser.isbinarycall(x)

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -2494,6 +2494,38 @@ end
     end
 end
 
+@testitem "anonymous function kwarg refs: #1312" setup=[shared_static_lint] begin
+    # A `(a; b)` signature with a single positional arg before the `;` collapses
+    # to a bracketed `:block` in the CST (rather than a `:tuple` + `:parameters`),
+    # so binding-marking has to handle that shape or the args resolve to nothing.
+    # Regression for LanguageServer.jl#1312.
+
+    # `function` keyword form
+    @test all(check_resolved("""
+    function (bar; baz)
+        bar + baz
+    end
+    """))
+
+    # arrow form
+    @test all(check_resolved("(bar; baz) -> bar + baz"))
+
+    # a defaulted kwarg is parsed as a plain assignment inside the block
+    @test all(check_resolved("""
+    function (bar; baz=1)
+        bar + baz
+    end
+    """))
+    @test all(check_resolved("(bar; baz=1) -> bar + baz"))
+
+    # a type-annotated kwarg
+    @test all(check_resolved("""
+    function (bar::Int; baz::Int)
+        bar + baz
+    end
+    """))
+end
+
 @testitem "iteration over 1:length(...)" setup=[shared_static_lint] begin
     cst, meta_dict, jw = parse_and_pass("arr = []; [1 for _ in 1:length(arr)]")
     @test isempty(collect_hints(cst, meta_dict, jw))


### PR DESCRIPTION
A `(a; b)` signature with a single positional arg before the `;` is parsed by CSTParser as a bracketed `:block` rather than a `:tuple` + `:parameters`. Neither `mark_sig_args!` (the `function (…)` path) nor `mark_binding!` (the `(…) -> …` path) handled that shape, so the args were never bound and every reference to them reported "no definition found".

Handle the bracketed block in both paths via a shared helper that also unwraps a defaulted kwarg `b = default`, which — like inside macrocalls — is parsed as a plain assignment instead of a `:kw` node.

Fixes julia-vscode/LanguageServer.jl#1312