### PR TITLE
fix: correct get_expr1 position lookup at node boundaries

### DIFF
--- a/src/layer_hover.jl
+++ b/src/layer_hover.jl
@@ -41,28 +41,27 @@ function get_expr1(x, offset, pos=0)
             arg = x[i]
             if pos < offset < (pos + arg.span) # def within span
                 return get_expr1(arg, offset, pos)
+            elseif offset == pos
+                if i > 1 && CSTParser.headof(x[i - 1]) === :IDENTIFIER && x[i - 1].span == x[i - 1].fullspan
+                    # Attribute the position to the preceding identifier only when
+                    # the cursor is flush against its text. The `span == fullspan`
+                    # check excludes an identifier that carries trailing trivia
+                    # (e.g. the `x` in `g(x;y)`, whose fullspan swallows the `;`):
+                    # there the cursor is past the text, so the following node owns
+                    # the position.
+                    return get_expr1(x[i - 1], offset, pos)
+                elseif arg.span != 0 || i == 1
+                    return get_expr1(arg, offset, pos)
+                end
+                # Zero-width node (empty block, mutable/bare-module flag, …) cannot
+                # own the position; fall through to the sibling that begins at this
+                # same offset.
             elseif arg.span == arg.fullspan
-                if offset == pos
-                    if i == 1
-                        return get_expr1(arg, offset, pos)
-                    elseif CSTParser.headof(x[i - 1]) === :IDENTIFIER
-                        return get_expr1(x[i - 1], offset, pos)
-                    else
-                        return get_expr1(arg, offset, pos)
-                    end
-                elseif i == length(x) # offset == pos + arg.fullspan
+                if i == length(x) # offset == pos + arg.fullspan
                     return get_expr1(arg, offset, pos)
                 end
             else
-                if offset == pos
-                    if i == 1
-                        return get_expr1(arg, offset, pos)
-                    elseif CSTParser.headof(x[i - 1]) === :IDENTIFIER
-                        return get_expr1(x[i - 1], offset, pos)
-                    else
-                        return get_expr1(arg, offset, pos)
-                    end
-                elseif offset == pos + arg.span
+                if offset == pos + arg.span
                     return get_expr1(arg, offset, pos)
                 elseif offset == pos + arg.fullspan
                 elseif pos + arg.span < offset < pos + arg.fullspan

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -679,3 +679,34 @@ end
     @test result !== nothing
     @test occursin("Datatype field `b` of Foo", result)
 end
+
+@testitem "Hover: keyword parameter in definition signature" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_hover_text, get_expr1
+    using JuliaWorkspaces: derived_julia_legacy_syntax_tree
+    using JuliaWorkspaces.URIs2: URI
+    import CSTParser
+
+    # CSTParser folds the `;` separator into the preceding positional argument's
+    # `fullspan`, so the `parameters` node directly follows an IDENTIFIER with no
+    # separator token in between. A boundary heuristic in `get_expr1` used to grab
+    # that preceding identifier, so hovering the keyword parameter `y` resolved to
+    # the positional `x` instead.
+    source = "g(x;y)=x+y\n"
+
+    jw = JuliaWorkspace()
+    uri = URI("file:///kwparam/test.jl")
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+
+    # Hovering the keyword parameter `y` (index 5) must resolve to `y`, not `x`.
+    result = get_hover_text(jw, uri, 5)
+    @test result !== nothing
+    clean = replace(result, "\r" => "")
+    @test occursin("```julia\ny\n```", clean)
+    @test !occursin("```julia\nx\n```", clean)
+
+    # Direct unit check on the offset lookup: offset 4 (0-based) is the `y` of the
+    # parameters block, offset 2 is the positional `x`.
+    cst = CSTParser.parse(source)
+    @test CSTParser.str_value(get_expr1(cst, 4)) == "y"
+    @test CSTParser.str_value(get_expr1(cst, 2)) == "x"
+end

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -204,11 +204,12 @@ end
         @test length(unique(ranges)) == length(ranges)               # no duplicate edits
     end
 
-    # Pre-existing `get_expr1` boundary quirk: with the cursor on the very first
-    # character of a type name right after the `struct` keyword (the `P` of
-    # `Point`, col 8), position resolution misses the identifier and no edits are
-    # produced. One character in it works (covered by the `struct` case above).
-    @test_broken length(get_rename_edits(jw, uri, string_index(source, 4, 8), "Coord")) == 2
+    # Cursor on the very first character of a type name right after the `struct`
+    # keyword (the `P` of `Point`, col 8): a zero-width mutability-flag node sits
+    # at the same offset as the identifier, and `get_expr1` used to resolve to it
+    # (missing the identifier, producing no edits). It now skips the zero-width
+    # node and resolves the identifier.
+    @test length(get_rename_edits(jw, uri, string_index(source, 4, 8), "Coord")) == 2
 end
 
 @testitem "References: rename macro" begin


### PR DESCRIPTION
get_expr1 resolves the CST node under a cursor offset by walking children and accumulating fullspans. Its handling of the boundary case (offset at a node's left edge) mishandled two CSTParser span layouts:

- An identifier whose fullspan swallows trailing trivia (e.g. the `x` in `g(x;y)`, which absorbs the `;`) wrongly captured a cursor that had moved past its text onto the following node, so hovering the keyword parameter `y` resolved to `x`.
- Zero-width nodes (empty blocks, the mutable/bare-module flag) share a position with the meaningful node starting there and shadowed it, so hovering the `end` of an empty module, or the first character of a type name, missed the real node.

Only attribute a boundary to the preceding identifier when the cursor is flush against its text (span == fullspan), and skip zero-width nodes so the sibling that actually begins at the offset wins.

Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/852.