### PR TITLE
fix(lint): don't flag colon imports of indexed re-exported modules

### DIFF
--- a/src/StaticLint/imports.jl
+++ b/src/StaticLint/imports.jl
@@ -344,7 +344,7 @@ function fill_synthetic_import_binding!(b::Binding, val, state)
 end
 
 """
-    mark_unresolved_imports!(x::EXPR, meta_dict, isquoted=false)
+    mark_unresolved_imports!(x::EXPR, env, meta_dict, isquoted=false)
 
 Post-`semantic_pass` marking of import statements that still failed to
 resolve: the first unresolved component of each import path gets an
@@ -352,40 +352,40 @@ resolve: the first unresolved component of each import path gets an
 alongside `resolve_remaining_getfields!`), because in-pass failures may
 still be retried via `state.resolveonly`.
 """
-function mark_unresolved_imports!(x::EXPR, meta_dict, isquoted=false)
+function mark_unresolved_imports!(x::EXPR, env, meta_dict, isquoted=false)
     # relies on quoted(x) and unquoted(x) being mutually exclusive
     isquoted = isquoted ? !unquoted(x) : quoted(x)
     if !isquoted && (headof(x) === :using || headof(x) === :import)
-        mark_unresolved_import_stmt!(x, meta_dict)
+        mark_unresolved_import_stmt!(x, env, meta_dict)
         return x
     end
     if x.args !== nothing
         for a in x.args
-            mark_unresolved_imports!(a, meta_dict, isquoted)
+            mark_unresolved_imports!(a, env, meta_dict, isquoted)
         end
     end
     return x
 end
 
-function mark_unresolved_import_stmt!(x::EXPR, meta_dict)
+function mark_unresolved_import_stmt!(x::EXPR, env, meta_dict)
     x.args === nothing && return
     if length(x.args) > 0 && isoperator(headof(x.args[1])) && valof(headof(x.args[1])) == ":"
         colon_expr = x.args[1]
-        failed = first_unresolved_import_component(colon_expr.args[1], meta_dict)
+        failed = first_unresolved_import_component(colon_expr.args[1], env, meta_dict)
         if failed !== nothing
             # the whole module path is unknown; one error there covers the
             # statement (the listed names carry synthetic bindings)
             seterror!(failed, UnresolvedImport, meta_dict)
         else
             for i = 2:length(colon_expr.args)
-                nfailed = first_unresolved_import_component(colon_expr.args[i], meta_dict)
+                nfailed = first_unresolved_import_component(colon_expr.args[i], env, meta_dict)
                 nfailed === nothing && continue
                 seterror!(nfailed, UnresolvedImport, meta_dict)
             end
         end
     else
         for path in x.args
-            failed = first_unresolved_import_component(path, meta_dict)
+            failed = first_unresolved_import_component(path, env, meta_dict)
             failed === nothing && continue
             seterror!(failed, UnresolvedImport, meta_dict)
             if headof(x) === :using
@@ -402,8 +402,8 @@ end
 # First component of an import path that is still unresolved after all
 # passes: module-path components show up as ref-less (they never get
 # synthetic bindings), bound-name components as still-synthetic bindings.
-function first_unresolved_import_component(path::EXPR, meta_dict)
-    headof(path) === :as && return first_unresolved_import_component(path.args[1], meta_dict)
+function first_unresolved_import_component(path::EXPR, env, meta_dict)
+    headof(path) === :as && return first_unresolved_import_component(path.args[1], env, meta_dict)
     path.args === nothing && return nothing
     for arg in path.args
         # already diagnosed some other way (e.g. RelativeImportTooManyDots,
@@ -413,15 +413,22 @@ function first_unresolved_import_component(path::EXPR, meta_dict)
         hasref(arg, meta_dict) || return arg
         r = refof(arg, meta_dict)
         # Per-file traversal mode only: a module-path component that resolved
-        # to the `:external_symbol` tree stand-in (an UNINDEXED external module
-        # brought in only as a bare name — no ItemRef, item === nothing) is
-        # still unresolved for statement-level reporting. Without this, the
-        # colon-import of such a module (`using NotIndexed: (*)`) would look
-        # resolved on its module path and move the UnresolvedImport error onto
-        # a listed member, matching the whole-closure pass's "Failed to resolve
-        # `<module>`" outcome. Only the tree context ever produces `TreeRef`s,
-        # so this clause is inert on the whole-closure pass.
-        r isa TreeRef && r.kind === :external_symbol && return arg
+        # to the `:external_symbol` tree stand-in (an external module brought in
+        # only as a bare name — no ItemRef, item === nothing). It is unresolved
+        # ONLY when the named module isn't actually in the env: an UNINDEXED
+        # external (`using NotIndexed: (*)`) must still be flagged, matching the
+        # whole-closure pass's "Failed to resolve `<module>`" outcome. But an
+        # INDEXED external reached through a workspace package's tree context
+        # (`using Revise.CodeTracking: x`, where Revise re-exports the indexed
+        # CodeTracking via `using CodeTracking`) is resolvable — the whole-module
+        # form binds it and stays silent, so the colon form must not flag it.
+        # Only the tree context ever produces `TreeRef`s, so this is inert on the
+        # whole-closure pass.
+        if r isa TreeRef && r.kind === :external_symbol
+            topmod = isempty(r.origin_module) ? r.name : first(r.origin_module)
+            haskey(getsymbols(env), Symbol(topmod)) || return arg
+            continue
+        end
         is_synthetic_import_binding(r) && return arg
     end
     return nothing

