### PR TITLE
fix: resolve re-exported names through `using` chains

### DIFF
--- a/src/StaticLint/imports.jl
+++ b/src/StaticLint/imports.jl
@@ -214,8 +214,8 @@ function _get_field(par, arg, state, visited=Base.IdSet{Any}())
             for used_module in values(par.modules)
                 if used_module isa SymbolServer.ModuleStore && isexportedby(Symbol(arg_str_rep), used_module)
                     return maybe_lookup(used_module[Symbol(arg_str_rep)], state)
-                elseif used_module isa Scope && scope_exports(used_module, arg_str_rep, state)
-                    return used_module.names[arg_str_rep]
+                elseif used_module isa Scope && (rb = exported_binding(used_module, arg_str_rep, state)) !== nothing
+                    return rb
                 end
             end
         end

--- a/src/StaticLint/references.jl
+++ b/src/StaticLint/references.jl
@@ -184,8 +184,9 @@ function resolve_ref_from_module(x::EXPR, scope::Scope, state::TraverseState)::B
     end
 
     # 2) Resolve exported names from this module scope
-    if scope_exports(scope, mn, state)
-        setref!(x, scope.names[mn], meta_dict)
+    b = exported_binding(scope, mn, state)
+    if b !== nothing
+        setref!(x, b, meta_dict)
         return true
     end
 
@@ -193,20 +194,51 @@ function resolve_ref_from_module(x::EXPR, scope::Scope, state::TraverseState)::B
 end
 
 """
-    scope_exports(scope::Scope, name::String)
+    scope_exports(scope::Scope, name::String, state)
 
 Does the scope export a variable called `name`?
 """
-function scope_exports(scope::Scope, name::String, state)
+scope_exports(scope::Scope, name::String, state) = exported_binding(scope, name, state) !== nothing
+
+"""
+    exported_binding(scope::Scope, name::String, state)
+
+The binding a module scope makes available under `name` via an `export`
+statement, or `nothing` if `name` isn't exported. Handles both names bound
+directly in the module and names brought in from a `using`'d module and then
+re-exported (`using ..Bar; export bar`).
+"""
+function exported_binding(scope::Scope, name::String, state)
     if scopehasbinding(scope, name) && (b = scope.names[name]) isa Binding
         initial_pass_on_exports(scope.expr, name, state)
         for ref in b.refs
             if ref isa EXPR && parentof(ref) isa EXPR && headof(parentof(ref)) === :export
-                return true
+                return b
             end
         end
     end
-    return false
+    # Re-export: `name` isn't bound locally, but an `export name` statement
+    # names it after a `using`'d module brought it into this scope. The
+    # exported identifier resolves (through the module's used modules) to the
+    # originating binding, which is what callers should point references at.
+    return reexported_binding(scope, name, state)
+end
+
+function reexported_binding(scope::Scope, name::String, state)
+    meta_dict = state.meta_dict
+    CSTParser.defines_module(scope.expr) || return nothing
+    block = scope.expr.args[3]
+    block === nothing && return nothing
+    initial_pass_on_exports(scope.expr, name, state)
+    for a in block.args
+        headof(a) === :export || continue
+        for arg in a.args
+            (isidentifier(arg) && valofid(arg) == name) || continue
+            r = refof(arg, meta_dict)
+            (r isa Binding || r isa SymbolServer.SymStore) && return r
+        end
+    end
+    return nothing
 end
 
 """

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -273,6 +273,56 @@ end
 
 
 
+@testitem "Re-exported names" setup=[shared_static_lint] begin
+    # A name brought into a module via `using` and then `export`ed should be
+    # available to code that `using`s that module (re-export).
+    @test check_resolved("""
+module Bar
+bar() = 0
+export bar
+end
+module Foo
+using ..Bar
+export bar
+end
+using .Foo
+bar()
+""") == fill(true, 8)
+
+    # Transitive re-export across three modules.
+    @test check_resolved("""
+module Bar
+bar() = 0
+export bar
+end
+module Foo
+using ..Bar
+export bar
+end
+module Baz
+using ..Foo
+export bar
+end
+using .Baz
+bar()
+""") == fill(true, 11)
+
+    # A name that is `using`'d but not re-exported must NOT leak out.
+    @test check_resolved("""
+module Bar
+bar() = 0
+export bar
+end
+module Foo
+using ..Bar
+end
+using .Foo
+bar()
+""") == [true, true, true, true, true, true, false]
+end
+
+
+
 @testitem "macros" setup=[shared_static_lint] begin
     @test check_resolved("""
         @enum(E,a,b)


### PR DESCRIPTION
A name brought into a module via `using` and then `export`ed lives in the module's `modules` table rather than its `names` table, so `scope_exports` treated it as not exported. References to such re-exported names via `using .Mod` were flagged as missing.

Add `exported_binding`, which returns the binding a module makes available under a name, handling both locally bound and re-exported names (the latter by following the export identifier's resolved reference to its origin). This also covers transitive re-exports across module chains.

Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/1204.