### PR TITLE
feat: shorten type qualifiers and omit `::Any` in signature help

### DIFF
--- a/shared/symbolserver/faketypes.jl
+++ b/shared/symbolserver/faketypes.jl
@@ -100,7 +100,21 @@ function _parameter(@nospecialize(p), budget::ExpandBudget=ExpandBudget())
     end
 end
 
-Base.show(io::IO, vr::VarRef) = vr.parent === nothing ? print(io, vr.name) : print(io, vr.parent, ".", vr.name)
+function Base.show(io::IO, vr::VarRef)
+    if vr.parent === nothing
+        print(io, vr.name)
+    else
+        # An `:ss_shorten` predicate in the IOContext may request dropping the
+        # module qualifier (e.g. `Core.Any` -> `Any`) for names it deems
+        # unambiguous
+        pred = get(io, :ss_shorten, nothing)
+        if pred !== nothing && pred(vr)
+            print(io, vr.name)
+        else
+            print(io, vr.parent, ".", vr.name)
+        end
+    end
+end
 function Base.show(io::IO, tn::FakeTypeName)
     print(io, tn.name)
     if !isempty(tn.parameters)

--- a/shared/symbolserver/utils.jl
+++ b/shared/symbolserver/utils.jl
@@ -327,11 +327,16 @@ const JULIA_DIR = normpath(joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia"))
 
 function Base.print(io::IO, m::MethodStore)
     print(io, m.name, "(")
+    # An `:ss_omit_any` flag in the IOContext drops the annotation on `::Any`
+    # arguments.
+    omit_any = get(io, :ss_omit_any, false)
     for i = 1:length(m.sig)
         if m.sig[i][1] != Symbol("#unused#")
             print(io, m.sig[i][1])
         end
-        print(io, "::", m.sig[i][2])
+        if !(omit_any && isfakeany(m.sig[i][2]))
+            print(io, "::", m.sig[i][2])
+        end
         i != length(m.sig) && print(io, ", ")
     end
     print(io, ")")

--- a/src/layer_signatures.jl
+++ b/src/layer_signatures.jl
@@ -116,13 +116,31 @@ function _get_signatures(b::StaticLint.Binding, tls::StaticLint.Scope, sigs::Vec
     end
 end
 
+# Predicate for `:ss_shorten`: a top-level `Core`/`Base` name that its module
+# exports (e.g. `Core.Any`, `Base.Dict`) can be printed without its qualifier.
+function _sig_shorten_pred(env)
+    syms = StaticLint.getsymbols(env)
+    return function (vr::SymbolServer.VarRef)
+        SymbolServer.isfakeany(vr) && return true
+        p = vr.parent
+        (p isa SymbolServer.VarRef && p.parent === nothing) || return false
+        mod = get(syms, p.name, nothing)
+        mod isa SymbolServer.ModuleStore && vr.name in mod.exportednames
+    end
+end
+
+_sig_type_str(@nospecialize(t), pred) =
+    sprint((io, x) -> show(IOContext(io, :ss_shorten => pred), x), t)
+
 function _get_signatures(b::T, tls::StaticLint.Scope, sigs::Vector{SignatureInfo}, env, meta_dict) where T <: Union{SymbolServer.FunctionStore,SymbolServer.DataTypeStore}
+    pred = _sig_shorten_pred(env)
     StaticLint.iterate_over_ss_methods(b, tls, env, function (m)
-        push!(sigs, SignatureInfo(
-            string(m),
-            "",
-            [ParameterInfo(string(a[1]), string(a[2])) for a in m.sig]
-        ))
+        label = sprint((io, x) -> print(IOContext(io, :ss_shorten => pred, :ss_omit_any => true), x), m)
+        params = [ParameterInfo(
+                string(a[1]),
+                SymbolServer.isfakeany(a[2]) ? "" : _sig_type_str(a[2], pred)
+            ) for a in m.sig]
+        push!(sigs, SignatureInfo(label, "", params))
         return false
     end)
 end

--- a/test/test_signatures.jl
+++ b/test/test_signatures.jl
@@ -193,6 +193,37 @@ end
     @test [p.label for p in sig.parameters] == ["var\"hello world\"", "normal"]
 end
 
+@testitem "Signatures: stdlib types unqualified and ::Any omitted" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
+    using JuliaWorkspaces.URIs2: URI
+
+    function sigs_for(call)
+        jw = JuliaWorkspace()
+        uri = URI("file:///sigshort/s.jl")
+        add_file!(jw, TextFile(uri, SourceText(call, "julia")))
+        return get_signature_help(jw, uri, ncodeunits(call)).signatures
+    end
+
+    # `identity(x)` has a single method with an untyped (::Any) argument, so
+    # the `::Any` annotation must be dropped entirely.
+    sigs = sigs_for("identity(")
+    @test !isempty(sigs)
+    s = first(sigs)
+    @test occursin("identity(x) in Base", s.label)
+    @test !occursin("Core.Any", s.label)
+    @test !occursin("::", split(s.label, " in ")[1])
+    @test s.parameters[1].label == "x"
+    @test s.parameters[1].documentation == ""
+
+    # `print(io::IO, ...)` — the exported `IO` type must render without its
+    # `Core.` module qualifier, both in the label and the parameter docs.
+    psigs = sigs_for("print(")
+    @test !isempty(psigs)
+    @test !any(s -> occursin("Core.IO", s.label), psigs)
+    @test any(s -> occursin("io::IO", s.label), psigs)
+    @test any(s -> any(p -> p.documentation == "IO", s.parameters), psigs)
+end
+
 @testitem "Signatures: function with var\"\" argument (#3867)" begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
     using JuliaWorkspaces.URIs2: URI


### PR DESCRIPTION
Method signature hints rendered types with full module qualifiers (`x::Core.Any`, `io::Core.IO`, `Base.Dict{K,V}`) and always kept the `::Any` annotation, which is verbose noise.

Render signature-help labels and parameter docs through two opt-in `IOContext` flags consumed by the shared SymbolServer show/print:

- `:ss_shorten` drops the module qualifier for a top-level `Core`/`Base` name that its module exports (and always for `Core.Any`).
- `:ss_omit_any` drops the annotation on `::Any` arguments.

Both default to the previous behavior when unset, so other consumers of the shared rendering are unaffected.

Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/826.