### PR TITLE
perf(projects): precompute folder path parts for project/package lookup

### DIFF
--- a/docs/perf/2026-07-24-performance-investigation.md
+++ b/docs/perf/2026-07-24-performance-investigation.md
@@ -1,0 +1,143 @@
+# Performance investigation — julia-vscode repo as workspace (2026-07-24)
+
+End-to-end measurement of LanguageServer + JuliaWorkspaces `main` (454fa4b) on the
+`/home/pfitzseb/git/julia-vscode` repo: **4362 text files / 2188 .jl files / 363
+Project.toml / 134 environments with a Manifest.toml** — roughly 4× the repro workspace
+used in the 2026-07-18 doc. Julia 1.12.6, shared 128-thread machine (numbers taken after
+clearing ~34 cores of leaked spinning DJP orphans; ambient load from other users remains).
+
+Method: a Python LSP driver (`lsbench.py`, session scratchpad) spawns the LS exactly like
+the extension (same args/env/cwd), speaks LSP over stdio, answers `workspace/configuration`
+/ progress-create / registration requests, logs every message with monotonic timestamps,
+and sends `documentSymbol` probes every 0.5 s to measure dispatch-loop availability.
+Depot isolated via `cp -al ~/.julia` + a fake `HOME` (note: DJP children *delete*
+`JULIA_DEPOT_PATH` from their env — `dynamic_feature.jl:156` — so `HOME` is the only
+isolation that reaches them). In-process profiling via a REPL session with the dev env.
+Push-diagnostics client (no pull, no refresh capability), `julialangTestItemIdentification`
+on, defaults otherwise (dynamic on, download on, cap 4, env resolution off).
+
+## Headline numbers
+
+| | DynamicOff | Dynamic, warm store | Dynamic, cold store |
+|---|---|---|---|
+| spawn → `initialize` response | 4.5 s | 4.5 s | 4.5 s |
+| `initialized` blocks dispatch loop | 59.9 s | 73.7 s | 113.3 s |
+| first `publishDiagnostics` | 64 s | 79 s | 118 s |
+| indexing complete | — | 20 s (fast lane) | ~5.5 min |
+| post-startup background churn | none | ~10 min refresh tail | ~10 min + 30 s flip loop |
+| LS RSS after suite | 3.2 GB | 3.4 GB | 4.9 GB |
+
+Warm request latencies (p50, n=20): hover 0.5–1.0 ms, documentSymbol 1.0–1.5 ms,
+definition 0.35–0.7 ms, completion 0.65–1.3 ms, `julia/getModuleAt` 0.06–0.23 ms,
+references 3.5–7.8 ms (cold-first ~1.0–1.1 s), workspace/symbol 15–29 ms.
+First-request JIT stalls: hover 1.2–2.0 s, references ~1.1 s, sweep hash-diff 334 ms.
+
+## Where startup time goes
+
+The `initialized` handler runs synchronously on the dispatch loop: folder walk + read
+(1.2 s), `add_files!` (4.1 s), then the initial `run_publish_sweep` = the cold
+full-workspace lint. In-process (DynamicOff, JIT-warm): **46 s, 18 GiB allocated, ~29% of
+wall time in GC** (JIT-cold in a fresh session: 90 s / 24 GiB).
+
+Cold-sweep profile composition (2502 samples):
+
+- `derived_new_static_lint_diagnostics` **67%**, of which `derived_file_analysis` 61%;
+  inside that, `check_all` 45% of the whole sweep — dominated by `check_call` (~1017
+  samples) and `sig_match_any` (571).
+- **`derived_package_for_file` + `derived_project_for_file` ≈ 20%** — almost all of it
+  `splitpath` → regex `match`. `layer_projects.jl:252-292` re-splits every candidate
+  folder per file and re-splits `splitpath(file_path)` *inside the filter closure, once
+  per candidate*: ≈ 2186 files × ~360 folders × 2 functions ≈ 1.6 M `splitpath` calls
+  ≈ 15 M regex matches, ~1–2 GiB of the allocation (RegexMatch ~1 GiB extrapolated).
+  Cheap fix: derived per-revision folder-parts table + hoist the file split (or replace
+  with plain string-prefix comparison).
+- `derived_testitems` 14%; parsing (JuliaSyntax + legacy) ~8% — the per-keystroke
+  double parse (2026-07-18 doc item 4) is now minor relative to `check_all`.
+- Allocation by type (sampled ×5000): VisibleName containers ~3.7 GiB, InventoryItem
+  ~2.5 GiB, SubString/String/RegexMatch ~3.4 GiB.
+
+Time-to-first-analysis fix shape: cold *single-file* diagnostics cost 2.5 s for the first
+file (env + its root warm-up) and 0.03 s for files in other roots. Publishing open files
+first, then running the initial sweep in self-re-enqueueing chunks on the dispatch loop
+(off-loop touches of the Salsa runtime are forbidden) would turn 64–118 s perceived TTFA
+into ~14 s (4.5 s init + ~7 s load + 2.5 s first file).
+
+## Dynamic indexing lifecycle
+
+- Cold: 134 envs indexed in ~5.5 min at cap 4 (download on; 94 MB of jstores written).
+  During indexing the dispatch loop hiccups continuously (40/456 probes >100 ms,
+  typical 200–500 ms) from cache loads + indexing-complete refresh sweeps.
+- Warm: the fast lane serves all 134 envs in ~7 s and the download bar completes from
+  cache — indexing bar done at t≈20 s. **But a background refresh tail then re-resolves
+  every env for ~10 minutes** (publishes trickle until t≈670 s), every restart, even when
+  no manifest changed. Interactive requests colliding with refresh sweeps show max
+  latencies of 600–850 ms (definition/completion/workspace-symbol) and 193–223 ms
+  (getModuleAt). Gating refreshes on manifest content change would remove nearly all of
+  this.
+
+## Typing / didChange behavior
+
+- Per keystroke the LS runs single-file `get_diagnostic` + `get_test_items` and publishes
+  only on hash change. Cost on this workspace: **~40–60 ms** (profile: ~60% re-lint of
+  the edited file via `check_all`, ~35% Salsa verification walk). The hash gate verifiably
+  works (no-op edits produce zero publishes).
+- The debounced full sweep costs **~365 ms median (DynamicOff)** — pure Salsa
+  verification; ~26% of samples are `Dict` probes in `_probe_derived` — but
+  **~1.8–2.0 s with dynamic indexing on** (measured as keystroke feedback delayed
+  2.2–2.4 s when queued behind it; unattributed, top follow-up). Because the sweep runs
+  on the dispatch loop, the *next* keystroke's feedback waits behind it: observed
+  worst-case didChange→publish 0.9–1.4 s (DynamicOff) / 2.2–2.4 s (dynamic).
+- A 30-keystroke burst at 30 cps saturates the loop (probes blocked ~1.2–1.5 s);
+  at realistic typing rates the ~40–60 ms/keystroke floor is ~30% loop utilization.
+- Post-edit sweep test-items cost: 1.3 ms. `run_publish_sweep`'s hash-diff over all 4362
+  files: ~6 ms warm (334 ms first call — JIT, not covered by the precompile workload).
+
+## Pathologies found
+
+1. **DJP child leak (production)**: 49 orphaned `julia_dynamic_analysis_process_main.jl`
+   children (ppid 1, oldest 8.3 days) totalling **44.8 GiB RSS and ~3400% CPU** (the
+   readline-SpinLock livelock). Live LS sessions on the same box each carry 3–4 resident
+   ~900 MB children, some spinning. Each LS restart leaks ~1 GiB + most of a core.
+2. **Oscillating diagnostics (dynamic on)**: `JuliaWorkspaces/src/layer_file_analysis.jl`
+   and `layer_static_lint.jl` flip between 3 and 4 diagnostics **every ~30 s,
+   indefinitely** (observed t=350…743+ s, both warm and cold runs). DynamicOff shows 3
+   hints each → the 4th is env-dependent; some environment input alternates between two
+   states. Each flip advances the revision → sweep + republish: permanent idle churn.
+   No child respawns or progress events coincide; root cause open.
+3. **Malformed request crashes the whole server**: `julia/getModuleAt` without a
+   `version` field → `KeyError` in the typed-params constructor escapes `dispatch_msg`
+   and exits the LS (`languageserverinstance.jl` dispatch loop). Param construction
+   should fail the request, not the server.
+4. Push-mode startup publishes all 2186 workspace files, **1027 of them with zero
+   diagnostics** — wasted traffic for clients without diagnostic-refresh support.
+5. A relative symbol-store path resolves against the LS cwd (`scripts/languageserver`);
+   the extension always passes absolute, but other clients can pollute the install tree.
+6. Long-lived sessions grow: a day-old real LS instance on this workspace sits at
+   **12.3 GB RSS** (vs 3.2–4.9 GB fresh) — consistent with Salsa's no-eviction design
+   plus refresh churn (2026-07-18 doc item 5).
+7. LS RSS on this workspace is ~3.2 GB immediately after startup with DynamicOff —
+   1.8 GiB of it live heap of analysis state (biggest: per-file analysis artifacts,
+   VisibleName/InventoryItem aggregates).
+
+## Ranked follow-ups
+
+1. Attribute and fix the ~2 s dynamic-mode publish sweep (vs ~365 ms DynamicOff);
+   or chunk sweeps so interactive messages interleave.
+2. Open-files-first + chunked initial sweep → TTFA ~14 s.
+3. `splitpath` hotspot in `layer_projects.jl` (~20% of cold sweep, ~afternoon fix).
+4. Manifest-change gating for warm-restart refreshes (removes the 10-min tail).
+5. Root-cause the 30 s env flap; fix DJP livelock reaping (steady-state drains).
+6. Extend the precompile workload: `run_publish_sweep` hash-diff, references,
+   `getModuleAt`, store-backed hover.
+7. Harden typed-param construction against malformed requests.
+8. Skip startup publishes for files that never had diagnostics.
+
+## Reproduction
+
+- Driver + event logs + summaries: session scratchpad (`lsbench.py`, `run*/events.jsonl`,
+  `run*/summary.json`, `findings-notes.md`).
+- Isolated depot: `~/.cache/claude-lsbench/{depot,fakehome}` (hardlink copy; disposable).
+- Warm symbol store: scratchpad `store-dyn-abs`.
+- In-process numbers: REPL with the dev env; `JuliaWorkspace(dynamic=DynamicOff)` +
+  `read_path_into_textdocuments` over the repo; edit via `update_file!` with a body-edit
+  marker; `Profile`/`Profile.Allocs` for composition.

