### PR TITLE
fix: correct rename for macros

### DIFF
--- a/src/layer_references.jl
+++ b/src/layer_references.jl
@@ -203,8 +203,15 @@ shared by references, rename, and highlight.
 """
 function _for_each_ref(f, identifier::CSTParser.EXPR, meta_dict::MetaDict, runtime)
     if StaticLint.hasref(identifier, meta_dict) && StaticLint.refof(identifier, meta_dict) isa StaticLint.Binding
+        # StaticLint can register the same EXPR node more than once (e.g. a macro
+        # definition's name ends up in the binding's `refs` twice), so dedupe by
+        # node identity to avoid emitting duplicate results. Identity
+        # (not structural) equality is required: distinct occurrences such as two
+        # `@add_2` invocations are structurally equal and must be kept separate.
+        seen = Base.IdSet{CSTParser.EXPR}()
         for r in StaticLint.loose_refs(StaticLint.refof(identifier, meta_dict), meta_dict)
-            if r isa CSTParser.EXPR
+            if r isa CSTParser.EXPR && !(r in seen)
+                push!(seen, r)
                 loc = _get_file_loc(r, runtime)
                 if loc !== nothing
                     uri, o = loc
@@ -362,8 +369,15 @@ function _get_rename_edits(runtime, uri::URI, offset::Int, new_name::String)
     x = get_expr1(cst, offset)
     x === nothing && return results
 
+    # A macro's definition uses the bare name (`add_2`) while every invocation
+    # carries a leading `@` (`@add_2`). The client may send the new name with or
+    # without the `@`; normalize to the bare form and re-add the `@` only for the
+    # occurrences that had one, so the definition and invocations stay consistent
+    bare_name = startswith(new_name, "@") ? new_name[nextind(new_name, 1):end] : new_name
+
     _for_each_ref(x, meta_dict, runtime) do ref, ref_uri, o
-        push!(results, RenameEdit(ref_uri, _offset_to_position(runtime, ref_uri, o), _offset_to_position(runtime, ref_uri, o + ref.span), new_name))
+        text = startswith(CSTParser.str_value(ref), "@") ? "@" * bare_name : bare_name
+        push!(results, RenameEdit(ref_uri, _offset_to_position(runtime, ref_uri, o), _offset_to_position(runtime, ref_uri, o + ref.span), text))
     end
 
     return results

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -150,6 +150,125 @@ end
     @test all(e -> e.uri == uri, edits)
 end
 
+@testitem "References: rename locals/structs/globals/consts" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_rename_edits
+    using JuliaWorkspaces.URIs2: URI
+
+    # Guards the common (non-macro) rename path across binding kinds: every edit
+    # must carry the verbatim new name (no stray `@`, no duplicated ranges) and
+    # cover exactly the definition plus each use.
+    source = """
+    module CoverTest
+    const MAX = 100
+    glob = 1
+    struct Point
+        x
+        y
+    end
+    function f()
+        local_var = glob + MAX
+        p = Point(local_var, 2)
+        return local_var + p.x
+    end
+    end
+    """
+    uri = URI("file:///cover/src/CoverTest.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+
+    function string_index(src, line, col)
+        lines = split(src, '\n')
+        off = 0
+        for l in 1:(line - 1)
+            off += ncodeunits(lines[l]) + 1
+        end
+        return off + col
+    end
+
+    # (kind, line, col-inside-the-identifier, new name, expected occurrence count)
+    cases = [
+        ("const", 2, 8, "LIMIT", 2),   # `MAX`: definition + one use
+        ("global", 3, 2, "gg", 2),     # `glob`: definition + one use
+        ("struct", 4, 10, "Coord", 2), # `Point`: definition + one use
+        ("local", 9, 9, "lv", 3),      # `local_var`: definition + two uses
+    ]
+
+    for (kind, line, col, new_name, expected) in cases
+        idx = string_index(source, line, col)
+        edits = get_rename_edits(jw, uri, idx, new_name)
+        @test length(edits) == expected                              # $kind
+        @test all(e -> e.new_text == new_name, edits)                # verbatim, no `@`
+        @test all(e -> e.uri == uri, edits)
+        ranges = [(e.start.line, e.start.column, e.stop.line, e.stop.column) for e in edits]
+        @test length(unique(ranges)) == length(ranges)               # no duplicate edits
+    end
+
+    # Pre-existing `get_expr1` boundary quirk: with the cursor on the very first
+    # character of a type name right after the `struct` keyword (the `P` of
+    # `Point`, col 8), position resolution misses the identifier and no edits are
+    # produced. One character in it works (covered by the `struct` case above).
+    @test_broken length(get_rename_edits(jw, uri, string_index(source, 4, 8), "Coord")) == 2
+end
+
+@testitem "References: rename macro" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_rename_edits, get_references
+    using JuliaWorkspaces.URIs2: URI
+
+    # A macro definition uses the bare name (`add_2`), while every invocation
+    # carries the leading `@` (`@add_2`). Renaming must keep those consistent:
+    # the definition edit must not gain a stray `@`, invocation edits must keep
+    # it, and the definition must not be emitted twice.
+    source = """
+    module RenMacro
+    macro add_2(x)
+        return :(\$x + 2)
+    end
+    f() = @add_2 1
+    g(x) = @add_2(x)
+    end
+    """
+    uri = URI("file:///renmacro/src/RenMacro.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+
+    function string_index(src, line, col)
+        lines = split(src, '\n')
+        off = 0
+        for l in 1:(line - 1)
+            off += ncodeunits(lines[l]) + 1
+        end
+        return off + col
+    end
+
+    # Renaming from the definition and from an invocation must behave the same.
+    for (line, col) in ((2, 7), (5, 8))
+        idx = string_index(source, line, col)
+
+        # The macro binding has one definition + two invocations = 3 occurrences,
+        # each emitted exactly once (no duplicate for the definition).
+        refs = get_references(jw, uri, idx)
+        @test length(refs) == 3
+
+        # Client may send the new name with or without the leading `@`.
+        for new_name in ("@sub_2", "sub_2")
+            edits = get_rename_edits(jw, uri, idx, new_name)
+            @test length(edits) == 3
+
+            # Definition edit (line 2): bare name, no `@`.
+            def_edits = filter(e -> e.start.line == 2, edits)
+            @test length(def_edits) == 1
+            @test def_edits[1].new_text == "sub_2"
+
+            # Invocation edits (lines 5 and 6): keep the leading `@`.
+            inv_edits = filter(e -> e.start.line != 2, edits)
+            @test length(inv_edits) == 2
+            @test all(e -> e.new_text == "@sub_2", inv_edits)
+        end
+    end
+end
+
 @testitem "References: highlight basic" begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_highlights
     using JuliaWorkspaces.URIs2: URI


### PR DESCRIPTION
Macro renaming produced broken edits: the definition uses the bare name (`add_2`) while invocations carry a leading `@` (`@add_2`), and StaticLint registers the definition's name node in the binding's refs twice.

- Dedupe references by node identity in `_for_each_ref` (via `Base.IdSet`), fixing the duplicate definition edit shared by references/rename/highlight.
- Normalize the requested name to its bare form and re-add `@` only for occurrences that had one, so definition and invocations stay consistent.

Add regression tests for macro rename and for the non-macro path across locals/structs/globals/consts, plus a `@test_broken` documenting the pre-existing `get_expr1` boundary quirk on a type name's first character.

Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/1272.