### PR TITLE
fix(lint): resolve const type aliases and respect local shadowing in method checks

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -347,6 +347,20 @@ end
 is_something_with_methods(x::T) where T <: Union{SymbolServer.FunctionStore,SymbolServer.DataTypeStore} = true
 is_something_with_methods(x) = false
 
+# A function-LOCAL callee binding — a closure or parameter defined inside a
+# function/macro body — as opposed to a module/file top-level definition. A local
+# fully shadows any same-named global, so its method set is exactly its own; the
+# cross-file `tree_arities` gate (which reasons about module-level names whose
+# methods may span sibling files) must not apply, or a call to the local
+# false-flags against the global's arity.
+_is_local_callee_binding(b, meta_dict) = false
+function _is_local_callee_binding(b::Binding, meta_dict)
+    b.val isa EXPR || return false
+    p = parentof(b.val)
+    p isa EXPR || return false
+    return maybe_get_parent_fexpr(p, x -> CSTParser.defines_function(x) || CSTParser.defines_macro(x)) !== nothing
+end
+
 function check_call(x, env::ExternalEnv, meta_dict, tree_visible=nothing, tree_extended=nothing, tree_arities=nothing, tree_in_scope=nothing)
     if iscall(x)
         parentof(x) isa EXPR && headof(parentof(x)) === :do && return # TODO: add number of args specified in do block.
