### PR TITLE
fix: resolve TreeRef element types in settype! instead of crashing

### DIFF
--- a/src/StaticLint/type_inf.jl
+++ b/src/StaticLint/type_inf.jl
@@ -1,10 +1,23 @@
-function settype!(b::Binding, type::Binding)
+function settype!(b::Binding, type::Binding, state=nothing)
     push!(type.refs, b)
     b.type = type
 end
 
-function settype!(b::Binding, type)
+function settype!(b::Binding, type, state=nothing)
     b.type = type
+end
+
+# `Binding.type` can't hold a `TreeRef` (a per-file cross-file/external ref), so
+# it's resolved to a store first: with `state` an external datatype resolves
+# through the env; anything unresolvable (e.g. a workspace struct, whose
+# declaration lives in another file's tree) — and any call made without `state`
+# — leaves the type unset rather than crashing in `convert`. `state` is optional
+# on every `settype!` method so callers can pass it uniformly, and a stray
+# TreeRef never reaches the `b.type = type` assignment.
+function settype!(b::Binding, tr::TreeRef, state=nothing)
+    store = state === nothing ? nothing : resolve_treeref_store(tr, state)
+    store isa SymbolServer.SymStore && settype!(b, store)
+    return
 end
 
 # `(a, b, …)::Tuple{T1, T2, …}` (a typed positional destructure, e.g. a function
@@ -132,7 +145,7 @@ function infer_type_assignment_rhs(binding, state, scope)
             # collection's eltype.
             infer_destructuring_type(binding, elt, meta_dict)
         else
-            settype!(binding, elt)
+            settype!(binding, elt, state)
         end
     elseif CSTParser.istuple(lhs) && !is_destructuring
         # Positional destructuring `a, b = rhs`: each variable is an element of
@@ -145,7 +158,7 @@ function infer_type_assignment_rhs(binding, state, scope)
         # otherwise non-scalar index yields an array, not an element (#449).
         ref = refof_maybe_getfield(rhs.args[1], meta_dict)
         if ref isa Binding && ref.val isa EXPR
-            settype!(binding, infer_eltype(ref.val, state))
+            settype!(binding, infer_eltype(ref.val, state), state)
         end
     elseif CSTParser.isdeclaration(rhs) && length(rhs.args) == 2 && !is_destructuring
         # RHS is a type assertion (`y = x::T`, `x = x::T`): the assigned binding
@@ -575,6 +588,8 @@ function maybe_get_vec_eltype(t, state)
     if iscurly(t)
         lhs_ref = refof_maybe_getfield(t.args[1], meta_dict)
         if lhs_ref isa SymbolServer.DataTypeStore && CoreTypes.isarray(lhs_ref) && length(t.args) > 1
+            # May be a cross-file element type (`Vector{Crayon}` with `Crayon` in
+            # a sibling file), i.e. a `TreeRef` — `settype!` resolves/drops it.
             refof(t.args[2], meta_dict)
         end
     end

--- a/test/staticlint/test_inference.jl
+++ b/test/staticlint/test_inference.jl
@@ -132,6 +132,37 @@ end
     @test occursin("PkgId", string(argb.type.name))
 end
 
+@testitem "infer element type of a cross-file Vector eltype (TreeRef)" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.URIs2: URI
+    const DataTypeStore = JuliaWorkspaces.SymbolServer.DataTypeStore
+
+    # Indexing a `Vector{T}` whose element type `T` lives in a sibling file
+    # resolves `T` to a TreeRef, which `Binding.type` can't hold — this used to
+    # crash `settype!` in `convert`. A workspace struct element stays unset; an
+    # external element (`Vector{PkgId}`) resolves through the env to its store.
+    root = URI("file:///t/src/Root.jl")
+    crayon = URI("file:///t/src/crayon.jl")
+    stack = URI("file:///t/src/stack.jl")
+    jw = ws_files(
+        root => "module Root\nusing Base: PkgId\ninclude(\"crayon.jl\")\ninclude(\"stack.jl\")\nend\n",
+        crayon => "struct Crayon\n    x\nend\n",
+        stack => "struct CrayonStack\n    crayons::Vector{Crayon}\n    ids::Vector{PkgId}\nend\nfunction f(s::CrayonStack)\n    c = s.crayons[1]\n    p = s.ids[1]\n    (c, p)\nend\n",
+    )
+    fa = JuliaWorkspaces.derived_file_analysis(jw.runtime, root, stack)
+    cst = JuliaWorkspaces.derived_julia_legacy_syntax_tree(jw.runtime, stack)
+
+    cb = find_binding(cst, fa.meta, "c")
+    @test cb !== nothing
+    @test cb.type === nothing  # workspace-struct element: unset, but no crash
+
+    pb = find_binding(cst, fa.meta, "p")
+    @test pb !== nothing
+    @test pb.type isa DataTypeStore
+    @test occursin("PkgId", string(pb.type.name))
+
+    @test isempty(fa.diagnostics)
+end
+
 @testitem "method through a const type alias with an unresolved base" setup=[shared_static_lint] begin
     using JuliaWorkspaces.URIs2: URI
 


### PR DESCRIPTION
Indexing or iterating a `Vector{T}` whose element type `T` is a struct defined in a sibling file resolves `T` to a `TreeRef` in per-file analysis mode. `infer_eltype` handed that `TreeRef` to `settype!`, but `Binding.type` is `Union{Binding,SymStore,Nothing}` and can't hold one, so `convert` threw and took down the whole file-analysis derived query.

Route any `TreeRef` second arg to a dedicated `settype!` method that resolves an external datatype through the env (so `Vector{PkgId}` now infers `PkgId`) and drops anything unresolvable (a workspace struct, declared in another file's tree) rather than assigning it. `state` is an optional third arg on every `settype!` method so callers pass it uniformly and a stray `TreeRef` can never reach `b.type = type`.