### PR TITLE
fix: offer signatures for methods with no positional arguments

### DIFF
--- a/src/layer_signatures.jl
+++ b/src/layer_signatures.jl
@@ -374,6 +374,11 @@ function _get_signature_help(runtime, uri::URI, offset::Int)
 
     arg = _fcall_arg_number(x)
 
-    filtered = filter(s -> length(s.parameters) > arg, sigs)
+    # Once the cursor sits at a positional argument beyond the first (`arg > 0`),
+    # narrow to signatures that actually have a parameter at that position. At the
+    # first position (`arg == 0`) nothing has been committed yet, so every method
+    # remains a candidate — including those with no positional parameters at all
+    # (e.g. `f(; kw)` or `f()`), which must still be offered rather than skipped.
+    filtered = arg == 0 ? sigs : filter(s -> length(s.parameters) > arg, sigs)
     return SignatureResult(filtered, 0, arg)
 end

--- a/test/test_signatures.jl
+++ b/test/test_signatures.jl
@@ -285,3 +285,32 @@ end
     sig = first(result.signatures)
     @test [p.label for p in sig.parameters] == ["var\"weird arg\"", "normal"]
 end
+
+@testitem "Signatures: methods with 0 positional arguments are not skipped" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
+    using JuliaWorkspaces.URIs2: URI
+
+    function sigs_for(call)
+        jw = JuliaWorkspace()
+        uri = URI("file:///sigzero/s.jl")
+        add_file!(jw, TextFile(uri, SourceText(call, "julia")))
+        return get_signature_help(jw, uri, ncodeunits(call)).signatures
+    end
+
+    # A function with a positional method and a keyword-only method: at the open
+    # paren all methods are candidates, so both signatures must be offered — the
+    # keyword-only `bar(; x)` has 0 positional parameters and must not be dropped.
+    sigs = sigs_for("bar(x) = x\nbar(; x) = bar(x)\nbar(")
+    labels = [s.label for s in sigs]
+    @test any(l -> occursin("bar(x)", l), labels)
+    @test any(l -> occursin("bar(; x)", l), labels)
+
+    # A sole keyword-only method must still produce a popup (0 positional args).
+    sigs = sigs_for("baz(; x) = x\nbaz(")
+    @test !isempty(sigs)
+    @test any(l -> occursin("baz(; x)", l.label), sigs)
+
+    # A method that takes no arguments at all must also be offered at `(`.
+    sigs = sigs_for("qux() = 1\nqux(")
+    @test !isempty(sigs)
+end


### PR DESCRIPTION
Signature help filtered candidate signatures with
`length(s.parameters) > arg`, but `parameters` holds only positional parameters. At the first argument position (`arg == 0`) this dropped every method with zero positional parameters, so a keyword-only method like `bar(; x)` was skipped and a sole `baz(; x)` produced no popup at all.

At the first position nothing is committed yet, so keep all methods as candidates; narrowing by positional arity still applies once the cursor moves past the first argument.

Fixes https://github.com/julia-vscode/LanguageServer.jl/issues/1367.