### PR TITLE
fix: handle non-file URIs in derived_{package,project}_for_file

### DIFF
--- a/src/layer_projects.jl
+++ b/src/layer_projects.jl
@@ -242,6 +242,8 @@ Salsa.@derived function derived_package_for_file(rt, file::URI)
     packages = derived_package_folders(rt)
 
     file_path = uri2filepath(file)
+
+    file_path === nothing && return nothing
     package = packages |>
         x -> map(x) do i
             package_folder_path = uri2filepath(i)
@@ -261,6 +263,8 @@ Salsa.@derived function derived_project_for_file(rt, file::URI)
     projects = derived_project_folders(rt)
 
     file_path = uri2filepath(file)
+
+    file_path === nothing && return nothing
     project = projects |>
         x -> map(x) do i
             project_folder_path = uri2filepath(i)

--- a/test/test_testitems.jl
+++ b/test/test_testitems.jl
@@ -636,3 +636,28 @@ end
     @test isequal(ti_b, TestItemDetail(u, "id", "n", "code", 23:22, 23:22, true, Symbol[], Symbol[]))
     @test hash(ts_b) == hash(TestSetupDetail(u, :n, :k, "code", 23:22, 23:22))
 end
+
+@testitem "get_test_items on untitled (non-file) URI" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_test_items
+    using JuliaWorkspaces.URIs2: @uri_str
+
+    jw = JuliaWorkspace()
+
+    # A recognized package folder makes derived_package_folders non-empty, so
+    # derived_package_for_file iterates it for the untitled file below.
+    add_file!(jw, TextFile(uri"file:///home/foo/Project.toml", SourceText("name = \"Foo\"\nuuid = \"12345678-1234-1234-1234-123456789012\"\nversion = \"0.1.0\"\n", "toml")))
+    add_file!(jw, TextFile(uri"file:///home/foo/src/Foo.jl", SourceText("module Foo\nend\n", "julia")))
+
+    uri = uri"untitled:Untitled-1"
+    content = """@testitem "foo" begin
+    end
+    """
+    add_file!(jw, TextFile(uri, SourceText(content, "julia")))
+
+    # Non-file URIs have no filesystem path; this must not crash. The file is
+    # not inside any package, so the testitem is reported as a testerror.
+    test_results = get_test_items(jw, uri)
+
+    @test length(test_results.testitems) == 0
+    @test length(test_results.testerrors) == 1
+end


### PR DESCRIPTION
uri2filepath returns nothing for non-file scheme URIs (e.g. untitled buffers). When the workspace contained a package/project folder, the filter block ran splitpath(nothing) and threw a MethodError, crashing get_test_items on didOpen of an untitled file.

Return nothing early when the file has no filesystem path: an untitled file cannot belong to a package or project.