### PR TITLE
fix: mark only the name for CannotDeclareConst

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1377,8 +1377,8 @@ function check_const_decl(name::String, b::Binding, scope, meta_dict)
     is_in_fexpr(b.name, x -> headof(x) === :import || headof(x) === :using) && return
 
     b.val isa Binding && return check_const_decl(name, b.val, scope, meta_dict)
-    if b.val isa EXPR && (CSTParser.defines_datatype(b.val) || is_const(bind))
-        seterror!(b.val, CannotDeclareConst, meta_dict)
+    if b.val isa EXPR && (CSTParser.defines_datatype(b.val) || is_const(b))
+        seterror!(b.name, CannotDeclareConst, meta_dict)
     else
         prev = scope.names[name]
         if (CoreTypes.isdatatype(prev.type) && !is_mask_binding_of_datatype(prev, meta_dict)) || is_const(prev)

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -1320,13 +1320,52 @@ end
 
 @testitem "const redefinition cannot declare const" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: getmeta, CannotDeclareConst
+    using JuliaWorkspaces.CSTParser
 
     cst, meta_dict = parse_and_pass("""
         T = 1
         struct T end
         """)
 
-    @test getmeta(cst[2], meta_dict).error == CannotDeclareConst
+    # the error should mark only the datatype name, not the whole `struct` block
+    name = CSTParser.get_name(cst[2])
+    @test getmeta(name, meta_dict).error == CannotDeclareConst
+    @test getmeta(cst[2], meta_dict).error === nothing
+end
+
+@testitem "double const decl flags the redeclared name" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: getmeta, errorof, CannotDeclareConst
+
+    # a second `const` decl of the same name in the same scope cannot declare the
+    # constant; the error marks only the redeclared name.
+    cst, meta_dict = parse_and_pass("""
+        const x = 1
+        const x = 2
+        """)
+
+    name = cst[2].args[1].args[1] # `const` -> `x = 2` -> `x`
+    @test getmeta(name, meta_dict).error == CannotDeclareConst
+    @test getmeta(cst[2], meta_dict).error === nothing
+end
+
+@testitem "local does not shadow-flag a global const" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, CannotDeclareConst
+
+    any_error(x, meta_dict, err) =
+        errorof(x, meta_dict) === err ||
+        (x.args !== nothing && any(a -> any_error(a, meta_dict, err), x.args))
+
+    # a local binding lives in its own scope, so reusing a global const's name
+    # inside a function must not be flagged as a const redeclaration.
+    cst, meta_dict = parse_and_pass("""
+        const y = 1
+        function f()
+            y = 2
+            y
+        end
+        """)
+
+    @test !any_error(cst, meta_dict, CannotDeclareConst)
 end
 
 @testitem "const redefinition invalid redefinition" setup=[shared_static_lint] begin
@@ -1351,7 +1390,7 @@ end
 end
 
 @testitem "importing a type is not a const redefinition (#352)" setup=[shared_static_lint] begin
-    using JuliaWorkspaces.StaticLint: errorof, InvalidRedefofConst
+    using JuliaWorkspaces.StaticLint: errorof, InvalidRedefofConst, CannotDeclareConst
 
     has_error(cst, meta_dict, jw, err) =
         any(errorof(x, meta_dict) === err for (_, x) in collect_hints(cst, meta_dict, jw))
@@ -1392,7 +1431,9 @@ end
         import Base: AbstractDict
         const AbstractDict = 1
         """)
-        @test has_error(cst, meta_dict, jw, InvalidRedefofConst)
+        # `const` over an imported name is a "cannot declare constant" error
+        # (Julia: "it was already declared as an import"), not a plain redefinition.
+        @test has_error(cst, meta_dict, jw, CannotDeclareConst)
     end
 end
 
@@ -2998,7 +3039,7 @@ end
             const X = 2
         end
         """)
-        @test has_error(cst, meta_dict, jw, InvalidRedefofConst)
+        @test has_error(cst, meta_dict, jw, CannotDeclareConst)
     end
 
     # References to file-level bindings still resolve from inside the block.


### PR DESCRIPTION
The CannotDeclareConst error was set on the whole const/datatype expression; mark just the declared name instead. Also fixes the `is_const(bind)` typo that resolved to `Base.bind` and silently disabled the const-over-existing-binding branch.