--- a/src/layer_projects.jl
+++ b/src/layer_projects.jl
@@ -249,44 +249,49 @@ Salsa.@derived function derived_project_folders(rt)
     return URI[i for i in keys(derived_potential_project_folders(rt)) if derived_project(rt, i)!==nothing]
 end
 
+const FolderParts = @NamedTuple{uri::URI, parts::Vector{String}}
+
+# Deepest folder first, and total-ordered so the table is stable across
+# revisions for an unchanged set of folders.
+function folder_parts_table(folders)
+    table = FolderParts[]
+    for folder_uri in folders
+        folder_path = uri2filepath(folder_uri)
+        folder_path === nothing && continue
+        push!(table, (uri=folder_uri, parts=splitpath(folder_path)))
+    end
+    sort!(table, by=i -> (-length(i.parts), i.parts))
+    return table
+end
+
+# The table is deepest first, so the first prefix match is the deepest folder.
+function deepest_folder_for_parts(table, file_parts)
+    for i in table
+        vec_startswith(file_parts, i.parts) && return i.uri
+    end
+    return nothing
+end
+
+# Splitting the folder paths once per revision instead of once per file keeps
+# the per-file lookup down to a single `splitpath`.
+Salsa.@derived function derived_package_folder_parts(rt)
+    return folder_parts_table(derived_package_folders(rt))
+end
+
+Salsa.@derived function derived_project_folder_parts(rt)
+    return folder_parts_table(derived_project_folders(rt))
+end
+
 Salsa.@derived function derived_package_for_file(rt, file::URI)
