### PR TITLE
perf(memoryr): stop caching JuliaSyntax trees and prune empty Meta entries

### DIFF
--- a/src/layer_file_analysis.jl
+++ b/src/layer_file_analysis.jl
@@ -430,6 +430,25 @@ function _strip_module_stores!(meta_dict::Dict{UInt64,StaticLint.Meta})
     return
 end
 
+"""
+    _pruned_meta(meta_dict) -> Dict
+
+The dict to freeze into a `FileAnalysis`: every all-`nothing` `Meta` dropped.
+These are `ensuremeta` residue of the pass — typically more than half of all
+entries — and every reader guards `hasmeta` with a field check, so an empty
+entry is indistinguishable from an absent one. Builds a fresh dict (rather
+than `filter!`) so the slot arrays shrink to the surviving entry count.
+"""
+function _pruned_meta(meta_dict::Dict{UInt64,StaticLint.Meta})
+    out = Dict{UInt64,StaticLint.Meta}()
+    for (k, m) in meta_dict
+        if m.binding !== nothing || m.scope !== nothing || m.ref !== nothing || m.error !== nothing
+            out[k] = m
+        end
+    end
+    return out
+end
+
 # Aggregate every tree-resolved reference site in `meta_dict` by
 # (name, origin_module). Two shapes count:
 # - a `Meta.ref` that IS a `TreeRef` (plain tree resolution, and body uses
@@ -772,7 +791,7 @@ Salsa.@derived function derived_file_analysis(rt, root, file)
 
     _strip_module_stores!(meta_dict)
 
-    return FileAnalysis(meta_dict, outbound, diagnostics)
+    return FileAnalysis(_pruned_meta(meta_dict), outbound, diagnostics)
 end
 
 """

--- a/src/layer_syntax_trees.jl
+++ b/src/layer_syntax_trees.jl
@@ -1,21 +1,14 @@
-Salsa.@derived function derived_julia_parse_result(rt, uri)
-    @debug "derived_julia_parse_result" uri=uri
-
-    tf = derived_text_file_content(rt, uri)
-
-    content = tf.content.content
-
+# Deliberately not a derived function: caching a tree per workspace file
+# retains hundreds of MiB on large repos, and a fresh `SyntaxNode` never
+# backdates (identity `isequal`) so the cache provides no early cutoff.
+# Consumers parse on demand (~1 ms/file) and cache only their small,
+# structurally-comparable outputs.
+function parse_julia_syntax_tree(content::AbstractString)
     stream = JuliaSyntax.ParseStream(content; version=VERSION)
     JuliaSyntax.parse!(stream; rule=:all)
     tree = JuliaSyntax.build_tree(SyntaxNode, stream)
 
     return tree, stream.diagnostics
-end
-
-Salsa.@derived function derived_julia_syntax_tree(rt, uri)
-    parse_result = derived_julia_parse_result(rt, uri)
-
-    return parse_result[1]
 end
 
 @static if isdefined(JuliaSyntax, :byte_range)
@@ -25,9 +18,11 @@ else
 end
 
 Salsa.@derived function derived_julia_syntax_diagnostics(rt, uri)
-    parse_result = derived_julia_parse_result(rt, uri)
+    tf = derived_text_file_content(rt, uri)
 
-    diag_results = map(parse_result[2]) do i
+    _, syntax_diagnostics = parse_julia_syntax_tree(tf.content.content)
+
+    diag_results = map(syntax_diagnostics) do i
         Diagnostic(
             _range(i),
             i.level,

--- a/src/layer_testitems.jl
+++ b/src/layer_testitems.jl
@@ -19,7 +19,7 @@ Salsa.@derived function derived_testitems(rt, uri)
     testerrors = []
 
     text_file = derived_text_file_content(rt, uri)
-    syntax_tree = derived_julia_syntax_tree(rt, uri)
+    syntax_tree, _ = parse_julia_syntax_tree(text_file.content.content)
 
     TestItemDetection.find_test_detail!(syntax_tree, testitems, testsetups, testerrors)
 

--- a/src/public.jl
+++ b/src/public.jl
@@ -484,19 +484,21 @@ end
 """
     get_julia_syntax_tree(jw::JuliaWorkspace, uri::URI)
 
-Get the syntax tree of a Julia file from the workspace.
+Get the syntax tree of a Julia file from the workspace. The tree is parsed
+on demand and not cached.
 
 # Returns
 
-- The tuple `(tree, diagnostics)`, where `tree` is the syntax tree
-  and `diagnostics` is a vector of `Diagnostic` structs.
+- The `JuliaSyntax.SyntaxNode` root of the parsed file.
 """
 function get_julia_syntax_tree(jw::JuliaWorkspace, uri::URI)
     @debug "get_julia_syntax_tree" uri=uri
 
     process_from_dynamic(jw)
 
-    return derived_julia_syntax_tree(jw.runtime, uri)
+    tf = derived_text_file_content(jw.runtime, uri)
+
+    return parse_julia_syntax_tree(tf.content.content)[1]
 end
 
 """

--- a/test/test_file_analysis.jl
+++ b/test/test_file_analysis.jl
@@ -2109,3 +2109,38 @@ end
     call_id = anns[end]
     @test SL.refof(call_id, meta_dict) isa SL.Binding
 end
+
+@testitem "derived_file_analysis: frozen meta carries no empty entries" setup=[FileAnalysisWS] begin
+    jw = ws_with(Dict(
+        ROOT => """
+        module MainPkg
+        include("a.jl")
+        include("b.jl")
+        end
+        """,
+        A => "afunc() = 1\n",
+        B => """
+        function bfunc(x)
+            y = x + afunc()
+            return y * 2
+        end
+        """,
+    ))
+
+    fa = JuliaWorkspaces.derived_file_analysis(jw.runtime, ROOT, B)
+
+    # `ensuremeta` residue (all fields `nothing`) is indistinguishable from
+    # absence for every reader and must not survive the freeze.
+    @test !isempty(fa.meta)
+    @test all(values(fa.meta)) do m
+        m.binding !== nothing || m.scope !== nothing || m.ref !== nothing || m.error !== nothing
+    end
+
+    # Queries against the pruned dict still resolve.
+    cst = JuliaWorkspaces.derived_julia_legacy_syntax_tree(jw.runtime, B)
+    @test SL.refof(only(find_identifiers(cst, "afunc")), fa.meta) isa SL.TreeRef
+    @test SL.scopeof(cst, fa.meta) isa SL.Scope
+    xs = find_identifiers(cst, "y")
+    @test length(xs) == 2
+    @test all(x -> SL.hasbinding(x, fa.meta) || SL.hasref(x, fa.meta), xs)
+end


### PR DESCRIPTION
This saves almost a GB for the julia-vscode repo.