### PR TITLE
fix(env): derive test-environment work-item keys in one place

### DIFF
--- a/docs/perf/2026-07-24-performance-investigation.md
+++ b/docs/perf/2026-07-24-performance-investigation.md
@@ -132,6 +132,110 @@ into ~14 s (4.5 s init + ~7 s load + 2.5 s first file).
 7. Harden typed-param construction against malformed requests.
 8. Skip startup publishes for files that never had diagnostics.
 
+## Addendum (2026-07-25): splitpath fix + dynamic-sweep attribution
+
+Follow-ups on ranked items 3 and 1, on branches `sp/project-for-file-splitpath` and
+`sp/dynamic-sweep-perf` (the latter includes the former; both local).
+
+### Item 3: splitpath hotspot — fixed (`41f4924`)
+
+`derived_package_folder_parts` / `derived_project_folder_parts` precompute the
+folder-parts tables once per revision (sorted deepest-first with a total order so an
+unchanged folder set stays structurally equal and backdates); the per-file lookups do a
+single `splitpath(file_path)` + one scan. `find_project_for_file` in `layer_testitems.jl`
+was a verbatim copy of the old logic with no other callers and was replaced by
+`derived_project_for_file`. Cold sweep: **41.0 s / 18.0 GiB → 27.8 s / 11.5 GiB**
+(−32% wall, −36% alloc; same-session remeasure of the baseline). `splitpath`/regex
+dropped from ~19% of sweep samples to 1–4 of 1331. New testitems cover
+deepest-folder-wins semantics and `derived_testenv`'s deved-package branch (previously
+zero coverage).
+
+### Item 1: the "~2 s dynamic-mode sweep" was misattributed
+
+Measured in-process (`DynamicIndexingOnly`, warm store, same edit+sweep protocol):
+
+- A **quiescent** dynamic workspace sweeps at ~371–407 ms vs 352 ms DynamicOff — only
+  ~1.16× (deeper env-ready chains). The end-to-end 1.8–2.4 s numbers were **churn**:
+  during the indexing phase the Salsa revision advanced **213× with no user edit**, and
+  every background env result forces a full-workspace verification walk (~375 ms of pure
+  verification for **0.3 ms** of real recomputation — 169 re-executions of
+  `derived_project_environment_ready`, counted via a TraceLogging receiver). The
+  1.5–2.4 s spikes are sweeps where newly-loaded package metadata genuinely changed
+  `derived_environment` and a root re-linted (legitimate work).
+- `set_input!`'s isequal early-exit does fire (re-applying an identical env result
+  leaves the revision unchanged; next sweep 0.02 ms) — the "volatile env value defeats
+  backdating" hypothesis is false. `process_from_dynamic` is a no-op on an empty
+  channel, but it does synchronous multi-MB `.jstore` reads on the caller's task when
+  results are pending (per result, not per sweep).
+
+**The verification floor is graph edges**: 96,190 nodes / 1,588,958 edges ≈ 240 ns/edge
+≈ 380 ms/sweep, ~44% of samples in `_probe_derived` dict probes dominated by
+`Tuple{URI}` hashing. 85% of edges came from three fan-ins, each re-walking whole-root
+state per name:
+
+| derived function | edges | nodes | avg deps |
+|---|---|---|---|
+| `derived_method_arities` | 1,108,206 (70%) | 11,827 | 93.7 |
+| `derived_project_uri_for_root` | 169,778 (11%) | 2,186 | 77.7 |
+| `derived_external_method_extensions` | 57,208 | 490 | 116.8 |
+
+### Fix (`5f59af8`)
+
+- `derived_method_arities_index(root)` / `derived_external_method_extensions_index(root)`:
+  one splice walk per root; per-name queries become dict lookups
+  (`derived_external_extension_names` reads the same index). Indices backdate when
+  equal, so the early-cutoff behavior is preserved.
+- `derived_deving_project(package_folder_uri)` replaces the two inlined every-project
+  scans in `derived_project_uri_for_root`.
+- `URI` caches its content hash in a private field (Windows lowercase rule preserved);
+  `==` short-circuits on it.
+
+| | edges | DynamicOff sweep | dynamic quiescent | after one env result |
+|---|---|---|---|---|
+| before | 1.59 M | 352 ms | 407 ms | 375 ms |
+| after | 0.30 M | **133 ms** | **153 ms** | **124 ms** |
+
+Churn-phase sweeps: ~400 ms median with 1.5–2.4 s spikes → ~204 ms median / 700 ms p90
+(one 3.6 s outlier = real re-lint + GC; churn comparison is across differently-warm
+stores, the quiescent columns are the rigorous ones). Cold full-workspace diagnostics
+unchanged. Full suite: 5778 pass / 7 broken / 0 fail / 0 error (+39 asserts: URI
+hash/equality invariants, index-vs-query agreement, identical-env-result backdating).
+
+### 30 s diagnostic flip: not reproduced in-process
+
+After quiescence, 90 s idle polling: revision constant, both flagged URIs steady at 3
+diagnostics. A reproduced warm-restart refresh tail (238 fast-laned items, 53 standalone
+refreshes over ~6 min at cap 4) **never advanced the revision** — the in-process refresh
+path is not the churn source, and refresh children rewrote no workspace manifest.
+Best remaining hypothesis (needs the LS in the loop): the LS registers file watchers on
+the fabricated standalone-project dirs next to the symbol store; a refresh child
+rewrites their Project/Manifest → watcher pushes new content → `derived_project`
+content-hash changes → env-ready flips until the next refresh result re-registers the
+key, at the refresh cadence.
+
+### New bug, needs a decision (not fixed on the perf branch)
+
+`process_from_dynamic` sets the **global** `input_env_ready` to `true` on the *first*
+env result, and `derived_file_env_ready` ORs it in — per-project gating of
+env-dependent diagnostics is effectively disabled from the first completed environment
+onward (verified: deleting a project's `WatchEnvironmentKey` from the ready set changes
+no file's readiness). Fixing it restores the documented suppression semantics but
+changes visible diagnostic behavior.
+
+### Still open after this round
+
+- Chunk the (now ~130–150 ms) debounced sweep on the dispatch loop; coalesce bursts of
+  dynamic-result applications into one revision instead of N.
+- Manifest-content gating for warm-restart refreshes (6 of 12 in-process minutes were
+  53 standalone refreshes producing byte-identical inputs).
+- Salsa (held for review): the per-edge dict re-probe in `_derived_changed_at` is now
+  essentially the entire remaining sweep cost — intern dependency keys or store
+  `DerivedValue` pointers in `dependencies`.
+- `derived_project_folders`/`derived_package_folders` iterate `Dict` keys — unstable
+  order can spuriously defeat backdating; sort them.
+- Test-infra note: a bare `@run_package_tests` from the package dir pulls in sibling
+  packages; drive the full suite through `test/runtests.jl`.
+
 ## Reproduction
 
 - Driver + event logs + summaries: session scratchpad (`lsbench.py`, `run*/events.jsonl`,

--- a/src/URIs2/URIs2.jl
+++ b/src/URIs2/URIs2.jl
@@ -6,6 +6,11 @@ include("vendored_from_uris.jl")
 
 export URI, uri2filepath, filepath2uri, @uri_str
 
+# The private `_hash` field caches the content hash of the other five, computed
+# once at construction. URI-keyed dict probes are the hottest operation in the
+# system (every memoized per-file query, and every edge of the dependency graph
+# the incremental engine walks), and re-hashing the path string on each probe
+# dominated that walk.
 """
     struct URI
 
@@ -23,10 +28,35 @@ struct URI
     path::String
     query::Union{String,Nothing}
     fragment::Union{String,Nothing}
+    _hash::UInt
+
+    function URI(scheme, authority, path, query, fragment)
+        scheme = _as_string(scheme)
+        authority = _as_string(authority)
+        path = something(_as_string(path), "")
+        query = _as_string(query)
+        fragment = _as_string(fragment)
+        return new(scheme, authority, path, query, fragment, _content_hash(scheme, authority, path, query, fragment))
+    end
 end
 
+_as_string(x::Nothing) = nothing
+_as_string(x::AbstractString) = String(x)
+
 @static if Sys.iswindows()
+    # Chained field hashes: hashing a tuple here heap-allocates it (the
+    # Union-typed query/fragment fields defeat stack allocation).
+    function _content_hash(scheme, authority, path, query, fragment)
+        h = hash(scheme, zero(UInt))
+        h = hash(authority, h)
+        h = scheme == "file" ? hash(lowercase(path), h) : hash(path, h)
+        h = hash(query, h)
+        return hash(fragment, h)
+    end
+
     function Base.:(==)(a::URI, b::URI)
+        a._hash == b._hash || return false
+
         if a.scheme=="file" && b.scheme=="file"
             a_path_norm = lowercase(a.path)
             b_path_norm = lowercase(b.path)
@@ -44,36 +74,27 @@ end
                 a.fragment == b.fragment
         end
     end
-
-    # Chained field hashes: hashing a tuple here heap-allocates it (the
-    # Union-typed query/fragment fields defeat stack allocation), and URI
-    # hashing is on the hot dict-probe path of every per-file query.
-    function Base.hash(a::URI, h::UInt)
-        h = hash(a.scheme, h)
-        h = hash(a.authority, h)
-        h = a.scheme == "file" ? hash(lowercase(a.path), h) : hash(a.path, h)
-        h = hash(a.query, h)
-        return hash(a.fragment, h)
-    end
 else
+    function _content_hash(scheme, authority, path, query, fragment)
+        h = hash(scheme, zero(UInt))
+        h = hash(authority, h)
+        h = hash(path, h)
+        h = hash(query, h)
+        return hash(fragment, h)
+    end
+
     function Base.:(==)(a::URI, b::URI)
+        a._hash == b._hash || return false
+
         return a.scheme == b.scheme &&
             a.authority == b.authority &&
             a.path == b.path &&
             a.query == b.query &&
             a.fragment == b.fragment
     end
-
-    # Chained field hashes — see the case-insensitive branch above for why
-    # the tuple version allocates.
-    function Base.hash(a::URI, h::UInt)
-        h = hash(a.scheme, h)
-        h = hash(a.authority, h)
-        h = hash(a.path, h)
-        h = hash(a.query, h)
-        return hash(a.fragment, h)
-    end
 end
+
+Base.hash(a::URI, h::UInt) = hash(a._hash, h)
 
 function percent_decode(str::AbstractString)
     return unescapeuri(str)

--- a/src/dynamic_feature/dynamic_feature.jl
+++ b/src/dynamic_feature/dynamic_feature.jl
@@ -348,6 +348,11 @@ struct DynamicFeature
     # re-reading (and re-`set_input`ing) multi-MB cache files.
     loaded_pkg_metadata::Set{PkgCacheKey}
     pending_count::Threads.Atomic{Int}
+    # Whether any result has been consumed by `process_from_dynamic`. Together
+    # with `pending_count` this is what `is_ready` reports: a workspace that has
+    # not produced a single result yet is not "done", however empty its queues
+    # look at that moment.
+    saw_result::Threads.Atomic{Bool}
     update_channel::Channel{Symbol}
     progress_callback::Union{Nothing,Function}
     # Last child-reported indexing percentage per work item (reactor-owned).
@@ -393,6 +398,7 @@ struct DynamicFeature
             Set{PkgCacheKey}(),
             Set{PkgCacheKey}(),
             Threads.Atomic{Int}(0),
+            Threads.Atomic{Bool}(false),
             Channel{Symbol}(1),   # coalesced wakeup signal (see _complete_work_item!)
             progress_callback,
             Dict{DJPKey,Int}(),

--- a/src/inputs.jl
+++ b/src/inputs.jl
@@ -6,6 +6,9 @@ Salsa.@declare_input input_active_project(rt)::Union{URI,Nothing}
 
 Salsa.@declare_input input_notebook_file(rt, uri)::NotebookFile
 
+# Manual override that makes every file's environment count as ready (see
+# `derived_file_env_ready`). Only tests set it: readiness is tracked per
+# project/work item, never workspace-wide.
 Salsa.@declare_input input_env_ready(rt)::Bool
 
 # Whether the workspace fabricates environments (standalone projects for
@@ -64,6 +67,11 @@ Salsa.@declare_input input_ready_test_environments(rt)::Dict{WatchTestEnvironmen
 # Created standalone package projects, mapping each standalone key to the
 # resulting project URI.
 Salsa.@declare_input input_standalone_projects(rt)::Dict{CreateStandaloneProjectKey,URI}
+
+# Work items that failed terminally. Their artifacts (a test/standalone project
+# URI) will never appear, so readiness gates treat these keys as settled and
+# proceed best-effort with whatever symbol caches exist.
+Salsa.@declare_input input_failed_dynamic_keys(rt)::Set{DJPKey}
 
 Salsa.@declare_input input_package_metadata(rt, name::Symbol, uuid::UUID, version::VersionNumber, git_tree_sha1::Union{Nothing,String})::Union{SymbolServer.Package,Nothing} function(ctx, name, uuid, version, git_tree_sha1)
 

--- a/src/layer_environment.jl
+++ b/src/layer_environment.jl
@@ -236,18 +236,16 @@ Salsa.@derived function derived_project_uri_for_root(rt, uri)
 
         # If the package is not a project (no manifest) and not dev'd into any workspace project,
         # trigger creation of a standalone project for it
-        if !_is_package_deved_in_workspace(rt, package_folder_uri)
+        deving_project = derived_deving_project(rt, package_folder_uri)
+        if deving_project === nothing
             standalone_uri = derived_ready_standalone_project(rt, package_folder_uri, pkg_content_hash)
             if standalone_uri !== nothing
                 return standalone_uri
             end
         else
             # Package IS deved in a workspace project (possibly the standalone project
-            # that was created for it) — find and return that project
-            deving_project = _find_deving_project(rt, package_folder_uri)
-            if deving_project !== nothing
-                return deving_project
-            end
+            # that was created for it) — use that project
+            return deving_project
         end
     end
 
@@ -255,20 +253,18 @@ Salsa.@derived function derived_project_uri_for_root(rt, uri)
     return active_project
 end
 
-function _is_package_deved_in_workspace(rt, package_folder_uri)
-    for project_folder_uri in derived_project_folders(rt)
-        project = derived_project(rt, project_folder_uri)
-        project === nothing && continue
-        for (_, v) in project.deved_packages
-            if v.uri == package_folder_uri
-                return true
-            end
-        end
-    end
-    return false
-end
+"""
+    derived_deving_project(rt, package_folder_uri) -> Union{Nothing,URI}
 
-function _find_deving_project(rt, package_folder_uri)
+The workspace project that `dev`s the package at `package_folder_uri`, or
+`nothing` if no project does.
+
+Memoized because the scan touches *every* project in the workspace: called
+inline, each caller (one per file, via `derived_project_uri_for_root`) would
+take a dependency on all of them, so the number of edges the incremental engine
+walks would grow as files × projects.
+"""
+Salsa.@derived function derived_deving_project(rt, package_folder_uri)
     for project_folder_uri in derived_project_folders(rt)
         project = derived_project(rt, project_folder_uri)
         project === nothing && continue
@@ -280,6 +276,9 @@ function _find_deving_project(rt, package_folder_uri)
     end
     return nothing
 end
+
+_is_package_deved_in_workspace(rt, package_folder_uri) =
+    derived_deving_project(rt, package_folder_uri) !== nothing
 
 """
     derived_file_env_ready(rt, uri)

--- a/src/layer_environment.jl
+++ b/src/layer_environment.jl
@@ -78,6 +78,36 @@ Salsa.@derived function derived_project_environment_ready(rt, project_uri, conte
 end
 
 """
+    derived_project_requires_indexing(rt, project_uri, content_hash) -> Bool
+
+Whether a dynamic process is scheduled to index `project_uri` (at
+`content_hash`). A project no work item covers — e.g. one without a manifest —
+can never become "ready", so readiness gates must not wait for it.
+
+Its own derived function so per-file gates depend on this per-project `Bool`
+instead of on the workspace-wide required set: when an unrelated workspace
+change recomputes the set, this key's answer usually does not change and
+Salsa's early cutoff stops the invalidation here.
+"""
+Salsa.@derived function derived_project_requires_indexing(rt, project_uri, content_hash::UInt64)
+    key = WatchEnvironmentKey(uri2filepath(project_uri), content_hash)
+    return key in derived_required_dynamic_projects(rt)
+end
+
+"""
+    derived_test_environment_pending(rt, project_uri, package, content_hash) -> Bool
+
+Whether a test-environment work item for `project_uri` + `package` is scheduled
+and can still produce a result. False when none is scheduled and false once the
+item failed terminally — waiting for either would gate forever.
+"""
+Salsa.@derived function derived_test_environment_pending(rt, project_uri, package, content_hash::UInt64)
+    key = WatchTestEnvironmentKey(uri2filepath(project_uri), package, content_hash)
+    key in input_failed_dynamic_keys(rt) && return false
+    return key in derived_required_dynamic_projects(rt)
+end
+
+"""
     derived_ready_test_environment(rt, project_uri, package, content_hash) -> Union{Nothing,URI}
 
 The ready test-project URI for `project_uri` + `package`, or `nothing` if the
@@ -286,27 +316,31 @@ _is_package_deved_in_workspace(rt, package_folder_uri) =
 Return true if this file's effective environment is ready for static-lint
 analysis that depends on environment data (e.g. missing-reference checks).
 
-Per-project gating: each file's *own* project must have completed dynamic
-indexing (the corresponding `:environment_ready` /
-`:standalone_package_project_ready` / `:test_environment_ready` message has
-been consumed). The legacy global `input_env_ready` flag is honored as a
-manual override for tests.
+Per-project gating: each file's *own* project must be settled — either its
+environment finished indexing (or failed, which is terminal too), or no work
+item is scheduled for it at all, in which case there is nothing to wait for.
 
 Files that need a test environment (`test/runtests.jl` or files with
-`@testitem`) additionally require the test-env DJP to have produced a merged
-test project URI before we consider their env "ready". Otherwise missing-ref
-diagnostics for test-only deps (TestItemRunner, Test, @testitem, @test, …)
-would flash as false positives until indexing finishes.
+`@testitem`) additionally require the test-env work item to have produced a
+merged test project URI, unless that item is not scheduled or failed
+terminally. Otherwise missing-ref diagnostics for test-only deps
+(TestItemRunner, Test, @testitem, @test, …) would flash as false positives
+until indexing finishes.
+
+The global `input_env_ready` flag is honored as a manual override for tests: it
+pretends every environment is ready.
 """
 Salsa.@derived function derived_file_env_ready(rt, uri)
-    # Determine the file's effective project URI and require its env to have
-    # been processed. The legacy global flag (settable in tests) acts as an
-    # override that pretends every project's env is ready.
+    input_env_ready(rt) && return true
+
+    # Determine the file's effective project URI and require its env to be
+    # settled.
     project_uri = derived_project_uri_for_root(rt, uri)
     if project_uri !== nothing
         project = derived_project(rt, project_uri)
         project_hash = project === nothing ? UInt64(0) : project.content_hash
-        if !derived_project_environment_ready(rt, project_uri, project_hash) && !input_env_ready(rt)
+        if !derived_project_environment_ready(rt, project_uri, project_hash) &&
+                derived_project_requires_indexing(rt, project_uri, project_hash)
             return false
         end
     end
@@ -333,7 +367,10 @@ Salsa.@derived function derived_file_env_ready(rt, uri)
 
     test_env_project = derived_project(rt, project_for_test_env)
     test_env_hash = test_env_project === nothing ? UInt64(0) : test_env_project.content_hash
-    return derived_ready_test_environment(rt, project_for_test_env, pkg.name, test_env_hash) !== nothing
+    ready_test_project = derived_ready_test_environment(rt, project_for_test_env, pkg.name, test_env_hash)
+    ready_test_project === nothing || return true
+    # No test project yet: only gate while one can still arrive.
+    return !derived_test_environment_pending(rt, project_for_test_env, pkg.name, test_env_hash)
 end
 
 """

--- a/src/layer_environment.jl
+++ b/src/layer_environment.jl
@@ -95,26 +95,24 @@ Salsa.@derived function derived_project_requires_indexing(rt, project_uri, conte
 end
 
 """
-    derived_test_environment_pending(rt, project_uri, package, content_hash) -> Bool
+    derived_test_environment_pending(rt, key::WatchTestEnvironmentKey) -> Bool
 
-Whether a test-environment work item for `project_uri` + `package` is scheduled
-and can still produce a result. False when none is scheduled and false once the
-item failed terminally — waiting for either would gate forever.
+Whether the test-environment work item `key` is scheduled and can still produce
+a result. False when none is scheduled and false once the item failed
+terminally — waiting for either would gate forever.
 """
-Salsa.@derived function derived_test_environment_pending(rt, project_uri, package, content_hash::UInt64)
-    key = WatchTestEnvironmentKey(uri2filepath(project_uri), package, content_hash)
+Salsa.@derived function derived_test_environment_pending(rt, key::WatchTestEnvironmentKey)
     key in input_failed_dynamic_keys(rt) && return false
     return key in derived_required_dynamic_projects(rt)
 end
 
 """
-    derived_ready_test_environment(rt, project_uri, package, content_hash) -> Union{Nothing,URI}
+    derived_ready_test_environment(rt, key::WatchTestEnvironmentKey) -> Union{Nothing,URI}
 
-The ready test-project URI for `project_uri` + `package`, or `nothing` if the
-test environment has not been indexed yet.
+The ready test-project URI recorded for the test-environment work item `key`, or
+`nothing` if that environment has not been indexed yet.
 """
-Salsa.@derived function derived_ready_test_environment(rt, project_uri, package, content_hash::UInt64)
-    key = WatchTestEnvironmentKey(uri2filepath(project_uri), package, content_hash)
+Salsa.@derived function derived_ready_test_environment(rt, key::WatchTestEnvironmentKey)
     return get(input_ready_test_environments(rt), key, nothing)
 end
 
@@ -233,25 +231,11 @@ Salsa.@derived function derived_project_uri_for_root(rt, uri)
         file_needs_test_env = lowercase(uri2filepath(uri)) == lowercase(runtests_path) ||
             _file_has_testitems(rt, uri)
 
-        if file_needs_test_env
-            package_name = pkg.name
+        if file_needs_test_env && pkg !== nothing
+            test_env_key = _test_environment_key(rt, package_folder_uri, pkg)
 
-            project_for_test_env = if package_folder_uri in derived_project_folders(rt)
-                package_folder_uri
-            else
-                # Check if there's a standalone project for this package
-                standalone_uri = derived_ready_standalone_project(rt, package_folder_uri, pkg_content_hash)
-                if standalone_uri !== nothing
-                    standalone_uri
-                else
-                    active_project
-                end
-            end
-
-            if project_for_test_env !== nothing
-                test_env_project = derived_project(rt, project_for_test_env)
-                test_env_hash = test_env_project === nothing ? UInt64(0) : test_env_project.content_hash
-                test_project_uri = derived_ready_test_environment(rt, project_for_test_env, package_name, test_env_hash)
+            if test_env_key !== nothing
+                test_project_uri = derived_ready_test_environment(rt, test_env_key)
 
                 if test_project_uri !== nothing
                     return test_project_uri
@@ -311,6 +295,38 @@ _is_package_deved_in_workspace(rt, package_folder_uri) =
     derived_deving_project(rt, package_folder_uri) !== nothing
 
 """
+    _test_environment_key(rt, package_folder_uri, pkg) -> Union{Nothing,WatchTestEnvironmentKey}
+
+The identity of the test-environment work item for the package `pkg` at
+`package_folder_uri`, or `nothing` if no project can provide that environment.
+
+Single source of truth for that identity: the required set (which schedules the
+item), the result recorder and every readiness query must derive the same key, or
+a recorded result is looked up under a key nobody ever produced.
+
+The environment comes from the package's own folder when the package is a project
+itself, and likewise when no workspace project `dev`s it (a standalone project is
+fabricated for it under that same folder). Only for a deved package does the
+active project provide it.
+"""
+function _test_environment_key(rt, package_folder_uri, pkg)
+    project_for_test = if package_folder_uri in derived_project_folders(rt) ||
+            !_is_package_deved_in_workspace(rt, package_folder_uri)
+        package_folder_uri
+    else
+        input_active_project(rt)
+    end
+    project_for_test === nothing && return nothing
+
+    project = derived_project(rt, project_for_test)
+    return WatchTestEnvironmentKey(
+        uri2filepath(project_for_test),
+        pkg.name,
+        project === nothing ? UInt64(0) : project.content_hash,
+    )
+end
+
+"""
     derived_file_env_ready(rt, uri)
 
 Return true if this file's effective environment is ready for static-lint
@@ -350,27 +366,18 @@ Salsa.@derived function derived_file_env_ready(rt, uri)
 
     pkg = derived_package(rt, package_folder_uri)
     pkg === nothing && return true
-    pkg_content_hash = pkg.content_hash
 
     runtests_path = joinpath(uri2filepath(package_folder_uri), "test", "runtests.jl")
     file_needs_test_env = lowercase(uri2filepath(uri)) == lowercase(runtests_path) ||
         _file_has_testitems(rt, uri)
     file_needs_test_env || return true
 
-    project_for_test_env = if package_folder_uri in derived_project_folders(rt)
-        package_folder_uri
-    else
-        standalone = derived_ready_standalone_project(rt, package_folder_uri, pkg_content_hash)
-        standalone !== nothing ? standalone : input_active_project(rt)
-    end
-    project_for_test_env === nothing && return true
+    test_env_key = _test_environment_key(rt, package_folder_uri, pkg)
+    test_env_key === nothing && return true
 
-    test_env_project = derived_project(rt, project_for_test_env)
-    test_env_hash = test_env_project === nothing ? UInt64(0) : test_env_project.content_hash
-    ready_test_project = derived_ready_test_environment(rt, project_for_test_env, pkg.name, test_env_hash)
-    ready_test_project === nothing || return true
+    derived_ready_test_environment(rt, test_env_key) === nothing || return true
     # No test project yet: only gate while one can still arrive.
-    return !derived_test_environment_pending(rt, project_for_test_env, pkg.name, test_env_hash)
+    return !derived_test_environment_pending(rt, test_env_key)
 end
 
 """
@@ -429,25 +436,10 @@ Salsa.@derived function derived_required_dynamic_projects(rt)
         pkg = derived_package(rt, package_uri)
         pkg === nothing && continue
 
-        # Determine which project provides the test environment
-        project_for_test = if package_uri in derived_project_folders(rt)
-            package_uri
-        elseif !_is_package_deved_in_workspace(rt, package_uri)
-            # Would use standalone project
-            package_uri
-        else
-            input_active_project(rt)
-        end
-        project_for_test === nothing && continue
+        test_env_key = _test_environment_key(rt, package_uri, pkg)
+        test_env_key === nothing && continue
 
-        proj = derived_project(rt, project_for_test)
-        proj_hash = proj === nothing ? UInt64(0) : proj.content_hash
-
-        push!(required, WatchTestEnvironmentKey(
-            uri2filepath(project_for_test),
-            pkg.name,
-            proj_hash,
-        ))
+        push!(required, test_env_key)
     end
 
     return required

--- a/src/layer_module_tree.jl
+++ b/src/layer_module_tree.jl
@@ -826,16 +826,39 @@ check a call's argument count against the callee's FULL cross-file method set.
 Salsa.@derived function derived_method_arities(rt, root, path, name)
     @debug "derived_method_arities" root=root path=path name=name
 
+    return get(derived_method_arities_index(rt, root), (path, name), _NO_ARITIES)
+end
+
+const _NO_ARITIES = MethodArity[]
+
+"""
+    derived_method_arities_index(rt, root) -> Dict{Tuple{Vector{String},String},Vector{MethodArity}}
+
+Every `(module path, name) => arities` entry of `root`'s tree in one node: the
+same selection [`derived_method_arities`](@ref) exposes per name, computed by a
+single splice walk.
+
+The walk reads the inventory of *every* file in the root, so computing it per
+name made each of the (many thousands of) per-name nodes depend on every file —
+the dominant term in the size of the dependency graph, hence in the cost of
+every incremental re-verification. Funnelling them through this one node makes
+each per-name node a single lookup, and keeps early cutoff: an edit that leaves
+the index equal backdates it, and one that changes it only re-runs the (O(1))
+per-name lookups.
+"""
+Salsa.@derived function derived_method_arities_index(rt, root)
+    @debug "derived_method_arities_index" root=root
+
     tree = derived_module_tree(rt, root)
     modpaths = Set{Vector{String}}(n.path for n in tree.modules)
-    result = MethodArity[]
-    path in modpaths || return result
+    result = Dict{Tuple{Vector{String},String},Vector{MethodArity}}()
 
-    _walk_spliced_binding_items!(rt, root, String[], name, Set{URI}([root])) do F, item, loc
+    _walk_spliced_binding_items!(rt, root, String[], nothing, Set{URI}([root])) do F, item, loc
         item.arity === nothing && return
         resolved = isempty(item.qualifier) ? loc :
             _resolve_extension_qualifier(modpaths, loc, item.qualifier)
-        resolved == path && push!(result, item.arity)
+        (resolved === nothing || resolved ∉ modpaths) && return
+        push!(get!(() -> MethodArity[], result, (resolved, item.name)), item.arity)
     end
     return result
 end
@@ -913,13 +936,32 @@ per-file inventories; plain data throughout.
 Salsa.@derived function derived_external_method_extensions(rt, root, name)
     @debug "derived_external_method_extensions" root=root name=name
 
+    return get(derived_external_method_extensions_index(rt, root), name, _NO_EXTERNAL_EXTENSIONS)
+end
+
+const _NO_EXTERNAL_EXTENSIONS = ExternalExtension[]
+
+"""
+    derived_external_method_extensions_index(rt, root) -> Dict{String,Vector{ExternalExtension}}
+
+Every `name => extensions` entry of `root`'s tree in one node, computed by a
+single splice walk. Same rationale as
+[`derived_method_arities_index`](@ref): the walk reads every file in the root,
+so a per-name node would make the graph the incremental engine re-verifies grow
+as files × names.
+"""
+Salsa.@derived function derived_external_method_extensions_index(rt, root)
+    @debug "derived_external_method_extensions_index" root=root
+
     tree = derived_module_tree(rt, root)
     modpaths = Set{Vector{String}}(n.path for n in tree.modules)
     import_targets = _external_import_targets(tree)
-    result = ExternalExtension[]
-    _walk_spliced_binding_items!(rt, root, String[], name, Set{URI}([root])) do F, item, loc
+    result = Dict{String,Vector{ExternalExtension}}()
+    _walk_spliced_binding_items!(rt, root, String[], nothing, Set{URI}([root])) do F, item, loc
         q = _external_extension_qualifier(modpaths, import_targets, item, loc)
-        q === nothing || push!(result, (qualifier=q, signature=item.signature, ref=(file=F, id=item.id)))
+        q === nothing && return
+        push!(get!(() -> ExternalExtension[], result, item.name),
+            (qualifier=q, signature=item.signature, ref=(file=F, id=item.id)))
     end
     return result
 end
@@ -937,12 +979,5 @@ added/removed, so most edits leave it unchanged and dependents backdate.
 Salsa.@derived function derived_external_extension_names(rt, root)
     @debug "derived_external_extension_names" root=root
 
-    tree = derived_module_tree(rt, root)
-    modpaths = Set{Vector{String}}(n.path for n in tree.modules)
-    import_targets = _external_import_targets(tree)
-    result = Set{String}()
-    _walk_spliced_binding_items!(rt, root, String[], nothing, Set{URI}([root])) do F, item, loc
-        _external_extension_qualifier(modpaths, import_targets, item, loc) === nothing || push!(result, item.name)
-    end
-    return result
+    return Set{String}(keys(derived_external_method_extensions_index(rt, root)))
 end

--- a/src/public.jl
+++ b/src/public.jl
@@ -628,14 +628,18 @@ end
     is_ready(jw::JuliaWorkspace)
 
 Check whether the workspace's dynamic environment loading has completed.
-Returns `true` if no dynamic feature is configured, or if the environment
-has finished loading and no tasks are pending.
+Returns `true` if no dynamic feature is configured, or if at least one result
+has been consumed (successful or failed) and no work item is pending.
+
+This is a whole-workspace question and stays coarse: per-file consumers want
+[`derived_file_env_ready`](@ref) instead, which is settled per project.
 """
 function is_ready(jw::JuliaWorkspace)
     @debug "is_ready"
 
-    jw.dynamic_feature === nothing && return true
-    return input_env_ready(jw.runtime) && jw.dynamic_feature.pending_count[] == 0
+    df = jw.dynamic_feature
+    df === nothing && return true
+    return df.saw_result[] && df.pending_count[] == 0
 end
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -420,6 +420,7 @@ struct JuliaWorkspace
         set_input_ready_project_environments!(rt, Set{WatchEnvironmentKey}())
         set_input_ready_test_environments!(rt, Dict{WatchTestEnvironmentKey,URI}())
         set_input_standalone_projects!(rt, Dict{CreateStandaloneProjectKey,URI}())
+        set_input_failed_dynamic_keys!(rt, Set{DJPKey}())
 
         new(rt, dynamic_feature)
     end
@@ -540,30 +541,33 @@ function process_from_dynamic(jw::JuliaWorkspace)
     ready_envs = copy(input_ready_project_environments(jw.runtime))
     ready_test_envs = copy(input_ready_test_environments(jw.runtime))
     standalone_projects = copy(input_standalone_projects(jw.runtime))
+    failed_keys = copy(input_failed_dynamic_keys(jw.runtime))
     envs_dirty = false
     test_envs_dirty = false
     standalone_dirty = false
-    any_env_ready = false
+    failed_dirty = false
+    saw_result = false
 
     while isready(df.out_channel)
         msg = take!(df.out_channel)
+        saw_result = true
 
         if msg isa FailedResult
             @warn "DJP reported failure" msg.key
             # `failed_projects` was already populated in the reactor. A failure
             # is treated as a terminal state for readiness (best-effort, with
             # whatever symbol caches exist) so `is_ready` doesn't stay false
-            # forever and per-project gating doesn't suppress diagnostics
-            # indefinitely. A failed watched environment is recorded like a
-            # successful one; failed test environments and standalone projects
-            # have nothing to record — the artifacts their success paths
-            # register (a test/standalone project URI) don't exist on failure —
-            # so they only contribute to the global readiness flag.
+            # forever and gating doesn't suppress diagnostics indefinitely. A
+            # failed watched environment is recorded like a successful one;
+            # failed test environments and standalone projects have no artifact
+            # to record — the test/standalone project URI their success paths
+            # register doesn't exist — so the key is only remembered as failed.
+            push!(failed_keys, msg.key)
+            failed_dirty = true
             if msg.key isa WatchEnvironmentKey
                 push!(ready_envs, msg.key)
                 envs_dirty = true
             end
-            any_env_ready = true
 
         elseif msg isa EnvironmentReadyResult
             @debug "Processing new env"
@@ -575,7 +579,6 @@ function process_from_dynamic(jw::JuliaWorkspace)
             # while their own DJPs are still pending.
             push!(ready_envs, WatchEnvironmentKey(msg.project_path, msg.content_hash))
             envs_dirty = true
-            any_env_ready = true
 
         elseif msg isa TestEnvironmentReadyResult
             @info "Processing new test env" msg.project_uri msg.package msg.test_project_uri
@@ -590,7 +593,6 @@ function process_from_dynamic(jw::JuliaWorkspace)
             test_proj_hash = test_proj === nothing ? UInt64(0) : test_proj.content_hash
             push!(ready_envs, WatchEnvironmentKey(uri2filepath(msg.test_project_uri), test_proj_hash))
             envs_dirty = true
-            any_env_ready = true
 
         elseif msg isa StandaloneProjectReadyResult
             @info "Processing new standalone package project" msg.package_folder_uri msg.project_uri
@@ -603,7 +605,6 @@ function process_from_dynamic(jw::JuliaWorkspace)
             standalone_proj_hash = standalone_proj === nothing ? UInt64(0) : standalone_proj.content_hash
             push!(ready_envs, WatchEnvironmentKey(uri2filepath(msg.project_uri), standalone_proj_hash))
             envs_dirty = true
-            any_env_ready = true
         else
             error("Unknown message: $msg")
         end
@@ -612,7 +613,8 @@ function process_from_dynamic(jw::JuliaWorkspace)
     envs_dirty && set_input_ready_project_environments!(jw.runtime, ready_envs)
     test_envs_dirty && set_input_ready_test_environments!(jw.runtime, ready_test_envs)
     standalone_dirty && set_input_standalone_projects!(jw.runtime, standalone_projects)
-    any_env_ready && set_input_env_ready!(jw.runtime, true)
+    failed_dirty && set_input_failed_dynamic_keys!(jw.runtime, failed_keys)
+    saw_result && (df.saw_result[] = true)
 
     return
 end

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -1967,3 +1967,196 @@ end
 
     @test derived_file_env_ready(jw.runtime, runtests_uri)
 end
+
+@testitem "env gating: a manifest-less package's test files wait for their test environment" begin
+    using JuliaWorkspaces: JuliaWorkspace, DynamicIndexingOnly, TextFile, SourceText,
+        _add_file!, process_from_dynamic, derived_package, derived_file_env_ready,
+        derived_required_dynamic_projects, derived_ready_test_environment,
+        derived_test_environment_pending, _test_environment_key,
+        TestEnvironmentReadyResult, WatchTestEnvironmentKey
+    using JuliaWorkspaces.URIs2: filepath2uri
+
+    # A package without a manifest is not a project folder, so its test-env work
+    # item is keyed on the package folder itself with a zero content hash.
+    dir = mktempdir()
+    mkpath(joinpath(dir, "src"))
+    mkpath(joinpath(dir, "test"))
+    files = [
+        joinpath(dir, "Project.toml") => ("""
+        name = "BareGate"
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee46"
+        version = "0.1.0"
+        """, "toml"),
+        joinpath(dir, "src", "BareGate.jl") => ("module BareGate\nend\n", "julia"),
+        joinpath(dir, "test", "runtests.jl") => ("using Test\n", "julia"),
+        joinpath(dir, "test", "test_gate.jl") => ("""
+        @testitem "t" begin
+            @test true
+        end
+        """, "julia"),
+    ]
+
+    jw = JuliaWorkspace(dynamic=DynamicIndexingOnly, store_path=mktempdir())
+    for (path, (content, lang)) in files
+        write(path, content)
+        _add_file!(jw, TextFile(filepath2uri(path), SourceText(content, lang)))
+    end
+
+    package_uri = filepath2uri(dir)
+    key = _test_environment_key(jw.runtime, package_uri, derived_package(jw.runtime, package_uri))
+    @test key == WatchTestEnvironmentKey(dir, "BareGate", UInt64(0))
+    @test key in derived_required_dynamic_projects(jw.runtime)
+
+    runtests_uri = filepath2uri(joinpath(dir, "test", "runtests.jl"))
+    testitem_uri = filepath2uri(joinpath(dir, "test", "test_gate.jl"))
+
+    # The work item is scheduled and unresolved, so both test files must wait.
+    @test derived_test_environment_pending(jw.runtime, key)
+    @test derived_ready_test_environment(jw.runtime, key) === nothing
+    @test !derived_file_env_ready(jw.runtime, runtests_uri)
+    @test !derived_file_env_ready(jw.runtime, testitem_uri)
+
+    merged_uri = filepath2uri(joinpath(mktempdir(), "merged"))
+    put!(jw.dynamic_feature.out_channel, TestEnvironmentReadyResult(
+        filepath2uri(key.project_path), key.package_name, merged_uri, key.content_hash))
+    process_from_dynamic(jw)
+
+    # Ready because the result was found, not because nothing is scheduled.
+    @test derived_ready_test_environment(jw.runtime, key) == merged_uri
+    @test derived_test_environment_pending(jw.runtime, key)
+    @test derived_file_env_ready(jw.runtime, runtests_uri)
+    @test derived_file_env_ready(jw.runtime, testitem_uri)
+end
+
+@testitem "env gating: a failed test-environment DJP unblocks a manifest-less package" begin
+    using JuliaWorkspaces: JuliaWorkspace, DynamicIndexingOnly, TextFile, SourceText,
+        _add_file!, process_from_dynamic, derived_package, derived_file_env_ready,
+        derived_required_dynamic_projects, derived_test_environment_pending,
+        _test_environment_key, FailedResult
+    using JuliaWorkspaces.URIs2: filepath2uri
+
+    dir = mktempdir()
+    mkpath(joinpath(dir, "src"))
+    mkpath(joinpath(dir, "test"))
+    files = [
+        joinpath(dir, "Project.toml") => ("""
+        name = "BareGateFail"
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee47"
+        version = "0.1.0"
+        """, "toml"),
+        joinpath(dir, "src", "BareGateFail.jl") => ("module BareGateFail\nend\n", "julia"),
+        joinpath(dir, "test", "runtests.jl") => ("using Test\n", "julia"),
+    ]
+
+    jw = JuliaWorkspace(dynamic=DynamicIndexingOnly, store_path=mktempdir())
+    for (path, (content, lang)) in files
+        write(path, content)
+        _add_file!(jw, TextFile(filepath2uri(path), SourceText(content, lang)))
+    end
+
+    package_uri = filepath2uri(dir)
+    key = _test_environment_key(jw.runtime, package_uri, derived_package(jw.runtime, package_uri))
+    @test key in derived_required_dynamic_projects(jw.runtime)
+
+    runtests_uri = filepath2uri(joinpath(dir, "test", "runtests.jl"))
+    @test !derived_file_env_ready(jw.runtime, runtests_uri)
+
+    put!(jw.dynamic_feature.out_channel, FailedResult(key))
+    process_from_dynamic(jw)
+
+    @test !derived_test_environment_pending(jw.runtime, key)
+    @test derived_file_env_ready(jw.runtime, runtests_uri)
+end
+
+@testitem "env gating: test-environment keys agree between producer and consumers" begin
+    using JuliaWorkspaces: JuliaWorkspace, TextFile, SourceText, _add_file!,
+        _set_active_project!, derived_package, derived_required_dynamic_projects,
+        _test_environment_key, WatchTestEnvironmentKey, derived_project
+    using JuliaWorkspaces.URIs2: filepath2uri
+
+    # Three shapes of package folder, all with a `test/runtests.jl` on disc (the
+    # required set only fabricates a test-env item for those): the package is its
+    # own project, the package has no manifest and no project devs it, and the
+    # package is deved by an enclosing project.
+    root = mktempdir()
+    manifest_toml = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """
+
+    function write_package(dir, name, uuid; manifest=nothing)
+        mkpath(joinpath(dir, "src"))
+        mkpath(joinpath(dir, "test"))
+        out = [
+            joinpath(dir, "Project.toml") => ("""
+            name = "$name"
+            uuid = "$uuid"
+            version = "0.1.0"
+            """, "toml"),
+            joinpath(dir, "src", "$name.jl") => ("module $name\nend\n", "julia"),
+            joinpath(dir, "test", "runtests.jl") => ("using Test\n", "julia"),
+        ]
+        manifest === nothing || push!(out, joinpath(dir, "Manifest.toml") => (manifest, "toml"))
+        return out
+    end
+
+    own_dir = joinpath(root, "Own")
+    bare_dir = joinpath(root, "Bare")
+    outer_dir = joinpath(root, "Outer")
+    deved_dir = joinpath(outer_dir, "Deved")
+
+    files = [
+        write_package(own_dir, "Own", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee48"; manifest=manifest_toml);
+        write_package(bare_dir, "Bare", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee49");
+        write_package(deved_dir, "Deved", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee4a");
+        [
+            joinpath(outer_dir, "Project.toml") => ("""
+            [deps]
+            Deved = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee4a"
+            """, "toml"),
+            joinpath(outer_dir, "Manifest.toml") => ("""
+            julia_version = "1.11.0"
+            manifest_format = "2.0"
+            project_hash = "abc123"
+
+            [[deps.Deved]]
+            deps = []
+            path = "Deved"
+            uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee4a"
+            version = "0.1.0"
+            """, "toml"),
+        ]
+    ]
+
+    jw = JuliaWorkspace()
+    for (path, (content, lang)) in files
+        write(path, content)
+        _add_file!(jw, TextFile(filepath2uri(path), SourceText(content, lang)))
+    end
+    outer_uri = filepath2uri(outer_dir)
+    _set_active_project!(jw, outer_uri)
+
+    required = derived_required_dynamic_projects(jw.runtime)
+    key_of(dir) = _test_environment_key(jw.runtime, filepath2uri(dir),
+        derived_package(jw.runtime, filepath2uri(dir)))
+
+    outer_hash = derived_project(jw.runtime, outer_uri).content_hash
+
+    # A package that is its own project provides its own test env.
+    @test key_of(own_dir) == WatchTestEnvironmentKey(own_dir, "Own",
+        derived_project(jw.runtime, filepath2uri(own_dir)).content_hash)
+    # No manifest and nothing devs it: keyed on the package folder, hash 0.
+    @test key_of(bare_dir) == WatchTestEnvironmentKey(bare_dir, "Bare", UInt64(0))
+    # Deved: the active project provides the test env.
+    @test key_of(deved_dir) == WatchTestEnvironmentKey(outer_dir, "Deved", outer_hash)
+
+    for dir in (own_dir, bare_dir, deved_dir)
+        @test key_of(dir) in required
+    end
+    # ...and every test-env item in the required set is one of those keys.
+    @test Set(k for k in required if k isa WatchTestEnvironmentKey) ==
+        Set(key_of(dir) for dir in (own_dir, bare_dir, deved_dir))
+end

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -1791,3 +1791,179 @@ end
     @test any(d -> d.source == "StaticLint.jl", diags)
     @test any(d -> occursin("JSON", d.message), diags)
 end
+
+# ──────────────────────────────────────────────────────────────────────
+# Per-project environment gating
+# ──────────────────────────────────────────────────────────────────────
+
+# `_add_file!` instead of `add_file!` in these tests: it skips the reconcile, so
+# the dynamic reactor stays idle and the only results are the injected ones.
+
+@testitem "env gating: a ready environment only unblocks its own project" begin
+    using JuliaWorkspaces: JuliaWorkspace, DynamicIndexingOnly, TextFile, SourceText,
+        _add_file!, get_diagnostic, process_from_dynamic, derived_project,
+        EnvironmentReadyResult, input_env_ready, set_input_env_ready!
+    using JuliaWorkspaces.URIs2: URI, uri2filepath
+
+    manifest_toml = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """
+
+    jw = JuliaWorkspace(dynamic=DynamicIndexingOnly, store_path=mktempdir())
+    for (name, n) in (("EnvGateA", "41"), ("EnvGateB", "42"))
+        _add_file!(jw, TextFile(URI("file:///ws/$name/Project.toml"), SourceText("""
+        name = "$name"
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee$n"
+        version = "0.1.0"
+        """, "toml")))
+        _add_file!(jw, TextFile(URI("file:///ws/$name/Manifest.toml"), SourceText(manifest_toml, "toml")))
+        _add_file!(jw, TextFile(URI("file:///ws/$name/src/$name.jl"), SourceText("""
+        module $name
+        f() = undefined_symbol
+        end
+        """, "julia")))
+    end
+
+    uri_a = URI("file:///ws/EnvGateA/src/EnvGateA.jl")
+    uri_b = URI("file:///ws/EnvGateB/src/EnvGateB.jl")
+    folder_b = URI("file:///ws/EnvGateB")
+
+    missing_refs(uri) = filter(d -> startswith(d.message, "Missing reference"), get_diagnostic(jw, uri))
+
+    # Nothing is ready yet: both projects gate their env-dependent diagnostics.
+    @test isempty(missing_refs(uri_a))
+    @test isempty(missing_refs(uri_b))
+
+    # Only B's environment finishes indexing.
+    put!(jw.dynamic_feature.out_channel, EnvironmentReadyResult(
+        uri2filepath(folder_b), derived_project(jw.runtime, folder_b).content_hash))
+    process_from_dynamic(jw)
+
+    @test !isempty(missing_refs(uri_b))
+    @test isempty(missing_refs(uri_a))     # A's own environment is still pending
+    @test !input_env_ready(jw.runtime)     # production never sets the manual override
+
+    # The manual override still unblocks every project.
+    set_input_env_ready!(jw.runtime, true)
+    @test !isempty(missing_refs(uri_a))
+end
+
+@testitem "env gating: a failed environment DJP unblocks its own project" begin
+    using JuliaWorkspaces: JuliaWorkspace, DynamicIndexingOnly, TextFile, SourceText,
+        _add_file!, get_diagnostic, process_from_dynamic, derived_project,
+        FailedResult, WatchEnvironmentKey
+    using JuliaWorkspaces.URIs2: URI, uri2filepath
+
+    jw = JuliaWorkspace(dynamic=DynamicIndexingOnly, store_path=mktempdir())
+    _add_file!(jw, TextFile(URI("file:///ws/EnvFail/Project.toml"), SourceText("""
+    name = "EnvFail"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee43"
+    version = "0.1.0"
+    """, "toml")))
+    _add_file!(jw, TextFile(URI("file:///ws/EnvFail/Manifest.toml"), SourceText("""
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """, "toml")))
+    fileuri = URI("file:///ws/EnvFail/src/EnvFail.jl")
+    _add_file!(jw, TextFile(fileuri, SourceText("module EnvFail\nf() = undefined_symbol\nend\n", "julia")))
+
+    folder = URI("file:///ws/EnvFail")
+    missing_refs() = filter(d -> startswith(d.message, "Missing reference"), get_diagnostic(jw, fileuri))
+
+    @test isempty(missing_refs())
+
+    # A failure is terminal: gating must not wait for an environment that will
+    # never arrive, so the (best-effort) diagnostics are published.
+    put!(jw.dynamic_feature.out_channel, FailedResult(WatchEnvironmentKey(
+        uri2filepath(folder), derived_project(jw.runtime, folder).content_hash)))
+    process_from_dynamic(jw)
+
+    @test !isempty(missing_refs())
+end
+
+@testitem "env gating: a project no DJP is scheduled for does not gate forever" begin
+    using JuliaWorkspaces: JuliaWorkspace, TextFile, SourceText, add_file!, get_diagnostic,
+        set_active_project!, derived_project, derived_project_uri_for_root
+    using JuliaWorkspaces.URIs2: URI
+
+    # Project.toml but no Manifest.toml: no environment is ever indexed for this
+    # project, so its files must not wait for a readiness signal that can never
+    # arrive.
+    env_dir = URI("file:///noman")
+    fileuri = URI("file:///noman/foo.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///noman/Project.toml"), SourceText("""
+    name = "NoMan"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee44"
+    version = "0.1.0"
+    """, "toml")))
+    add_file!(jw, TextFile(fileuri, SourceText("import JSON\n", "julia")))
+    set_active_project!(jw, env_dir)
+
+    @test derived_project(jw.runtime, env_dir) === nothing
+    @test derived_project_uri_for_root(jw.runtime, fileuri) == env_dir
+
+    diags = get_diagnostic(jw, fileuri)
+    @test any(d -> d.source == "StaticLint.jl" && occursin("JSON", d.message), diags)
+end
+
+@testitem "env gating: a failed test-environment DJP unblocks the package's test files" begin
+    using JuliaWorkspaces: JuliaWorkspace, DynamicIndexingOnly, TextFile, SourceText,
+        _add_file!, process_from_dynamic, derived_project, derived_file_env_ready,
+        derived_required_dynamic_projects, EnvironmentReadyResult, FailedResult,
+        WatchTestEnvironmentKey
+    using JuliaWorkspaces.URIs2: URI, filepath2uri
+
+    # The test-env work item is only scheduled for a package with a real
+    # `test/runtests.jl` on disc, so this fixture is written to disc.
+    dir = mktempdir()
+    mkpath(joinpath(dir, "src"))
+    mkpath(joinpath(dir, "test"))
+    files = Dict(
+        joinpath(dir, "Project.toml") => ("""
+        name = "TestEnvGate"
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee45"
+        version = "0.1.0"
+        """, "toml"),
+        joinpath(dir, "Manifest.toml") => ("""
+        julia_version = "1.11.0"
+        manifest_format = "2.0"
+        project_hash = "abc123"
+
+        [deps]
+        """, "toml"),
+        joinpath(dir, "src", "TestEnvGate.jl") => ("module TestEnvGate\nend\n", "julia"),
+        joinpath(dir, "test", "runtests.jl") => ("f() = undefined_symbol\n", "julia"),
+    )
+
+    jw = JuliaWorkspace(dynamic=DynamicIndexingOnly, store_path=mktempdir())
+    for (path, (content, lang)) in files
+        write(path, content)
+        _add_file!(jw, TextFile(filepath2uri(path), SourceText(content, lang)))
+    end
+
+    proj_uri = filepath2uri(dir)
+    proj_hash = derived_project(jw.runtime, proj_uri).content_hash
+    test_key = WatchTestEnvironmentKey(dir, "TestEnvGate", proj_hash)
+    @test test_key in derived_required_dynamic_projects(jw.runtime)
+
+    put!(jw.dynamic_feature.out_channel, EnvironmentReadyResult(dir, proj_hash))
+    process_from_dynamic(jw)
+
+    runtests_uri = filepath2uri(joinpath(dir, "test", "runtests.jl"))
+    # The project env is ready, but the test env this file needs is still pending.
+    @test !derived_file_env_ready(jw.runtime, runtests_uri)
+
+    put!(jw.dynamic_feature.out_channel, FailedResult(test_key))
+    process_from_dynamic(jw)
+
+    @test derived_file_env_ready(jw.runtime, runtests_uri)
+end

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -1920,11 +1920,11 @@ end
         _add_file!, process_from_dynamic, derived_project, derived_file_env_ready,
         derived_required_dynamic_projects, EnvironmentReadyResult, FailedResult,
         WatchTestEnvironmentKey
-    using JuliaWorkspaces.URIs2: URI, filepath2uri
+    using JuliaWorkspaces.URIs2: URI, filepath2uri, uri2filepath
 
     # The test-env work item is only scheduled for a package with a real
     # `test/runtests.jl` on disc, so this fixture is written to disc.
-    dir = mktempdir()
+    dir = uri2filepath(filepath2uri(mktempdir()))  # round-trip: drive-letter casing must match production-derived keys on Windows
     mkpath(joinpath(dir, "src"))
     mkpath(joinpath(dir, "test"))
     files = Dict(
@@ -1974,11 +1974,11 @@ end
         derived_required_dynamic_projects, derived_ready_test_environment,
         derived_test_environment_pending, _test_environment_key,
         TestEnvironmentReadyResult, WatchTestEnvironmentKey
-    using JuliaWorkspaces.URIs2: filepath2uri
+    using JuliaWorkspaces.URIs2: filepath2uri, uri2filepath
 
     # A package without a manifest is not a project folder, so its test-env work
     # item is keyed on the package folder itself with a zero content hash.
-    dir = mktempdir()
+    dir = uri2filepath(filepath2uri(mktempdir()))  # round-trip: drive-letter casing must match production-derived keys on Windows
     mkpath(joinpath(dir, "src"))
     mkpath(joinpath(dir, "test"))
     files = [
@@ -2033,9 +2033,9 @@ end
         _add_file!, process_from_dynamic, derived_package, derived_file_env_ready,
         derived_required_dynamic_projects, derived_test_environment_pending,
         _test_environment_key, FailedResult
-    using JuliaWorkspaces.URIs2: filepath2uri
+    using JuliaWorkspaces.URIs2: filepath2uri, uri2filepath
 
-    dir = mktempdir()
+    dir = uri2filepath(filepath2uri(mktempdir()))  # round-trip: drive-letter casing must match production-derived keys on Windows
     mkpath(joinpath(dir, "src"))
     mkpath(joinpath(dir, "test"))
     files = [
@@ -2072,13 +2072,13 @@ end
     using JuliaWorkspaces: JuliaWorkspace, TextFile, SourceText, _add_file!,
         _set_active_project!, derived_package, derived_required_dynamic_projects,
         _test_environment_key, WatchTestEnvironmentKey, derived_project
-    using JuliaWorkspaces.URIs2: filepath2uri
+    using JuliaWorkspaces.URIs2: filepath2uri, uri2filepath
 
     # Three shapes of package folder, all with a `test/runtests.jl` on disc (the
     # required set only fabricates a test-env item for those): the package is its
     # own project, the package has no manifest and no project devs it, and the
     # package is deved by an enclosing project.
-    root = mktempdir()
+    root = uri2filepath(filepath2uri(mktempdir()))  # round-trip: drive-letter casing must match production-derived keys on Windows
     manifest_toml = """
     julia_version = "1.11.0"
     manifest_format = "2.0"

--- a/test/test_dynamic_reconcile.jl
+++ b/test/test_dynamic_reconcile.jl
@@ -536,3 +536,35 @@ end
     @test df.pending_count[] == 0
     @test isempty(df.inflight)
 end
+
+@testitem "Dynamic results: an unchanged env result does not invalidate anything" begin
+    using JuliaWorkspaces
+    using JuliaWorkspaces: JuliaWorkspace, DynamicIndexingOnly, EnvironmentReadyResult,
+        process_from_dynamic, derived_all_diagnostics
+    using JuliaWorkspaces.URIs2: URI
+
+    jw = JuliaWorkspace(dynamic=DynamicIndexingOnly, store_path=mktempdir())
+    add_file!(jw, TextFile(URI("file:///ws/A/src/A.jl"), SourceText("module A\nf(x) = 1\nend\n", "julia")))
+
+    apply(path, hash) = begin
+        put!(jw.dynamic_feature.out_channel, EnvironmentReadyResult(path, UInt64(hash)))
+        process_from_dynamic(jw)
+        jw.runtime.storage.current_revision
+    end
+
+    rev0 = jw.runtime.storage.current_revision
+    rev1 = apply("/ws/A", 1)
+    @test rev1 > rev0                          # first result is new information
+    diags = derived_all_diagnostics(jw.runtime)
+
+    # Re-applying the identical result must hit the input's equality early exit:
+    # no revision bump, so nothing downstream even needs re-verifying.
+    @test apply("/ws/A", 1) == rev1
+
+    # A result for a *different* env is new information (revision advances), but
+    # it changes no diagnostic, so `derived_all_diagnostics` must backdate rather
+    # than recompute — the memoized value is handed back unchanged.
+    rev2 = apply("/ws/B", 2)
+    @test rev2 > rev1
+    @test derived_all_diagnostics(jw.runtime) === diags
+end

--- a/test/test_juliaworkspace.jl
+++ b/test/test_juliaworkspace.jl
@@ -248,3 +248,22 @@ end
     process_from_dynamic(jw2)
     @test is_ready(jw2)
 end
+
+@testitem "is_ready is independent of the manual env-ready override" begin
+    using JuliaWorkspaces: JuliaWorkspace, DynamicIndexingOnly, EnvironmentReadyResult,
+        process_from_dynamic, is_ready, input_env_ready, set_input_env_ready!
+
+    jw = JuliaWorkspace(dynamic=DynamicIndexingOnly, store_path=mktempdir())
+
+    # The override is a per-file diagnostics gate only; it must not make the
+    # dynamic feature look done.
+    set_input_env_ready!(jw.runtime, true)
+    @test !is_ready(jw)
+
+    # And completed dynamic work must not set the override.
+    jw2 = JuliaWorkspace(dynamic=DynamicIndexingOnly, store_path=mktempdir())
+    put!(jw2.dynamic_feature.out_channel, EnvironmentReadyResult("/some/project", UInt64(1)))
+    process_from_dynamic(jw2)
+    @test is_ready(jw2)
+    @test !input_env_ready(jw2.runtime)
+end

--- a/test/test_module_tree.jl
+++ b/test/test_module_tree.jl
@@ -1436,3 +1436,56 @@ end
     @test isempty(JuliaWorkspaces.derived_method_items(jw.runtime, root_uri, ["Pkg"], "nope"))
     @test isempty(JuliaWorkspaces.derived_method_items(jw.runtime, root_uri, ["Nope"], "foo"))
 end
+
+@testitem "method arity / external extension indices agree with the per-name queries" begin
+    using JuliaWorkspaces
+    using JuliaWorkspaces: derived_method_arities, derived_method_arities_index,
+        derived_external_method_extensions, derived_external_method_extensions_index,
+        derived_external_extension_names
+    using JuliaWorkspaces.URIs2: URI
+
+    root = URI("file:///ws/A/src/A.jl")
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(root, SourceText("""
+    module A
+    import Base: relpath
+    f(x) = 1
+    f(x, y) = 2
+    f(; kw=1) = 3
+    relpath(x::Int) = "workspace overload"
+    Base.length(x::Int) = 0
+    module Inner
+    g(x) = 1
+    end
+    A.Inner.g(x, y) = 2
+    include("more.jl")
+    end
+    """, "julia")))
+    add_file!(jw, TextFile(URI("file:///ws/A/src/more.jl"), SourceText("f(x, y, z) = 4\n", "julia")))
+
+    arities = derived_method_arities_index(jw.runtime, root)
+    # Methods spliced from an include are part of the same name's set.
+    @test length(derived_method_arities(jw.runtime, root, ["A"], "f")) == 4
+    @test derived_method_arities(jw.runtime, root, ["A"], "f") == arities[(["A"], "f")]
+    # A qualified extension counts for the module its qualifier resolves to.
+    @test length(derived_method_arities(jw.runtime, root, ["A", "Inner"], "g")) == 2
+    # Every index entry must be exactly what the per-name query returns.
+    for ((path, name), v) in arities
+        @test derived_method_arities(jw.runtime, root, path, name) == v
+    end
+    # An unknown module path or name yields no arities.
+    @test isempty(derived_method_arities(jw.runtime, root, ["A"], "nosuchname"))
+    @test isempty(derived_method_arities(jw.runtime, root, ["Nope"], "f"))
+
+    ext = derived_external_method_extensions_index(jw.runtime, root)
+    @test derived_external_extension_names(jw.runtime, root) == Set(keys(ext))
+    @test "length" in derived_external_extension_names(jw.runtime, root)
+    # `import Base: relpath` makes the bare definition an external extension too.
+    @test "relpath" in derived_external_extension_names(jw.runtime, root)
+    for (name, v) in ext
+        @test derived_external_method_extensions(jw.runtime, root, name) == v
+    end
+    @test isempty(derived_external_method_extensions(jw.runtime, root, "nosuchname"))
+    # A workspace-local function is not an external extension.
+    @test !("f" in derived_external_extension_names(jw.runtime, root))
+end

--- a/test/test_uris2.jl
+++ b/test/test_uris2.jl
@@ -160,3 +160,37 @@ end
     @test value.query === nothing
     @test value.fragment === nothing
 end
+
+@testitem "hash agrees with equality regardless of how a URI was built" begin
+    using JuliaWorkspaces.URIs2
+
+    from_string = URI("file:///home/me/a%20file.jl?q=1#frag")
+    from_fields = URI(scheme="file", authority="", path="/home/me/a file.jl", query="q=1", fragment="frag")
+
+    @test from_string == from_fields
+    @test isequal(from_string, from_fields)
+    @test hash(from_string) == hash(from_fields)
+    @test hash(from_string, UInt(7)) == hash(from_fields, UInt(7))
+
+    d = Dict(from_string => 1)
+    @test d[from_fields] == 1
+
+    # Differing in any single component must not compare equal.
+    others = [
+        URI(scheme="http", authority="", path="/home/me/a file.jl", query="q=1", fragment="frag"),
+        URI(scheme="file", authority="host", path="/home/me/a file.jl", query="q=1", fragment="frag"),
+        URI(scheme="file", authority="", path="/home/me/other.jl", query="q=1", fragment="frag"),
+        URI(scheme="file", authority="", path="/home/me/a file.jl", query="q=2", fragment="frag"),
+        URI(scheme="file", authority="", path="/home/me/a file.jl", query="q=1", fragment="other"),
+        URI(scheme="file", authority="", path="/home/me/a file.jl", query=nothing, fragment="frag"),
+    ]
+    for other in others
+        @test from_string != other
+        @test !haskey(d, other)
+    end
+
+    # Round-tripping through `string` preserves identity as a dict key.
+    @test URI(string(from_string)) == from_string
+    @test hash(URI(string(from_string))) == hash(from_string)
+    @test filepath2uri("/home/me/a file.jl") == URI(string(filepath2uri("/home/me/a file.jl")))
+end


### PR DESCRIPTION
The required set, the result recorder and the readiness/environment-selection
queries each derived a `WatchTestEnvironmentKey` on their own. The producer keyed
a package that is neither a project folder nor deved on the package folder itself
(hash 0 without a manifest), while the consumers keyed it on the package's
standalone project — or, before that exists, on the active project. The keys
could therefore never match: the readiness query found neither a recorded result
nor a scheduled item, so such a package's test files were treated as ready
instead of waiting for their test environment, and the merged test project the
recorder registered was never picked up as the file's environment.

Extract the selection into `_test_environment_key` and use it for the required
set, the readiness gate and the environment lookup, so all three speak about the
same work item. The per-key readiness queries now take the key directly.