-    packages = derived_package_folders(rt)
-
     file_path = uri2filepath(file)
-
     file_path === nothing && return nothing
-    package = packages |>
-        x -> map(x) do i
-            package_folder_path = uri2filepath(i)
-            parts = splitpath(package_folder_path)
-            return (uri = i, parts = parts)
-        end |>
-        x -> filter(x) do i
-            return vec_startswith(splitpath(file_path), i.parts)
-        end |>
-        x -> sort(x, by=i->length(i.parts), rev=true) |>
-        x -> length(x) == 0 ? nothing : first(x).uri
 
-    return package
+    return deepest_folder_for_parts(derived_package_folder_parts(rt), splitpath(file_path))
 end
 
 Salsa.@derived function derived_project_for_file(rt, file::URI)
-    projects = derived_project_folders(rt)
-
     file_path = uri2filepath(file)
-
     file_path === nothing && return nothing
-    project = projects |>
-        x -> map(x) do i
-            project_folder_path = uri2filepath(i)
-            parts = splitpath(project_folder_path)
-            return (uri = i, parts = parts)
-        end |>
-        x -> filter(x) do i
-            return vec_startswith(splitpath(file_path), i.parts)
-        end |>
-        x -> sort(x, by=i->length(i.parts), rev=true) |>
-        x -> length(x) == 0 ? nothing : first(x).uri
 
