### PR TITLE
fix: keep unnamed parameters in signature help

### DIFF
--- a/src/layer_signatures.jl
+++ b/src/layer_signatures.jl
@@ -124,14 +124,12 @@ end
 
 # Signatures of the workspace method extensions of a store-backed callee,
 # rendered exactly like `_collect_tree_signatures!` renders a tree method item:
-# the defining EXPR is materialized request-time and paired with its own
-# file-analysis meta so parameter names recover.
+# from the defining EXPR, materialized request-time.
 function _workspace_extension_signatures!(sigs::Vector{SignatureInfo}, f_ref, env, runtime, root::URI)
     for e in _matching_workspace_extensions(runtime, root, env, f_ref)
         entry = get(derived_item_positions(runtime, e.ref.file), e.ref.id, nothing)
         entry === nothing && continue
-        item_meta = derived_file_analysis(runtime, root, e.ref.file).meta
-        _expr_signature!(sigs, entry.expr, item_meta)
+        _expr_signature!(sigs, entry.expr)
     end
     return
 end
@@ -140,16 +138,13 @@ end
 # in the callee's origin module (`derived_method_items`), rendered from its
 # defining EXPR. The EXPR is materialized request-time from the item's own file
 # (`derived_item_positions`) — allowed in a request handler, never in a derived
-# value — and paired with that file's per-file analysis meta (same memoized
-# CST, so the arg bindings match by objectid), so `_expr_signature!` recovers
-# parameter names (and var"..." quoting) exactly as for a local definition.
+# value — and rendered on its own, without analyzing the defining file.
 function _collect_tree_signatures!(sigs::Vector{SignatureInfo}, tr::StaticLint.TreeRef, runtime, root::URI)
     qroot = _method_items_root(runtime, root, tr.origin_module)
     for ref in derived_method_items(runtime, qroot, tr.origin_module, tr.name)
         entry = get(derived_item_positions(runtime, ref.file), ref.id, nothing)
         entry === nothing && continue
-        item_meta = derived_file_analysis(runtime, qroot, ref.file).meta
-        _expr_signature!(sigs, entry.expr, item_meta)
+        _expr_signature!(sigs, entry.expr)
         # A struct's INNER constructors are not separate top-level items (they
         # live inside the struct body), and `_expr_signature!`'s struct branch
         # deliberately suppresses the implicit field constructor when they