--- a/src/layer_file_analysis.jl
+++ b/src/layer_file_analysis.jl
@@ -761,7 +761,7 @@ Salsa.@derived function derived_file_analysis(rt, root, file)
 
     # Late import-failure marking (in-pass failures may be retried via
     # `state.resolveonly`, so this can only run after the pass).
-    StaticLint.mark_unresolved_imports!(cst, meta_dict)
+    StaticLint.mark_unresolved_imports!(cst, env, meta_dict)
 
     diagnostics = _file_analysis_diagnostics(rt, cst, env, meta_dict, lint_config, project_uri, root, path)
 

--- a/src/layer_static_lint.jl
+++ b/src/layer_static_lint.jl
@@ -165,7 +165,7 @@ Salsa.@derived function derived_static_lint_meta_for_root(rt, uri)
 
         # Late import-failure marking. Runs here (not in-pass) because
         # resolve_import failures may be retried via state.resolveonly.
-        StaticLint.mark_unresolved_imports!(cst2, meta_dict)
+        StaticLint.mark_unresolved_imports!(cst2, env, meta_dict)
     end
 
     return (meta_dict=meta_dict, workspace_packages=workspace_packages)

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -1099,6 +1099,58 @@ end
     @test !any(d -> startswith(d.message, "Failed to resolve"), diags)
 end
 
+@testitem "unresolved import: colon import `using Foo.Bar: x` through a workspace package's re-exported indexed module is not flagged" begin
+    using JuliaWorkspaces.URIs2: URI
+    using JuliaWorkspaces.SymbolServer: Package, ModuleStore, VarRef, FunctionStore, MethodStore
+
+    # The `using Revise.CodeTracking: MethodInfoKey` shape: `Outer` is a WORKSPACE
+    # (deved) package whose source brings in an indexed dependency `Inner` via
+    # `using Inner`. Resolving `Outer.Inner` runs through Outer's tree context,
+    # where `Inner` surfaces as an `:external_symbol` stand-in. The whole-module
+    # form (`using Outer.Inner`) binds it and stays silent; the COLON form's
+    # module-path component used to be flagged as an unresolved import even though
+    # `Inner` is indexed and resolvable.
+    inner_uuid = Base.UUID("22222222-2222-2222-2222-222222222222")
+    inner_tree = "2222222222222222222222222222222222222222"
+    inner_ms = ModuleStore(VarRef(nothing, :Inner), Dict{Symbol,Any}(), "", true, [:bar], Symbol[])
+    inner_ms.vals[:bar] = FunctionStore(VarRef(VarRef(nothing, :Inner), :bar), MethodStore[], "", VarRef(VarRef(nothing, :Inner), :bar), true)
+    inner_pkg = Package("Inner", inner_ms, inner_uuid, nothing)
+
+    outer_project = """
+    name = "Outer"
+    uuid = "11111111-1111-1111-1111-111111111111"
+    version = "0.1.0"
+    [deps]
+    Inner = "22222222-2222-2222-2222-222222222222"
+    """
+    outer_manifest = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    [[deps.Inner]]
+    uuid = "22222222-2222-2222-2222-222222222222"
+    git-tree-sha1 = "$inner_tree"
+    version = "1.0.0"
+    """
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///ws/Outer/Project.toml"), SourceText(outer_project, "toml")))
+    add_file!(jw, TextFile(URI("file:///ws/Outer/Manifest.toml"), SourceText(outer_manifest, "toml")))
+    add_file!(jw, TextFile(URI("file:///ws/Outer/src/Outer.jl"), SourceText("module Outer\nusing Inner\nend\n", "julia")))
+    fileuri = URI("file:///ws/Outer/test/runtests.jl")
+    add_file!(jw, TextFile(fileuri, SourceText("using Outer.Inner: bar\n", "julia")))
+    JuliaWorkspaces.set_input_env_ready!(jw.runtime, true)
+    JuliaWorkspaces.set_input_package_metadata!(jw.runtime, :Inner, inner_uuid, v"1.0.0", inner_tree, inner_pkg)
+
+    diags = get_diagnostic(jw, fileuri)
+
+    # `Inner` is indexed and reachable through Outer, so its colon import resolves.
+    @test !any(d -> occursin("Failed to resolve `Inner`", d.message), diags)
+    @test !any(d -> occursin("could not be indexed", d.message) && occursin("Inner", d.message), diags)
+end
+
 @testitem "unresolved import: as-aliased imports are flagged" begin
     using JuliaWorkspaces.URIs2: URI
 


### PR DESCRIPTION
`using Foo.Bar: x` where `Foo` is a workspace (deved) package that re-exports an indexed module `Bar` via `using Bar` was wrongly reported as an unresolved import. In per-file traversal mode the module-path component `Bar` surfaces as an `:external_symbol` tree stand-in, and `first_unresolved_import_component` flagged every such stand-in. The whole-module form (`using Foo.Bar`) binds the component and stays silent, so the colon form was inconsistent — and wrong, since `Bar` is indexed and resolvable.

Only flag an `:external_symbol` component when the named module is not in the environment (a genuinely unindexed external), so indexed re-exports resolve while `using NotIndexed: x` still reports. Threads `env` through `mark_unresolved_imports!` to make the membership check.