### PR TITLE
feat: add `unresolved-import` lint config toggle

### DIFF
--- a/src/layer_diagnostics.jl
+++ b/src/layer_diagnostics.jl
@@ -38,6 +38,7 @@ Salsa.@derived function derived_lintconfig_diagnostics(rt, uri)
         "call", "iter", "nothingcomp", "constif", "lazy", "datadecl", "typeparam", "modname", "pirates", "useoffuncargs",
         "kwdefault", "literal", "break-continue", "constdecl",
         "missing-refs",
+        "unresolved-import",
         "format-config-errors",
     ]
 

--- a/src/layer_file_analysis.jl
+++ b/src/layer_file_analysis.jl
@@ -559,14 +559,20 @@ function _file_analysis_diagnostics(rt, cst, env, meta_dict, lint_config, projec
         elseif CSTParser.isidentifier(err[2]) && !StaticLint.haserror(err[2], meta_dict)
             push!(diagnostics, Diagnostic(rng, :warning, "Missing reference: $(err[2].val)", nothing, Symbol[], "StaticLint.jl"))
         elseif StaticLint.haserror(err[2], meta_dict) && StaticLint.errorof(err[2], meta_dict) === StaticLint.UnresolvedImport
-            name = CSTParser.str_value(err[2])
-            cause = name in declared_deps ?
-                "`$name` is a declared dependency but its symbols could not be indexed." :
-                "Failed to resolve `$name`."
-            consequence = StaticLint.is_in_wildcard_import(err[2]) ?
-                "Missing-reference checks are disabled in this scope and all nested scopes." :
-                "Anything imported through this statement is assumed to exist and will not be checked."
-            push!(diagnostics, Diagnostic(rng, :warning, "$cause $consequence", nothing, Symbol[], "StaticLint.jl"))
+            # `unresolved-import = false` suppresses this diagnostic. The branch
+            # must still match (not be folded into the guard) so the
+            # UnresolvedImport LintCode doesn't fall through to the generic
+            # LintCodes handler below, which would re-emit "Failed to resolve import.".
+            if get(lint_config, "unresolved-import", true)
+                name = CSTParser.str_value(err[2])
+                cause = name in declared_deps ?
+                    "`$name` is a declared dependency but its symbols could not be indexed." :
+                    "Failed to resolve `$name`."
+                consequence = StaticLint.is_in_wildcard_import(err[2]) ?
+                    "Missing-reference checks are disabled in this scope and all nested scopes." :
+                    "Anything imported through this statement is assumed to exist and will not be checked."
+                push!(diagnostics, Diagnostic(rng, :warning, "$cause $consequence", nothing, Symbol[], "StaticLint.jl"))
+            end
         elseif StaticLint.haserror(err[2], meta_dict) && StaticLint.errorof(err[2], meta_dict) isa StaticLint.LintCodes
             code = StaticLint.errorof(err[2], meta_dict)
             description = get(StaticLint.LintCodeDescriptions, code, "")

--- a/src/layer_static_lint.jl
+++ b/src/layer_static_lint.jl
@@ -221,14 +221,20 @@ Salsa.@derived function derived_static_lint_diagnostics_for_root(rt, root)
             elseif CSTParser.isidentifier(err[2]) && !StaticLint.haserror(err[2], meta_dict)
                 push!(current_res, Diagnostic(rng, :warning, "Missing reference: $(err[2].val)", nothing, Symbol[], "StaticLint.jl"))
             elseif StaticLint.haserror(err[2], meta_dict) && StaticLint.errorof(err[2], meta_dict) === StaticLint.UnresolvedImport
-                name = CSTParser.str_value(err[2])
-                cause = name in declared_deps ?
-                    "`$name` is a declared dependency but its symbols could not be indexed." :
-                    "Failed to resolve `$name`."
-                consequence = StaticLint.is_in_wildcard_import(err[2]) ?
-                    "Missing-reference checks are disabled in this scope and all nested scopes." :
-                    "Anything imported through this statement is assumed to exist and will not be checked."
-                push!(current_res, Diagnostic(rng, :warning, "$cause $consequence", nothing, Symbol[], "StaticLint.jl"))
+                # `unresolved-import = false` suppresses this diagnostic. The branch
+                # must still match (not be folded into the guard) so the
+                # UnresolvedImport LintCode doesn't fall through to the generic
+                # LintCodes handler below, which would re-emit "Failed to resolve import.".
+                if get(lint_config, "unresolved-import", true)
+                    name = CSTParser.str_value(err[2])
+                    cause = name in declared_deps ?
+                        "`$name` is a declared dependency but its symbols could not be indexed." :
+                        "Failed to resolve `$name`."
+                    consequence = StaticLint.is_in_wildcard_import(err[2]) ?
+                        "Missing-reference checks are disabled in this scope and all nested scopes." :
+                        "Anything imported through this statement is assumed to exist and will not be checked."
+                    push!(current_res, Diagnostic(rng, :warning, "$cause $consequence", nothing, Symbol[], "StaticLint.jl"))
+                end
             elseif StaticLint.haserror(err[2], meta_dict) && StaticLint.errorof(err[2], meta_dict) isa StaticLint.LintCodes
                 code = StaticLint.errorof(err[2], meta_dict)
                 description = get(StaticLint.LintCodeDescriptions, code, "")

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -950,6 +950,61 @@ end
     @test any(d -> startswith(d.message, "Failed to resolve `NotARealPackage`"), diags)
 end
 
+@testitem "unresolved-import: false suppresses only the import diagnostic" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    project_toml = """
+    name = "UnresTog"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee44"
+    version = "0.1.0"
+    """
+    manifest_toml = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """
+    # Explicit import (not wildcard) so missing-ref checks stay on in the scope:
+    # the genuine typo must still be reported to prove the toggle is surgical.
+    source = """
+    module UnresTog
+    using NotARealPackage: NotARealPackage
+    function f()
+        return genuine_typo()
+    end
+    end
+    """
+
+    # Enabled (default) — both the import warning and the genuine typo appear.
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///unrestog/Project.toml"), SourceText(project_toml, "toml")))
+    add_file!(jw, TextFile(URI("file:///unrestog/Manifest.toml"), SourceText(manifest_toml, "toml")))
+    add_file!(jw, TextFile(URI("file:///unrestog/src/UnresTog.jl"), SourceText(source, "julia")))
+    JuliaWorkspaces.set_input_env_ready!(jw.runtime, true)
+
+    diags = get_diagnostic(jw, URI("file:///unrestog/src/UnresTog.jl"))
+    @test any(d -> startswith(d.message, "Failed to resolve `NotARealPackage`"), diags)
+    @test any(d -> d.message == "Missing reference: genuine_typo", diags)
+
+    # Disabled — the import warning is gone, but the rest of static-lint still runs.
+    jw2 = JuliaWorkspace()
+    add_file!(jw2, TextFile(URI("file:///unrestog2/Project.toml"), SourceText(project_toml, "toml")))
+    add_file!(jw2, TextFile(URI("file:///unrestog2/Manifest.toml"), SourceText(manifest_toml, "toml")))
+    add_file!(jw2, TextFile(URI("file:///unrestog2/src/UnresTog.jl"), SourceText(source, "julia")))
+    add_file!(jw2, TextFile(URI("file:///unrestog2/JuliaLint.toml"), SourceText("unresolved-import = false", "toml")))
+    JuliaWorkspaces.set_input_env_ready!(jw2.runtime, true)
+
+    diags2 = get_diagnostic(jw2, URI("file:///unrestog2/src/UnresTog.jl"))
+    # The UnresolvedImport diagnostic (both "Failed to resolve" and "could not be
+    # indexed" phrasings) is suppressed...
+    @test !any(d -> contains(d.message, "Failed to resolve `") || contains(d.message, "could not be indexed"), diags2)
+    # ...and it did not fall through to the generic LintCode "Failed to resolve import." message.
+    @test !any(d -> d.message == "Failed to resolve import.", diags2)
+    # ...while an unrelated static-lint check (missing reference) stays active.
+    @test any(d -> d.message == "Missing reference: genuine_typo", diags2)
+end
+
 @testitem "unresolved import: late-resolving sibling module fills binding" begin
     using JuliaWorkspaces.URIs2: URI
 


### PR DESCRIPTION
As discussed on Slack, this PR adds a keyword in JuliaLint.toml to suppress `UnresolvedImport` diagnostics.

I used Claude Opus 4.8 to develop this PR.