-    return project
+    return deepest_folder_for_parts(derived_project_folder_parts(rt), splitpath(file_path))
 end

--- a/src/layer_testitems.jl
+++ b/src/layer_testitems.jl
@@ -11,25 +11,6 @@ function vec_startswith(a, b)
     return true
 end
 
-function find_project_for_file(projects::Vector{URI}, file::URI)
-    file.scheme != "file" && return nothing
-
-    file_path = uri2filepath(file)
-    project = projects |>
-        x -> map(x) do i
-            project_folder_path = uri2filepath(i)
-            parts = splitpath(project_folder_path)
-            return (uri = i, parts = parts)
-        end |>
-        x -> filter(x) do i
-            return vec_startswith(splitpath(file_path), i.parts)
-        end |>
-        x -> sort(x, by=i->length(i.parts), rev=true) |>
-        x -> length(x) == 0 ? nothing : first(x).uri
-
-    return project
-end
-
 Salsa.@derived function derived_testitems(rt, uri)
     @debug "derived_testitems" uri=uri
 
@@ -132,9 +113,7 @@ Salsa.@derived function derived_all_testitems(rt)
 end
 
 Salsa.@derived function derived_testenv(rt, uri)
-    projects = derived_project_folders(rt)
-
-    project_uri = find_project_for_file(projects, uri)
+    project_uri = derived_project_for_file(rt, uri)
     package_uri = derived_package_for_file(rt, uri)
 
     if project_uri === nothing
@@ -150,7 +129,7 @@ Salsa.@derived function derived_testenv(rt, uri)
     package_name = package_uri === nothing ? nothing : derived_package(rt, package_uri).name
 
     if project_uri == package_uri
-    elseif project_uri in projects
+    elseif project_uri in derived_project_folders(rt)
         relevant_project = derived_project(rt, project_uri)
 
         if relevant_project === nothing || findfirst(i->i.uri == package_uri, collect(values(relevant_project.deved_packages))) === nothing

--- a/test/test_projects.jl
+++ b/test/test_projects.jl
@@ -115,6 +115,69 @@ end
     @test isempty(lint_result.workspace_packages)
 end
 
