### PR TITLE
fix: keep constructor-overloaded types as DataType, not Function

### DIFF
--- a/src/StaticLint/bindings.jl
+++ b/src/StaticLint/bindings.jl
@@ -408,8 +408,16 @@ function add_binding(x, state, scope=state.scope)
                     elseif isexportedby(name, lhs_ref)
                         # Name is already available
                         tls.names[name] = b
+                        overloaded = maybe_lookup(lhs_ref[Symbol(name)], state)
+                        # A constructor overload keeps the type's meaning:
+                        # `function Base.Tuple(x)` must not retype `Tuple` as a
+                        # plain `Function`, or `isa(x, Tuple)` / `::Tuple` would
+                        # see a non-type.
+                        if resolves_to_datatype(overloaded, state.env)
+                            b.type = CoreTypes.DataType
+                        end
                         if !hasref(b.name, meta_dict) # Is this an appropriate indicator that we've not marked the overload?
-                            push!(b.refs, maybe_lookup(lhs_ref[Symbol(name)], state))
+                            push!(b.refs, overloaded)
                             setref!(b.name, b, meta_dict) # we actually set the rhs of the qualified name to point to this binding
                         end
                     else

--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -162,7 +162,7 @@ function _typeof(x, state)
     elseif x isa SymbolServer.DataTypeStore
         return CoreTypes.DataType
     elseif x isa SymbolServer.FunctionStore
-        return CoreTypes.Function
+        return resolves_to_datatype(x, state.env) ? CoreTypes.DataType : CoreTypes.Function
     elseif x isa TreeRef
         # per-file traversal mode: map the tree item kind
         if x.kind === :function || x.kind === :macro

--- a/src/StaticLint/type_inf.jl
+++ b/src/StaticLint/type_inf.jl
@@ -430,6 +430,11 @@ function get_eventual_datatype(b::SymbolServer.FunctionStore, env::ExternalEnv)
     return SymbolServer._lookup(b.extends, getsymbols(env))
 end
 
+# `store` denotes a datatype: a `DataTypeStore`, or a constructor `FunctionStore`
+# whose `extends` resolves to one (`Base.Tuple` → `Core.Tuple`). Such a name is a
+# type, so its binding must stay a `DataType` rather than become a `Function`.
+resolves_to_datatype(store, env::ExternalEnv) = get_eventual_datatype(store, env) isa SymbolServer.DataTypeStore
+
 # Per-file traversal mode only: does `b`'s declaration carry an explicit `::`
 # type annotation that resolved through the module tree (a `TreeRef`)? The
 # legacy `Binding.type` slot can't carry a TreeRef, so `infer_type_decl`

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -804,6 +804,41 @@ end
     @test JuliaWorkspaces.StaticLint.errorof(cst.args[2].args[1], meta_dict) === nothing
 end
 
+@testitem "constructor overload of imported type keeps DataType (isa)" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, scopeof, CoreTypes
+
+    # Adding a constructor method to an existing (imported) type must not retype
+    # its name as a plain `Function`: the name still denotes a type, so
+    # `isa(x, Tuple)` / `::Tuple` stay valid and are not flagged.
+    (cst, meta_dict) = parse_and_pass("""
+    function Base.Tuple(x)
+        (x,)
+    end
+    function foo(x)
+        return isa(x, Tuple)
+    end
+    """)
+
+    # the local `Tuple` binding stays a DataType, not a Function
+    @test CoreTypes.isdatatype(scopeof(cst, meta_dict).names["Tuple"].type)
+
+    # `isa(x, Tuple)` inside foo's body is not flagged
+    isacall = cst.args[2].args[2].args[1].args[1]
+    @test errorof(isacall, meta_dict) === nothing
+
+    # Same reasoning for an explicit `import Base: Tuple` (a constructor
+    # `FunctionStore`): the imported name is still a type.
+    (cst2, md2) = parse_and_pass("""
+    import Base: Tuple
+    function foo(x)
+        return isa(x, Tuple)
+    end
+    """)
+    @test CoreTypes.isdatatype(scopeof(cst2, md2).names["Tuple"].type)
+    isacall2 = cst2.args[2].args[2].args[1].args[1]
+    @test errorof(isacall2, md2) === nothing
+end
+
 @testitem "check_call macro-wrapped definition signature not flagged" setup=[shared_static_lint] begin
     using JuliaWorkspaces: CSTParser
     using JuliaWorkspaces.StaticLint: errorof, IncorrectCallArgs


### PR DESCRIPTION
A type with constructor methods is cached as a FunctionStore whose `extends` resolves to its DataTypeStore (e.g. `Base.Tuple` -> `Core.Tuple`). Defining a constructor overload (`function Base.Tuple(x)`) or importing such a name (`import Base: Tuple`) typed the binding as `Function`, so `isa(x, Tuple)` / `::Tuple` saw a non-type and were falsely flagged with IncorrectCallArgs.

Set the binding type to DataType when the name resolves to a datatype, via a new `resolves_to_datatype` predicate over the existing `get_eventual_datatype` resolver (add_binding's exported-overload branch and `_typeof` for import bindings).