@@ -162,7 +157,7 @@ function _collect_tree_signatures!(sigs::Vector{SignatureInfo}, tr::StaticLint.T
             body = entry.expr.args[3]
             if body isa CSTParser.EXPR && body.args !== nothing
                 for member in body.args
-                    CSTParser.defines_function(member) && _expr_signature!(sigs, member, item_meta)
+                    CSTParser.defines_function(member) && _expr_signature!(sigs, member)
                 end
             end
         end
@@ -229,10 +224,43 @@ _sig_type_str(@nospecialize(t), pred) =
 # signature label.
 _utf16_length(s::AbstractString) = sum(c -> codepoint(c) >= 0x10000 ? 2 : 1, s; init=0)
 
-# Text of a single SymbolServer method parameter exactly as it is rendered in
-# the signature label by `Base.print(io, ::MethodStore)` under the same
-# `:ss_shorten`/`:ss_omit_any` context: `name::type`, `::type` for an unnamed
-# (`#unused#`) argument, or just `name` when the `::Any` annotation is omitted.
+# Assemble a signature label from its rendered pieces, returning it together
+# with the `[start, end)` UTF-16 offset range of each positional parameter.
+#
+# `ParameterInformation.label` may be a substring of the signature label or such
+# an offset range (LSP spec); we always emit ranges, because a substring cannot
+# tell apart two parameters that render identically (`::Any, ::Any`) and would
+# match a name that also occurs in the callee (the `a` of `bar(a::Int)`). Since
+# the label is built here from the very same parameter texts, the ranges are
+# exact by construction — no searching, and nothing to keep in sync with a
+# separate renderer.
+#
+# Every signature source funnels through this: symbol-store methods and
+# workspace definitions alike, so both produce identical label and range shapes.
+function _assemble_signature(callee::AbstractString, positional::Vector{String};
+        kwargs::Vector{String}=String[], suffix::AbstractString="")
+    buf = IOBuffer()
+    print(buf, callee, "(")
+    off = _utf16_length(callee) + 1  # past "callee("
+    ranges = Tuple{Int,Int}[]
+    for (i, text) in enumerate(positional)
+        if i > 1
+            print(buf, ", ")
+            off += 2
+        end
+        w = _utf16_length(text)
+        push!(ranges, (off, off + w))
+        print(buf, text)
+        off += w
+    end
+    isempty(kwargs) || print(buf, "; ", join(kwargs, ", "))
+    print(buf, ")", suffix)
+    return String(take!(buf)), ranges
+end
+
+# Text of a single SymbolServer method parameter: `name::type`, `::type` for an
+# unnamed (`#unused#`) argument, or just `name` when the annotation is `::Any`
+# (which reads as noise in a parameter hint).
 function _ss_param_text(a, pred)
     buf = IOBuffer()
     io = IOContext(buf, :ss_shorten => pred)
@@ -241,76 +269,113 @@ function _ss_param_text(a, pred)
     return String(take!(buf))
 end
 
+# Where a store method comes from, as `Base.print(io, ::MethodStore)` renders it.
+_ss_method_suffix(m::SymbolServer.MethodStore) =
+    string(" in ", m.mod, " at ", replace(m.file, SymbolServer.JULIA_DIR => ""), ':', m.line)
+
 function _get_signatures(b::T, tls::StaticLint.Scope, sigs::Vector{SignatureInfo}, env, meta_dict, in_scope=nothing) where T <: Union{SymbolServer.FunctionStore,SymbolServer.DataTypeStore}
     pred = _sig_shorten_pred(env)
     StaticLint.iterate_over_ss_methods(b, tls, env, function (m)
-        label = sprint((io, x) -> print(IOContext(io, :ss_shorten => pred, :ss_omit_any => true), x), m)
-        # `ParameterInformation.label` is a `[start, end)` UTF-16 offset range
-        # into the signature label (LSP spec). The label starts with `name(` and
-        # joins parameters with `, `, so each parameter's span follows from the
-        # accumulated rendered widths — a positional map, so it can never emit
-        # the `#unused#` placeholder and stays unambiguous even when two
-        # parameters render identically (e.g. `::Any, ::Any`).
-        off = _utf16_length(string(m.name)) + 1  # advance past "name("
-        n = length(m.sig)
-        params = ParameterInfo[]
-        for (i, a) in enumerate(m.sig)
-            w = _utf16_length(_ss_param_text(a, pred))
-            push!(params, ParameterInfo(
-                (off, off + w),
-                SymbolServer.isfakeany(a[2]) ? "" : _sig_type_str(a[2], pred)
-            ))
-            off += w
-            i == n || (off += 2)  # ", " separator
-        end
+        texts = String[_ss_param_text(a, pred) for a in m.sig]
+        # The store records keyword names but no types or defaults, so they are
+        # listed bare — same as a workspace definition, they belong in the label
+        # but are not offered as parameters.
+        label, ranges = _assemble_signature(string(m.name), texts;
+            kwargs=String[string(k) for k in m.kws], suffix=_ss_method_suffix(m))
+        params = [ParameterInfo(
+            ranges[i],
+            SymbolServer.isfakeany(m.sig[i][2]) ? "" : _sig_type_str(m.sig[i][2], pred)
+        ) for i in eachindex(ranges)]
         push!(sigs, SignatureInfo(label, "", params))
         return false
     end; in_scope=in_scope)
 end
 
 _get_signatures(x::CSTParser.EXPR, tls::StaticLint.Scope, sigs::Vector{SignatureInfo}, env, meta_dict, in_scope=nothing) =
-    _expr_signature!(sigs, x, meta_dict)
+    _expr_signature!(sigs, x)
 
-# Build the `SignatureInfo` for a definition EXPR `x` (a function/macro
-# definition or a struct) and push it onto `sigs`. Uses `meta_dict` only to
-# recover argument bindings' names (var"..." quoting) — the struct branch needs
-# no meta. Shared by the local-binding path (`_get_signatures`) and the
-# tree-resolved path (`_collect_tree_signatures!`), which materializes the
-# defining EXPR of a cross-file inventory item and passes that item's own
-# file-analysis meta.
-function _expr_signature!(sigs::Vector{SignatureInfo}, x::CSTParser.EXPR, meta_dict)
+# Text of a name or type EXPR in a signature label: a `var"..."` name keeps its
+# quoting (as a bare `Symbol` it would render unquoted), everything else is
+# rendered by `to_codeobject`.
+_sig_expr_text(x::CSTParser.EXPR) =
+    CSTParser.isidentifier(x) ? something(_name_expr_label(x), "") : string(CSTParser.to_codeobject(x))
+
+# Text of one parameter of a definition EXPR (or one field of a struct), spelled
+# the way the call site reads it: `a`, `a::Int`, `::Int`, `a...`, `a = default`.
+# A `@nospecialize` wrapper and a `const` field marker are dropped — neither says
+# anything about the call. Rendering each parameter separately (rather than
+# printing the whole signature) is what lets `_assemble_signature` know the
+# parameters' offsets.
+function _sig_param_text(arg::CSTParser.EXPR)
+    inner = StaticLint.unwrap_nospecialize(arg)
+    inner === arg || return _sig_param_text(inner)
+    args = arg.args
+    n = args === nothing ? 0 : length(args)
+    if CSTParser.headof(arg) === :const && n == 1
+        return _sig_param_text(args[1])
+    elseif CSTParser.iskwarg(arg) && n == 2
+        return string(_sig_param_text(args[1]), " = ", _sig_expr_text(args[2]))
+    elseif CSTParser.issplat(arg) && n == 1
+        return string(_sig_param_text(args[1]), "...")
+    elseif CSTParser.isdeclaration(arg) && n == 2
+        return string(_sig_param_text(args[1]), "::", _sig_expr_text(args[2]))
+    end
+    # an unnamed `::Int` (a declaration with no name) lands here
+    return _sig_expr_text(arg)
+end
+
+# Text of what is being called: `foo`, `Base.getindex`, `Foo{T}`, or a functor's
+# `(f::Foo)`, which needs its parens to read as a call.
+_sig_callee_text(x::CSTParser.EXPR) =
+    CSTParser.isdeclaration(x) ? string("(", _sig_param_text(x), ")") : _sig_expr_text(x)
+
+# Build the `SignatureInfo` for a definition EXPR `x` (a function definition or a
+# struct) and push it onto `sigs`. Shared by the local-binding path
+# (`_get_signatures`) and the tree-resolved path (`_collect_tree_signatures!`),
+# which materializes the defining EXPR of a cross-file inventory item. The EXPR
+# alone is enough: parameters are rendered from the definition's own syntax, so
+# no file analysis of the defining file is needed.
+function _expr_signature!(sigs::Vector{SignatureInfo}, x::CSTParser.EXPR)
     if CSTParser.defines_function(x)
         sig = CSTParser.rem_wheres_decls(CSTParser.get_sig(x))
-        params = ParameterInfo[]
-        if sig isa CSTParser.EXPR && sig.args !== nothing
-            for i = 2:length(sig.args)
-                argbinding = StaticLint.bindingof(sig.args[i], meta_dict)
-                if argbinding !== nothing
-                    # var"..." argument names keep their quoting
-                    n = argbinding.name isa CSTParser.EXPR ? _name_expr_label(argbinding.name) : nothing
-                    push!(params, ParameterInfo(something(n, ""), nothing))
-                end
+        (sig isa CSTParser.EXPR && sig.args !== nothing && !isempty(sig.args)) || return
+        # An anonymous `function (x) ... end` has no callee to render — and no
+        # name a call site could resolve, so it does not reach here either.
+        CSTParser.iscall(sig) || return
+        positional = String[]
+        kwargs = String[]
+        for i = 2:length(sig.args)
+            arg = sig.args[i]
+            if CSTParser.isparameters(arg)
+                # kwargs appear in the label but are not offered as parameters
+                arg.args === nothing || append!(kwargs, (_sig_param_text(a) for a in arg.args))
+            else
+                # EVERY positional parameter gets an entry, named or not: the
+                # highlighted parameter is selected by index, so dropping an
+                # unnamed `::Int` would shift every later parameter.
+                push!(positional, _sig_param_text(arg))
             end
-            push!(sigs, SignatureInfo(string(CSTParser.to_codeobject(sig)), "", params))
         end
+        _push_expr_signature!(sigs, _sig_callee_text(sig.args[1]), positional, kwargs)
     elseif CSTParser.defines_struct(x)
-        args = x.args[3]
-        if length(args) > 0
-            if !any(CSTParser.defines_function, args.args)
-                params = ParameterInfo[]
-                for field in args.args
-                    field_name = CSTParser.rem_decl(field)
-                    label = ""
-                    if field_name isa CSTParser.EXPR && CSTParser.isidentifier(field_name)
-                        # var"..." field names keep their quoting
-                        label = something(_name_expr_label(field_name), "")
-                    end
-                    push!(params, ParameterInfo(label, nothing))
-                end
-                push!(sigs, SignatureInfo(string(CSTParser.to_codeobject(x)), "", params))
-            end
-        end
+        # a struct still being typed can be missing its name or body
+        (x.args !== nothing && length(x.args) >= 3) || return
+        body = x.args[3]
+        (body isa CSTParser.EXPR && body.args !== nothing && !isempty(body.args)) || return
+        # With an explicit inner constructor there is no implicit field
+        # constructor to offer (`_collect_tree_signatures!` renders the inner
+        # ones from the struct body instead).
+        any(CSTParser.defines_function, body.args) && return
+        fields = String[_sig_param_text(f) for f in body.args]
+        _push_expr_signature!(sigs, _sig_callee_text(CSTParser.rem_subtype(x.args[2])), fields, String[])
     end
+    return
+end
+
+function _push_expr_signature!(sigs::Vector{SignatureInfo}, callee::String, positional::Vector{String}, kwargs::Vector{String})
+    label, ranges = _assemble_signature(callee, positional; kwargs=kwargs)
+    push!(sigs, SignatureInfo(label, "", ParameterInfo[ParameterInfo(r, nothing) for r in ranges]))
+    return
 end
 
 # ============================================================================

--- a/test/test_signatures.jl
+++ b/test/test_signatures.jl
@@ -1,3 +1,20 @@
+@testsnippet SigLabels begin
+    # UTF-16 code-unit slice of `s` for a 0-based `[start, end)` range, the LSP
+    # form of `ParameterInformation.label`. The test signatures are ASCII, so
+    # this coincides with a plain character slice.
+    function utf16_slice(s, range)
+        units = Char[]
+        for c in s
+            push!(units, c)
+            codepoint(c) >= 0x10000 && push!(units, c)  # surrogate pair filler
+        end
+        return String(units[(range[1] + 1):range[2]])
+    end
+
+    # The parameters of `sig` as the text each one selects in its label.
+    param_texts(sig) = [utf16_slice(sig.label, p.label) for p in sig.parameters]
+end
+
 @testitem "Signatures: basic function call" begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
     using JuliaWorkspaces.URIs2: URI
@@ -168,7 +185,7 @@ end
     @test !isempty(result.signatures)
 end
 
-@testitem "Signatures: struct constructor with var\"\" field (#3867)" begin
+@testitem "Signatures: struct constructor with var\"\" field (#3867)" setup=[SigLabels] begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
     using JuliaWorkspaces.URIs2: URI
 
@@ -190,7 +207,42 @@ end
     result = get_signature_help(jw, uri, idx)
     @test !isempty(result.signatures)
     sig = first(result.signatures)
-    @test [p.label for p in sig.parameters] == ["var\"hello world\"", "normal"]
+    # the implicit field constructor reads as a call, not as the struct body
+    @test sig.label == "Foo(var\"hello world\"::Int, normal::Int)"
+    @test param_texts(sig) == ["var\"hello world\"::Int", "normal::Int"]
+end
+
+@testitem "Signatures: store-backed methods list their keyword arguments" setup=[SigLabels] begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
+    using JuliaWorkspaces.URIs2: URI
+
+    # Store methods and workspace definitions go through the same label
+    # assembly, so a store method's keywords are listed after its positional
+    # parameters just like a definition's — the store records only their names.
+    source = """
+    sort(
+    """
+
+    jw = JuliaWorkspace()
+    uri = URI("file:///sigkw/test.jl")
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+
+    sigs = get_signature_help(jw, uri, ncodeunits("sort(")).signatures
+    @test !isempty(sigs)
+    kwsigs = filter(s -> occursin("; ", s.label), sigs)
+    @test !isempty(kwsigs)
+    @test any(s -> occursin("by", s.label), kwsigs)
+
+    # Keywords come after the positional parameters, so no parameter range may
+    # reach into them — the highlighted parameter stays the positional one.
+    for s in kwsigs
+        semi = first(findfirst("; ", s.label))
+        for p in s.parameters
+            @test p.label isa Tuple{Int,Int}
+            @test !occursin(";", utf16_slice(s.label, p.label))
+            @test p.label[2] < semi
+        end
+    end
 end
 
 @testitem "Signatures: stdlib types unqualified and ::Any omitted" begin
@@ -224,7 +276,7 @@ end
     @test any(s -> any(p -> p.documentation == "IO", s.parameters), psigs)
 end
 
-@testitem "Signatures: parameter labels are offset ranges into the signature" begin
+@testitem "Signatures: parameter labels are offset ranges into the signature" setup=[SigLabels] begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
     using JuliaWorkspaces.URIs2: URI
 
@@ -241,17 +293,6 @@ end
     uri = URI("file:///sigunused/test.jl")
     add_file!(jw, TextFile(uri, SourceText(source, "julia")))
 
-    # UTF-16 code-unit slice of `s` for a 0-based `[start, end)` range. The test
-    # signatures are ASCII, so this coincides with a plain character slice.
-    function utf16_slice(s, range)
-        units = Char[]
-        for c in s
-            push!(units, c)
-            codepoint(c) >= 0x10000 && push!(units, c)  # surrogate pair filler
-        end
-        return String(units[(range[1] + 1):range[2]])
-    end
-
     result = get_signature_help(jw, uri, ncodeunits("get("))
     @test !isempty(result.signatures)
     params = [(sig.label, p) for sig in result.signatures for p in sig.parameters]
@@ -266,7 +307,7 @@ end
     @test any(((label, p),) -> startswith(utf16_slice(label, p.label), "::"), params)
 end
 
-@testitem "Signatures: function with var\"\" argument (#3867)" begin
+@testitem "Signatures: function with var\"\" argument (#3867)" setup=[SigLabels] begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
     using JuliaWorkspaces.URIs2: URI
 
@@ -283,7 +324,65 @@ end
     result = get_signature_help(jw, uri, idx)
     @test !isempty(result.signatures)
     sig = first(result.signatures)
-    @test [p.label for p in sig.parameters] == ["var\"weird arg\"", "normal"]
+    @test param_texts(sig) == ["var\"weird arg\"", "normal"]
+end
+
+@testitem "Signatures: unnamed parameters keep their position" setup=[SigLabels] begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
+    using JuliaWorkspaces.URIs2: URI
+
+    function sig_at(src, call)
+        jw = JuliaWorkspace()
+        uri = URI("file:///signoname/s.jl")
+        add_file!(jw, TextFile(uri, SourceText(src, "julia")))
+        return get_signature_help(jw, uri, findlast(call, src)[end])
+    end
+
+    # An unnamed argument (`::Int`) has no binding, so it used to be dropped from
+    # the parameter list: `active_parameter` then pointed one parameter too far
+    # and highlighted `a` while the cursor was still at the first argument.
+    src = "foo(::Int, a) = a\nfoo("
+    result = sig_at(src, "foo(")
+    sig = only(result.signatures)
+    @test sig.label == "foo(::Int, a)"
+    @test length(sig.parameters) == 2
+    @test result.active_parameter == 0
+    @test utf16_slice(sig.label, sig.parameters[1].label) == "::Int"
+    @test utf16_slice(sig.label, sig.parameters[2].label) == "a"
+
+    # ... and at the second argument the signature must not be filtered out for
+    # having too few parameters.
+    result = sig_at("foo(::Int, a) = a\nfoo(1, ", "foo(1, ")
+    @test result.active_parameter == 1
+    @test length(only(result.signatures).parameters) == 2
+
+    # Identically rendered parameters must select distinct spans, so the client
+    # highlights the second `::Int` rather than the first.
+    result = sig_at("baz(::Int, ::Int) = 1\nbaz(", "baz(")
+    sig = only(result.signatures)
+    @test param_texts(sig) == ["::Int", "::Int"]
+    @test sig.parameters[1].label != sig.parameters[2].label
+
+    # A parameter text that also occurs in the callee name or in an earlier
+    # parameter's type must not be matched there.
+    result = sig_at("barb(a::Abc, b) = a\nbarb(", "barb(")
+    sig = only(result.signatures)
+    @test param_texts(sig) == ["a::Abc", "b"]
+
+    # `@nospecialize` wrappers are dropped from the label; default values are
+    # kept, and both keep their parameter positions.
+    result = sig_at("qux(@nospecialize(x::Any), ::Int, y=1) = x\nqux(", "qux(")
+    sig = only(result.signatures)
+    @test sig.label == "qux(x::Any, ::Int, y = 1)"
+    @test param_texts(sig) == ["x::Any", "::Int", "y = 1"]
+
+    result = sig_at("quux(a, b::Int=1, ::Int=2) = a\nquux(", "quux(")
+    @test param_texts(only(result.signatures)) == ["a", "b::Int = 1", "::Int = 2"]
+
+    # Keyword arguments are still not offered as parameters, so they cannot
+    # shift the positional ones either.
+    result = sig_at("f5(::Int, a; kw=1) = a\nf5(", "f5(")
+    @test param_texts(only(result.signatures)) == ["::Int", "a"]
 end
 
 @testitem "Signatures: methods with 0 positional arguments are not skipped" begin
@@ -315,7 +414,7 @@ end
     @test !isempty(sigs)
 end
 
-@testitem "Signatures: cross-file callee shows all method signatures with parameter names" begin
+@testitem "Signatures: cross-file callee shows all method signatures with parameter names" setup=[SigLabels] begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
     using JuliaWorkspaces.URIs2: URI
 
@@ -359,12 +458,12 @@ end
     @test any(l -> occursin("greet(name)", l), labels)
     @test any(l -> occursin("greet(first, last)", l), labels)
     # Parameter names are carried through from the cross-file definitions.
-    allparams = [p.label for s in result.signatures for p in s.parameters]
+    allparams = [t for s in result.signatures for t in param_texts(s)]
     @test "name" in allparams
     @test "first" in allparams && "last" in allparams
 end
 
-@testitem "Signatures: deved workspace-package callee shows its signatures" begin
+@testitem "Signatures: deved workspace-package callee shows its signatures" setup=[SigLabels] begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
     using JuliaWorkspaces.URIs2: URI
 
@@ -417,15 +516,15 @@ end
     idx = findfirst("myfunc(", entry)[end] + 1
     result = get_signature_help(jw, uri, idx)
     @test any(s -> occursin("myfunc(alpha, beta)", s.label), result.signatures)
-    @test any(s -> [p.label for p in s.parameters] == ["alpha", "beta"], result.signatures)
+    @test any(s -> param_texts(s) == ["alpha", "beta"], result.signatures)
 
     idx_q = findlast("myfunc(", entry)[end] + 1
     result_q = get_signature_help(jw, uri, idx_q)
     @test any(s -> occursin("myfunc(alpha, beta)", s.label), result_q.signatures)
-    @test any(s -> [p.label for p in s.parameters] == ["alpha", "beta"], result_q.signatures)
+    @test any(s -> param_texts(s) == ["alpha", "beta"], result_q.signatures)
 end
 
-@testitem "Signatures: cross-file struct with only an inner constructor shows it" begin
+@testitem "Signatures: cross-file struct with only an inner constructor shows it" setup=[SigLabels] begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
     using JuliaWorkspaces.URIs2: URI
 
@@ -471,7 +570,7 @@ end
     @test length(result.signatures) == 1
     sig = only(result.signatures)
     @test occursin("Inner(x::Int)", sig.label)
-    @test [p.label for p in sig.parameters] == ["x"]
+    @test param_texts(sig) == ["x::Int"]
 
     # The SAME-FILE case goes through the unchanged local Binding path and
     # must keep rendering the inner constructor exactly once (no double
@@ -537,7 +636,7 @@ end
     @test any(s -> occursin("println(", s.label) && occursin(" in Base", s.label), result_q.signatures)
 end
 
-@testitem "Signatures: cross-file struct constructor shows field-based signature" begin
+@testitem "Signatures: cross-file struct constructor shows field-based signature" setup=[SigLabels] begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_signature_help
     using JuliaWorkspaces.URIs2: URI
 
@@ -580,7 +679,8 @@ end
     result = get_signature_help(jw, uri, idx)
     @test !isempty(result.signatures)
     sig = first(result.signatures)
-    @test [p.label for p in sig.parameters] == ["a", "b"]
+    @test sig.label == "T(a, b)"
+    @test param_texts(sig) == ["a", "b"]
 end
 
 @testitem "Signatures: workspace overload of a store-backed function is offered" begin


### PR DESCRIPTION
An argument without a binding — `::Int`, `@nospecialize(x)`, `y=1` — was skipped when building a definition's parameter list, but the highlighted parameter is selected by index into that list, so every later parameter shifted: `foo(::Int, a)` listed only `a` and highlighted it while the cursor was still at the first argument. A signature could also be dropped from the popup entirely, since the arity filter compared the cursor position against the shortened list.

Every positional parameter now gets an entry (only the `;`-parameters block is left out, as before), and both signature sources build their label through one assembler that returns each parameter's UTF-16 offset range. Ranges are exact by construction, which a substring label cannot be: it can neither tell apart two parameters that render identically (`::Int, ::Int`) nor avoid matching a name that also occurs in the callee (the `a` of `bar(a::Int)`).

The store path keeps its labels byte for byte (verified against `print(::MethodStore)` over 21179 stdlib methods) apart from now listing a method's keyword names, which the printer omitted and a workspace definition always showed.

Definitions are rendered from their own syntax, so parameter names no longer come from a binding: signature help for a cross-file callee stops analyzing each defining file.

Other visible changes: an implicit field constructor reads as a call (`T(a, b::Int)`) instead of the whole struct body, a `@nospecialize` wrapper is dropped from the label, an operator definition renders as `+(a::T, b::T)` rather than `a::T + b::T`, and a parameter's range spans its full text (`x::Int`, `b::Int = 1`) as the store path always did.

Fixes https://github.com/julia-vscode/julia-vscode/issues/4153.