+@testitem "derived_package_for_file and derived_project_for_file pick the deepest folder" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText,
+        derived_package_for_file, derived_project_for_file,
+        derived_package_folders, derived_project_folders
+    using JuliaWorkspaces.URIs2: URI
+
+    outer_project = """
+    name = "Outer"
+    uuid = "3c9a1b52-1f0f-4a9e-9c7d-7a1e0b7d4c11"
+    version = "1.0.0"
+    """
+
+    inner_project = """
+    name = "Inner"
+    uuid = "6b0e2f31-8d55-4f2a-9d10-2b6c5e8f9a22"
+    version = "2.0.0"
+    """
+
+    manifest = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+
+    [deps]
+    """
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///nesting/Project.toml"), SourceText(outer_project, "toml")))
+    add_file!(jw, TextFile(URI("file:///nesting/Manifest.toml"), SourceText(manifest, "toml")))
+    add_file!(jw, TextFile(URI("file:///nesting/lib/Inner/Project.toml"), SourceText(inner_project, "toml")))
+    add_file!(jw, TextFile(URI("file:///nesting/lib/Inner/Manifest.toml"), SourceText(manifest, "toml")))
+
+    @test length(derived_package_folders(jw.runtime)) == 2
+    @test length(derived_project_folders(jw.runtime)) == 2
+
+    # A file in the nested package belongs to the nested package, not the outer one
+    nested_file = URI("file:///nesting/lib/Inner/src/Inner.jl")
+    @test derived_package_for_file(jw.runtime, nested_file) == URI("file:///nesting/lib/Inner")
+    @test derived_project_for_file(jw.runtime, nested_file) == URI("file:///nesting/lib/Inner")
+
+    # A file only inside the outer package belongs to the outer package
+    outer_file = URI("file:///nesting/src/Outer.jl")
+    @test derived_package_for_file(jw.runtime, outer_file) == URI("file:///nesting")
+    @test derived_project_for_file(jw.runtime, outer_file) == URI("file:///nesting")
+
+    # A file sitting exactly at a package root
+    root_file = URI("file:///nesting/lib/Inner/Project.toml")
+    @test derived_package_for_file(jw.runtime, root_file) == URI("file:///nesting/lib/Inner")
+    @test derived_project_for_file(jw.runtime, root_file) == URI("file:///nesting/lib/Inner")
+
+    # A file outside of any package or project
+    outside_file = URI("file:///somewhere_else/foo.jl")
+    @test derived_package_for_file(jw.runtime, outside_file) === nothing
+    @test derived_project_for_file(jw.runtime, outside_file) === nothing
+
+    # A file that has no path at all
+    untitled_file = URI("untitled:Untitled-1")
+    @test derived_package_for_file(jw.runtime, untitled_file) === nothing
+    @test derived_project_for_file(jw.runtime, untitled_file) === nothing
+
+    # A sibling prefix must not match: /nesting/libextra is not inside /nesting/lib
+    @test derived_package_for_file(jw.runtime, URI("file:///nesting/libextra/Inner/src/Inner.jl")) == URI("file:///nesting")
+end
+
 @testitem "derived_project with Manifest.toml but no Project.toml does not crash" begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_diagnostics
     using JuliaWorkspaces.URIs2: URI

--- a/test/test_testitems.jl
+++ b/test/test_testitems.jl
@@ -604,6 +604,45 @@ version = "0.1.0"
     end
 end
 
+@testitem "derived_testenv for a file in a deved package of a project" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_test_env
+    using JuliaWorkspaces.URIs2: URI
+
+    project_toml = """
+    [deps]
+    Inner = "6b0e2f31-8d55-4f2a-9d10-2b6c5e8f9a22"
+    """
+
+    manifest_toml = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+
+    [[deps.Inner]]
+    deps = []
+    path = "Inner"
+    uuid = "6b0e2f31-8d55-4f2a-9d10-2b6c5e8f9a22"
+    version = "2.0.0"
+    """
+
+    inner_project = """
+    name = "Inner"
+    uuid = "6b0e2f31-8d55-4f2a-9d10-2b6c5e8f9a22"
+    version = "2.0.0"
+    """
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///devedenv/Project.toml"), SourceText(project_toml, "toml")))
+    add_file!(jw, TextFile(URI("file:///devedenv/Manifest.toml"), SourceText(manifest_toml, "toml")))
+    add_file!(jw, TextFile(URI("file:///devedenv/Inner/Project.toml"), SourceText(inner_project, "toml")))
+    add_file!(jw, TextFile(URI("file:///devedenv/Inner/src/Inner.jl"), SourceText("module Inner end", "julia")))
+
+    # The deved package is the package, the outer folder is the project
+    test_env = get_test_env(jw, URI("file:///devedenv/Inner/src/Inner.jl"))
+    @test test_env.package_name == "Inner"
+    @test test_env.package_uri == URI("file:///devedenv/Inner")
+    @test test_env.project_uri == URI("file:///devedenv")
+end
+
 @testitem "Test-item detail equality distinguishes empty ranges by position" begin
     using JuliaWorkspaces: TestItemDetail, TestSetupDetail, TestErrorDetail
     using JuliaWorkspaces.URIs2: @uri_str


### PR DESCRIPTION
`derived_package_for_file` and `derived_project_for_file` re-split every
candidate project folder for every file, and re-split the file path itself
once per candidate inside the filter closure. On a workspace with ~2200 Julia
files across ~360 project folders that is ~1.6 M `splitpath` calls (each a
regex match per path component), ~20% of a cold full-workspace analysis
sweep.

Split the folder paths once per revision in two new derived functions
(`derived_package_folder_parts`, `derived_project_folder_parts`), keep them
sorted deepest-first, and reduce the per-file lookup to one `splitpath` plus
a scan for the first prefix match. Deepest-folder-wins semantics are
unchanged; ties are impossible because equally deep prefixes of the same path
are the same folder.

`find_project_for_file` was a copy of the same logic and is replaced by
`derived_project_for_file`.

Cold sweep on that workspace: 41.0 s / 18.0 GiB -> 27.8 s / 11.5 GiB, and
`splitpath` no longer registers in the profile.