@@ -367,7 +381,7 @@ function check_call(x, env::ExternalEnv, meta_dict, tree_visible=nothing, tree_e
         # tree-visible (methods may span sibling files), OR a `TreeRef` to a
         # function/macro/struct defined only in sibling files.
         if tree_visible !== nothing &&
-           (func_ref isa Binding ||
+           ((func_ref isa Binding && !_is_local_callee_binding(func_ref, meta_dict)) ||
             (func_ref isa TreeRef && func_ref.kind in (:function, :macro, :struct, :mutable_struct)))
             name = CSTParser.get_name(x)
             if name isa EXPR && isidentifier(name)
@@ -721,32 +735,36 @@ function describe_call_mismatch(call::EXPR, env::ExternalEnv, meta_dict; cand_ar
     # (the cross-file arity path has no per-method types — that is Part B).
     cands === nothing && return header
 
-    # closest arity/keyword-ok candidate with a known mismatch
+    # candidates of matching arity (and, if the call has keywords, keyword-ok)
     kw_ok = [i for i in arity_ok if counts[i].kwsplat || all(kw in counts[i].kws for kw in act_kws)]
     consider = isempty(kw_ok) ? arity_ok : kw_ok
-    best_i, best_slot, best_got, best_exp, best_count = 0, 0, nothing, nothing, typemax(Int)
+    # Collapse duplicate views of the SAME method — a workspace binding yields its
+    # definition EXPR through both `.val` and a `.refs` entry. With more than one
+    # DISTINCT candidate of matching arity, no single "expected `T`" is meaningful
+    # (the argument may suit another overload's slot), so emit header only rather
+    # than naming an arbitrary one; the header already lists the actual arg types.
+    distinct = Any[]
     for i in consider
-        mism = 0
-        first_slot = 0
-        for s in 1:nargs
-            exp = _expected_arg_type(cands[i], s, nargs, store, meta_dict)
-            exp === nothing && continue
-            got = s <= length(inferred) ? inferred[s] : nothing
-            if !_has_type_intersection(got, exp, store, meta_dict)
-                mism += 1
-                first_slot == 0 && (first_slot = s)
-            end
-        end
-        if mism > 0 && mism < best_count
-            best_count = mism
-            best_i, best_slot = i, first_slot
-            best_exp = _expected_arg_type(cands[i], first_slot, nargs, store, meta_dict)
-            best_got = first_slot <= length(inferred) ? inferred[first_slot] : nothing
+        any(c -> c === cands[i], distinct) || push!(distinct, cands[i])
+    end
+    length(distinct) == 1 || return header
+
+    cand = distinct[1]
+    slot = 0
+    for s in 1:nargs
+        exp = _expected_arg_type(cand, s, nargs, store, meta_dict)
+        exp === nothing && continue
+        got = s <= length(inferred) ? inferred[s] : nothing
+        if !_has_type_intersection(got, exp, store, meta_dict)
+            slot = s
+            break
         end
     end
-    if best_slot > 0
-        return string(header, " At argument ", best_slot, ": expected `",
-            _format_type(best_exp), "`, got `", _format_type(best_got), "`.")
+    if slot > 0
+        exp = _expected_arg_type(cand, slot, nargs, store, meta_dict)
+        got = slot <= length(inferred) ? inferred[slot] : nothing
+        return string(header, " At argument ", slot, ": expected `",
+            _format_type(exp), "`, got `", _format_type(got), "`.")
     end
     return header
 end

--- a/src/StaticLint/type_inf.jl
+++ b/src/StaticLint/type_inf.jl
@@ -189,7 +189,19 @@ function infer_type_assignment_rhs(binding, state, scope)
         elseif (literal_type = infer_literal_type(rhs)) !== nothing
             settype!(binding, literal_type)
         elseif isidentifier(rhs) || is_getfield_w_quotenode(rhs)
-            refof_rhs = isidentifier(rhs) ? refof(rhs, meta_dict) : refof_maybe_getfield(rhs, meta_dict)
+            # Resolve the RHS on demand (idempotent): a cross-file / external base
+            # (`const PA = PkgId` under `using Base: PkgId`) may not have a ref yet
+            # when inference reaches the assignment, and in per-file mode only
+            # resolves through the `:__tree__` context on the scope chain. Without
+            # this the alias's type stayed unset and it wasn't recognized as a type
+            # alias (so `::Alias` args didn't narrow — see `_resolve_type_alias`).
+            if isidentifier(rhs)
+                !hasref(rhs, meta_dict) && resolve_ref(rhs, scope, state)
+                refof_rhs = refof(rhs, meta_dict)
+            else
+                refof_maybe_getfield(rhs, meta_dict) === nothing && resolve_getfield(rhs, scope, state)
+                refof_rhs = refof_maybe_getfield(rhs, meta_dict)
+            end
             if is_destructuring
                 # property destructuring `(; field) = obj`: infer the field's
                 # declared type from `obj`'s type rather than `obj`'s type itself.
@@ -207,6 +219,17 @@ function infer_type_assignment_rhs(binding, state, scope)
                     settype!(binding, CoreTypes.DataType)
                 else
                     settype!(binding, refof_rhs.type)
+                end
+            elseif refof_rhs isa TreeRef
+                # A cross-file / external base (`const PA = PkgId`): mark the alias
+                # as a datatype/function so `::Alias` narrows through
+                # `_resolve_type_alias`, exactly as the parametric `curly` branch
+                # above does.
+                store = resolve_treeref_store(refof_rhs, state)
+                if store isa SymbolServer.DataTypeStore
+                    settype!(binding, CoreTypes.DataType)
+                elseif store isa SymbolServer.FunctionStore
+                    settype!(binding, CoreTypes.Function)
                 end
             elseif refof_rhs isa SymbolServer.GenericStore && refof_rhs.typ isa SymbolServer.FakeTypeName
                 settype!(binding, maybe_lookup(refof_rhs.typ.name, state))
@@ -252,6 +275,67 @@ end
 # An alias may resolve to something carrying no field information (or `nothing`).
 infer_destructuring_type(binding, rb, meta_dict, depth=0) = nothing
 
+# A `const Alias = <type>` binding: a datatype-typed binding whose `val` is a
+# plain assignment rather than a `struct`/`abstract`/`primitive` definition. Its
+# own supertype chain dead-ends at `Any` (`_super` can't walk an assignment), so
+# it must never stand in as a resolved type — resolve it through `_resolve_type_alias`
+# or drop it.
+_is_type_alias(b::Binding) =
+    b.val isa EXPR && isassignment(b.val) && length(b.val.args) == 2 && CoreTypes.isdatatype(b.type)
+
+# A `const Alias = T` / `const Alias = T{...}` type alias: follow the RHS to the
+# datatype it names, so a `::Alias` annotation narrows to the real type (method
+# matching, field completion) instead of the opaque alias binding (whose type is
+# the `DataType` meta-type and whose supertype chain dead-ends at `Any`). Returns
+# the aliased `DataTypeStore` / datatype `Binding`, or `nothing` when `b` isn't
+# such an alias, or when its base type can't be resolved (external package not in
+# the env, unresolved cross-file name). `depth` guards against `const A = B;
+# const B = A` cycles.
+function _resolve_type_alias(b::Binding, state, depth=0)
+    depth > 20 && return nothing
+    _is_type_alias(b) || return nothing
+    rhs = CSTParser.rem_wheres_decls(b.val.args[2])
+    if iscurly(rhs) && rhs.args !== nothing && length(rhs.args) >= 1
+        rhs = rhs.args[1]
+    end
+    meta_dict = state.meta_dict
+    # The base is resolved on demand in the alias's own scope (idempotent) — its
+    # ref may not be set yet when type inference reaches a `::Alias` annotation,
+    # and in per-file mode a cross-file/external base only resolves through the
+    # `:__tree__` context seeded on that scope chain. Mirrors `infer_type_decl`.
+    scope = retrieve_scope(b.val, meta_dict)
+    if isidentifier(rhs)
+        scope isa Scope && !hasref(rhs, meta_dict) && resolve_ref(rhs, scope, state)
+        r = refof(rhs, meta_dict)
+    elseif is_getfield_w_quotenode(rhs)
+        scope isa Scope && !hasref(rhs, meta_dict) && resolve_getfield(rhs, scope, state)
+        r = refof_maybe_getfield(rhs, meta_dict)
+    else
+        return nothing
+    end
+    if r isa TreeRef
+        # per-file mode: a cross-file / external base (`using OrderedCollections`
+        # ⇒ `OrderedDict`) resolves to an `:external_symbol` TreeRef, exactly as a
+        # direct `::OrderedDict` annotation does — resolve it through the env the
+        # same way `_settype_from_decl!` does.
+        store = resolve_treeref_store(r, state)
+        return store isa SymbolServer.DataTypeStore ? store : nothing
+    elseif r isa SymbolServer.DataTypeStore
+        return r
+    elseif r isa SymbolServer.FunctionStore
+        return get_eventual_datatype(r, state.env)
+    elseif r isa Binding
+        rb = get_root_method(r)
+        rb isa Binding || return nothing
+        # `const A = B`: chase B if it is itself an alias, else use it directly
+        # when it's a real workspace datatype.
+        nested = _resolve_type_alias(rb, state, depth + 1)
+        nested !== nothing && return nested
+        !_is_type_alias(rb) && CoreTypes.isdatatype(rb.type) && return rb
+    end
+    return nothing
+end
+
 # Shared tail of both `infer_type_decl` forms: `t` is the (unwrapped, resolved)
 # type expression of a `::T` declaration. A cross-file `TreeRef` annotation
 # (e.g. a sibling `using Base: PkgId`) is resolved through the env — since
@@ -267,7 +351,24 @@ function _settype_from_decl!(binding, t, state)
     elseif r isa Binding
         rb = get_root_method(r)
         if rb isa Binding && CoreTypes.isdatatype(rb.type)
-            settype!(binding, rb)
+            alias = _resolve_type_alias(rb, state)
+            if alias !== nothing
+                settype!(binding, alias)
+            elseif !_is_type_alias(rb)
+                # A real workspace datatype (`struct`/`abstract`/…): its supertype
+                # chain is walkable, narrow to it.
+                settype!(binding, rb)
+            end
+            # else: an alias whose base didn't resolve — leave the type unset so
+            # it reads as `Any`, exactly like a direct annotation to an
+            # unresolvable type. The opaque alias binding has no supertype chain
+            # and would false-flag method calls on the arg.
+        elseif rb isa Binding && rb.val isa EXPR && isassignment(rb.val)
+            # `x::Alias` where the alias's base was fully unresolvable, so it never
+            # even got a `DataType` type (`const A = SomethingUndefined`): leave
+            # the arg type unset (→ `Any`) rather than the opaque alias binding.
+            # Its broken supertype chain would false-flag method calls; the bad
+            # base is already reported as a missing reference.
         else
             settype!(binding, r)
         end

--- a/src/layer_file_analysis.jl
+++ b/src/layer_file_analysis.jl
@@ -494,6 +494,10 @@ function _call_cross_file_arities(rt, root, path, call, meta_dict)
     root === nothing && return nothing
     func_ref = StaticLint.refof_call_func(call, meta_dict)
     (func_ref isa StaticLint.Binding || func_ref isa StaticLint.TreeRef) || return nothing
+    # A function-local callee fully shadows any same-named global, so its method
+    # set is exactly its own — describe from the local candidates, not the global
+    # name's cross-file arities (mirrors `check_call`'s gate).
+    func_ref isa StaticLint.Binding && StaticLint._is_local_callee_binding(func_ref, meta_dict) && return nothing
     nm = CSTParser.get_name(call)
     (nm isa CSTParser.EXPR && StaticLint.isidentifier(nm)) || return nothing
     name = StaticLint.valofid(nm)

--- a/src/layer_references.jl
+++ b/src/layer_references.jl
@@ -434,6 +434,16 @@ function _get_definitions_from_val(b::StaticLint.Binding, tls, env, results, run
                 _get_definitions_from_val(method, tls, env, results, runtime, root; in_scope=in_scope)
             end
         end
+        # A type/function ALIAS (`const A = T`, `const g = f`) also carries a
+        # datatype/function type, but its `val` is a plain assignment rather than
+        # a definition. The ref-walk above still finds any methods/constructors
+        # defined ON the alias (`A(x) = ...`), but not the alias declaration
+        # itself — add it so go-to-def also lands on the `const` line (and yields
+        # something rather than nothing for a plain alias with no methods).
+        if b.val isa CSTParser.EXPR &&
+                !(CSTParser.defines_function(b.val) || CSTParser.defines_datatype(b.val) || CSTParser.defines_macro(b.val))
+            _get_definitions_from_val(b.val, tls, env, results, runtime, root; in_scope=in_scope)
+        end
     elseif b.val isa CSTParser.EXPR
         _get_definitions_from_val(b.val, tls, env, results, runtime, root; in_scope=in_scope)
     end

--- a/test/staticlint/test_inference.jl
+++ b/test/staticlint/test_inference.jl
@@ -150,6 +150,142 @@ end
     @test !any(d -> occursin("Cannot define function", d.message), fa.diagnostics)
 end
 
+@testitem "method matching through a const type alias" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.URIs2: URI
+
+    # A `::Alias` arg annotation, where `Alias` is a `const` type alias (parametric
+    # `const IntDict = Dict{Int,Int}` or not `const MyDict = Dict`), must narrow to
+    # the aliased datatype so calls on the arg (`length(x)`) match. Previously the
+    # arg took the opaque alias binding (type `DataType`, no supertype chain) and
+    # every method call false-flagged "No method matching".
+    root = URI("file:///t/src/M.jl")
+    f = URI("file:///t/src/t.jl")
+    jw = ws_files(
+        root => "module M\ninclude(\"t.jl\")\nend\n",
+        f => """
+        const MyDict = Dict
+        const IntDict = Dict{Int,Int}
+        f(x::IntDict) = length(x)
+        f(x::MyDict) = length(x)
+        f(x::Dict) = length(x)
+        """,
+    )
+    fa = JuliaWorkspaces.derived_file_analysis(jw.runtime, root, f)
+    @test !any(d -> occursin("No method matching", d.message), fa.diagnostics)
+end
+
+@testitem "narrow through a const alias whose base is cross-file/external" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.URIs2: URI
+    using JuliaWorkspaces.StaticLint: bindingof, Binding, CoreTypes
+    using JuliaWorkspaces.CSTParser: CSTParser
+    const DataTypeStore = JuliaWorkspaces.SymbolServer.DataTypeStore
+
+    # A `const Alias = T` whose base `T` is only visible cross-file / from another
+    # module resolves per-file to an `:external_symbol` TreeRef (not a local
+    # Binding/store). The alias must still follow that TreeRef to the real
+    # datatype — both the bare form (`const PA = PkgId`) and the parametric form
+    # (`const PAV = Vector{PkgId}`) — so `::Alias` args narrow and calls on them
+    # don't false-flag. Uses `Base: PkgId` (always available in the test env).
+    root = URI("file:///t/src/M.jl")
+    f = URI("file:///t/src/t.jl")
+    jw = ws_files(
+        root => "module M\nusing Base: PkgId\ninclude(\"t.jl\")\nend\n",
+        f => "const PA = PkgId\nconst PAV = Vector{PkgId}\nf(x::PA) = x.name\ng(x::PAV) = length(x)\n",
+    )
+    fa = JuliaWorkspaces.derived_file_analysis(jw.runtime, root, f)
+    cst = JuliaWorkspaces.derived_julia_legacy_syntax_tree(jw.runtime, f)
+
+    argtype(name) = begin
+        t = nothing
+        find_first(cst) do x
+            if CSTParser.isdeclaration(x) && length(x.args) >= 2 &&
+                    JuliaWorkspaces.StaticLint.isidentifier(x.args[2]) &&
+                    CSTParser.valof(x.args[2]) == name && bindingof(x, fa.meta) isa Binding
+                t = bindingof(x, fa.meta).type
+                return true
+            end
+            false
+        end
+        t
+    end
+
+    # bare alias → the real PkgId datatype
+    tpa = argtype("PA")
+    @test tpa isa DataTypeStore && occursin("PkgId", string(tpa.name))
+    # parametric alias → the container datatype (Array)
+    @test argtype("PAV") isa DataTypeStore
+    # `x.name` (a real PkgId field) and `length(::Vector)` must not false-flag
+    @test !any(d -> occursin("No method matching", d.message) ||
+                    occursin("has no field", d.message), fa.diagnostics)
+end
+
+@testitem "const alias with an unresolvable base does not false-flag calls" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.URIs2: URI
+
+    # When an alias's base can't be resolved at all (undefined name), the arg must
+    # read as `Any` (type left unset) rather than the opaque alias binding — a
+    # broken supertype chain would spuriously fail method matching. The bad base
+    # is still reported as a missing reference; the method call must not be. Covers
+    # both the bare (`const B2 = Undef`) and parametric (`const B1 = Undef{Int}`)
+    # forms.
+    root = URI("file:///t/src/M.jl")
+    f = URI("file:///t/src/t.jl")
+    jw = ws_files(
+        root => "module M\ninclude(\"t.jl\")\nend\n",
+        f => "const B1 = NoSuchType{Int}\nf(x::B1) = length(x)\nconst B2 = AlsoMissing\ng(x::B2) = length(x)\n",
+    )
+    fa = JuliaWorkspaces.derived_file_analysis(jw.runtime, root, f)
+    @test !any(d -> occursin("No method matching", d.message), fa.diagnostics)
+    # the genuinely-broken bases are still surfaced
+    @test any(d -> occursin("Missing reference", d.message), fa.diagnostics)
+end
+
+@testitem "local shadow of a global function is not checked against the global" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.URIs2: URI
+
+    # A local closure or parameter that shadows a module-level function fully
+    # replaces it — its method set is exactly its own, so calls must be checked
+    # against the local, not the global's (cross-file) arity. Previously the
+    # tree-arity gate keyed on the NAME and false-flagged the shadowed call.
+    root = URI("file:///t/src/M.jl")
+    f = URI("file:///t/src/t.jl")
+    jw = ws_files(
+        root => "module M\ninclude(\"t.jl\")\nend\n",
+        f => """
+        foo(a, b) = a + b
+        function bar()
+            foo(a) = a
+            foo(1)
+        end
+        function bar(foo)
+            foo(1)
+        end
+        """,
+    )
+    fa = JuliaWorkspaces.derived_file_analysis(jw.runtime, root, f)
+    @test !any(d -> occursin("No method matching", d.message), fa.diagnostics)
+
+    # ...but a genuinely-wrong call to the (unshadowed) global still flags.
+    g = URI("file:///t/src/g.jl")
+    jw2 = ws_files(
+        root => "module M\ninclude(\"g.jl\")\nend\n",
+        g => "foo(a, b) = a + b\nbaz() = foo(1)\n",
+    )
+    fa2 = JuliaWorkspaces.derived_file_analysis(jw2.runtime, root, g)
+    @test any(d -> occursin("No method matching", d.message), fa2.diagnostics)
+
+    # A genuinely-wrong call to the LOCAL reports the local's arity, not the
+    # shadowed global's (the message must not quote the global's 2 args).
+    h = URI("file:///t/src/h.jl")
+    jw3 = ws_files(
+        root => "module M\ninclude(\"h.jl\")\nend\n",
+        h => "foo(a, b) = a + b\nfunction bar()\n    foo(a) = a\n    foo(1, 2, 3)\nend\n",
+    )
+    fa3 = JuliaWorkspaces.derived_file_analysis(jw3.runtime, root, h)
+    d = only(filter(x -> occursin("No method matching", x.message), fa3.diagnostics))
+    @test occursin("Expected 1 argument", d.message) && occursin("got 3", d.message)
+end
+
 @testitem "infer property-destructure loop variable field types" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: CoreTypes
     # `for (; a, b) in coll` must infer each variable's OWN field type from the

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -4201,6 +4201,12 @@ end
     m = describe("f(x::Int) = x\nf(x::Int, y::Int) = x\nf(\"s\")\n", "f")
     @test occursin("argument 1", m) && occursin("expected `Int", m) && occursin("got `String", m)
 
+    # several methods of the SAME (matching) arity: no single expected type is
+    # meaningful, so only the header is emitted — never an arbitrary "expected".
+    m = describe("f(x::Int) = x\nf(x::String) = x\nf(2.0)\n", "f")
+    @test occursin("No method matching `f(::Float64)`", m)
+    @test !occursin("expected", m) && !occursin("At argument", m)
+
     # keyword: a store function with no keywords called with one
     m = describe("g() = sqrt(1; foo=2)\n", "sqrt")
     @test occursin("keyword `foo`", m)

--- a/test/test_references.jl
+++ b/test/test_references.jl
@@ -99,6 +99,44 @@ end
     @test all(d -> d.uri == uri, defs)
 end
 
+@testitem "References: go-to-definition on a const type alias" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_definitions
+    using JuliaWorkspaces.URIs2: URI
+
+    # A `const` type alias (`const MyDict = Dict`, `const IntDict = Dict{Int,Int}`)
+    # carries a `DataType` binding type, but its `val` is a plain assignment, not a
+    # struct/function definition — go-to-def must land on the `const` declaration
+    # rather than hunting the binding's refs for methods (an alias defines none, so
+    # the walk returned nothing).
+    source = """
+    module Foo
+    const MyDict = Dict
+    const IntDict = Dict{Int,Int}
+
+    IntDict(x) = Dict{Int,Int}(x => x)
+
+    f(x::IntDict) = length(x)
+    f(x::MyDict) = length(x)
+    end
+    """
+    jw = JuliaWorkspace()
+    uri = URI("file:///aliasdef/src/Foo.jl")
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+
+    # `MyDict` in `f(x::MyDict)` → jumps to `const MyDict = Dict` (line 2).
+    p_my = first(findfirst("::MyDict", source)) + length("::")
+    defs_my = get_definitions(jw, uri, p_my)
+    @test !isempty(defs_my)
+    @test any(d -> d.uri == uri && d.start.line == 2, defs_my)
+
+    # `IntDict` in `f(x::IntDict)` → jumps to BOTH the `const` declaration (line 3)
+    # and the constructor defined on the alias (line 5).
+    p_int = first(findfirst("::IntDict", source)) + length("::")
+    defs_int = get_definitions(jw, uri, p_int)
+    @test any(d -> d.uri == uri && d.start.line == 3, defs_int)
+    @test any(d -> d.uri == uri && d.start.line == 5, defs_int)
+end
+
 @testitem "References: go-to-definition on a using'd module name" begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_definitions
     using JuliaWorkspaces.URIs2: URI


### PR DESCRIPTION
Per-file method matching and go-to-definition mishandled several cases, producing spurious "No method matching" diagnostics and empty go-to-def results:

- `const` type aliases (`const A = T`, `const A = T{...}`) did not narrow a `::A` argument to the aliased datatype. The arg took the opaque alias binding (type `DataType`, supertype chain dead-ending at `Any`), so any call on it false-flagged. `_resolve_type_alias` now follows the alias RHS to the real datatype, including bases that resolve cross-file/externally to a `TreeRef` (resolved on demand through the env, mirroring a direct annotation). Bare and parametric alias forms are both handled; a base that is genuinely unresolvable leaves the type unset (reads as `Any`) instead of the opaque binding.

- go-to-definition on a type/function alias walked the binding's refs for method definitions (finding none) instead of the alias declaration. It now also jumps to the `const` line, while still offering any methods defined on the alias.

- a function-local callee (closure or parameter) that shadows a same-named global was checked against the global's cross-file arity set. Locals are now excluded from the tree-arity gate (`_is_local_callee_binding`) and checked against their own method set.

- the mismatch message no longer quotes a shadowed global's arity for a local callee, and no longer names an arbitrary overload's expected type when several candidates of the matching arity exist (header only).