### PR TITLE
fix: support version-specific manifests

### DIFF
--- a/shared/symbolserver/utils.jl
+++ b/shared/symbolserver/utils.jl
@@ -838,3 +838,29 @@ function write_depot(server::Server, ctx, written_caches)
         !isempty(written_path) && push!(written_caches, written_path)
     end
 end
+
+"""
+    manifest_names(version = VERSION)
+
+The manifest file names Pkg would consider for `version`, most specific first
+(mirrors `Base.manifest_names`). Version-specific manifests are only recognized
+for `version`, i.e. the Julia version this process runs under, because that is
+the version the symbol caches are built with.
+"""
+function manifest_names(version = VERSION)
+    return [
+        "JuliaManifest-v$(version.major).$(version.minor).toml",
+        "Manifest-v$(version.major).$(version.minor).toml",
+        "JuliaManifest.toml",
+        "Manifest.toml",
+    ]
+end
+
+"""
+    get_manifest_candidates(environment_path, version = VERSION)
+
+Return the manifest files that exist in `environment_path`, most specific first.
+"""
+function get_manifest_candidates(environment_path, version = VERSION)
+    return filter(isfile, joinpath.(environment_path, manifest_names(version)))
+end

--- a/src/SymbolServer/SymbolServer.jl
+++ b/src/SymbolServer/SymbolServer.jl
@@ -100,14 +100,9 @@ function download_cache_files(ssi, environment_path, progress_callback)
     mkpath(download_dir_parent)
 
     mktempdir(download_dir_parent) do download_dir
-        candidates = [
-            joinpath(environment_path, "JuliaManifest.toml"),
-            joinpath(environment_path, "Manifest.toml")
-        ]
+        candidates = get_manifest_candidates(environment_path)
 
         for manifest_filename in candidates
-            !isfile(manifest_filename) && continue
-
             manifest = read_manifest(manifest_filename)
             manifest === nothing && continue
 
@@ -322,8 +317,9 @@ function load_project_packages_into_store!(store_path, depot_path, environment_p
         return
     end
 
-    manifest_filename = isfile(joinpath(environment_path, "JuliaManifest.toml")) ? joinpath(environment_path, "JuliaManifest.toml") : joinpath(environment_path, "Manifest.toml")
-    manifest = read_manifest(manifest_filename)
+    manifest_candidates = get_manifest_candidates(environment_path)
+    isempty(manifest_candidates) && return
+    manifest = read_manifest(first(manifest_candidates))
     manifest === nothing && return
     uuids = values(deps(project))
     num_uuids = length(values(deps(project)))

--- a/src/dynamic_feature/dynamic_feature.jl
+++ b/src/dynamic_feature/dynamic_feature.jl
@@ -487,13 +487,14 @@ const MissingPackage = @NamedTuple{name::String, uuid::UUID, version::String, gi
 """
     _get_missing_packages(project_path, store_path) -> Vector{MissingPackage}
 
-Parse the Manifest.toml at `project_path` and return a list of regular and stdlib
+Parse the manifest at `project_path` and return a list of regular and stdlib
 packages whose .jstore cache files do not yet exist on disk. Deved packages are
 skipped entirely (they have no git_tree_sha1 and are handled by StaticLint).
 """
 function _get_missing_packages(project_path::String, store_path::String)
-    manifest_path = joinpath(project_path, "Manifest.toml")
-    isfile(manifest_path) || return MissingPackage[]
+    manifest_candidates = SymbolServer.get_manifest_candidates(project_path)
+    isempty(manifest_candidates) && return MissingPackage[]
+    manifest_path = first(manifest_candidates)
 
     manifest_content = try
         Pkg.TOML.parsefile(manifest_path)

--- a/src/layer_projects.jl
+++ b/src/layer_projects.jl
@@ -7,6 +7,20 @@ Salsa.@derived function derived_project_files(rt)
 end
 
 """
+    _manifest_priority(path)
+
+Rank a manifest path the way Pkg picks one: version-specific for the Julia
+version we run under first, then the plain names. Returns `nothing` for a
+manifest we must not bind at all — a version-specific manifest for a *different*
+Julia version describes an environment this process cannot index, since the
+caches it asks for are keyed by that version.
+"""
+function _manifest_priority(path)
+    name = lowercase(basename(path))
+    return findfirst(n -> lowercase(n) == name, SymbolServer.manifest_names())
+end
+
+"""
     derived_project_toml_files(rt, folder_uri)
 
 Probe for Project.toml and Manifest.toml files in `folder_uri` by
@@ -30,7 +44,7 @@ Salsa.@derived function derived_project_toml_files(rt, folder_uri)
     end
 
     manifest_file = nothing
-    for name in ("JuliaManifest.toml", "Manifest.toml")
+    for name in SymbolServer.manifest_names()
         candidate = filepath2uri(joinpath(folder_path, name))
         tf = derived_text_file_content(rt, candidate)
         if tf !== nothing
@@ -60,7 +74,10 @@ Salsa.@derived function derived_potential_project_folders(rt)
                 pf[folder_uri] = file_uri
             end
         elseif is_path_manifest_file(file_path)
-            if !haskey(mf, folder_uri) || endswith(lowercase(file_path), "juliamanifest.toml")
+            priority = _manifest_priority(file_path)
+            existing = get(mf, folder_uri, nothing)
+            if priority !== nothing &&
+                (existing === nothing || priority < _manifest_priority(uri2filepath(existing)))
                 mf[folder_uri] = file_uri
             end
         else

--- a/test/test_projects.jl
+++ b/test/test_projects.jl
@@ -215,3 +215,52 @@ end
     # nothing`.
     get_diagnostics(jw)
 end
+
+@testitem "derived_project prefers the manifest for the running Julia version" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, derived_project
+    using JuliaWorkspaces.URIs2: URI
+
+    project_toml = """
+    name = "Foo"
+    uuid = "5c0ad2b5-2f9c-4b2c-9f0c-1e5c4dd1a1cd"
+    version = "0.1.0"
+
+    [deps]
+    """
+
+    manifest_toml(julia_version) = """
+    julia_version = "$julia_version"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """
+
+    versioned_name = "Manifest-v$(VERSION.major).$(VERSION.minor).toml"
+    foreign_name = "Manifest-v$(VERSION.major).$(VERSION.minor + 1).toml"
+
+    # All three manifests in one folder: Pkg would use the version-specific one,
+    # and so must we — the caches we look up are keyed by the entries of the
+    # manifest this Julia version resolves against.
+    folder_uri = URI("file:///versionedmanifesttest")
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///versionedmanifesttest/Project.toml"), SourceText(project_toml, "toml")))
+    add_file!(jw, TextFile(URI("file:///versionedmanifesttest/Manifest.toml"), SourceText(manifest_toml("1.0.0"), "toml")))
+    add_file!(jw, TextFile(URI("file:///versionedmanifesttest/$foreign_name"), SourceText(manifest_toml("1.0.0"), "toml")))
+    add_file!(jw, TextFile(URI("file:///versionedmanifesttest/$versioned_name"), SourceText(manifest_toml(string(VERSION)), "toml")))
+
+    project = derived_project(jw.runtime, folder_uri)
+    @test project !== nothing
+    @test endswith(string(project.manifest_file_uri), versioned_name)
+    @test project.julia_version == VERSION
+
+    # A manifest for another Julia version is not bound at all: we can only
+    # index an environment resolved for the Julia version we run under, so this
+    # folder counts as having no manifest rather than as a wrongly-keyed one.
+    other_uri = URI("file:///foreignmanifesttest")
+    jw2 = JuliaWorkspace()
+    add_file!(jw2, TextFile(URI("file:///foreignmanifesttest/Project.toml"), SourceText(project_toml, "toml")))
+    add_file!(jw2, TextFile(URI("file:///foreignmanifesttest/$foreign_name"), SourceText(manifest_toml("1.0.0"), "toml")))
+
+    @test derived_project(jw2.runtime, other_uri) === nothing
+end

--- a/test/test_symbolserver.jl
+++ b/test/test_symbolserver.jl
@@ -1170,3 +1170,57 @@ end
     @test sort(r.publicnames) == [:expf, :pubf]
     @test haskey(r.vals, :pubf) && haskey(r.vals, :expf)
 end
+
+@testitem "SymbolServer: version-specific manifests are candidates for this Julia version" begin
+    using JuliaWorkspaces.SymbolServer: get_manifest_candidates, manifest_names
+
+    this_version = "Manifest-v$(VERSION.major).$(VERSION.minor).toml"
+    other_version = "Manifest-v$(VERSION.major).$(VERSION.minor + 1).toml"
+
+    mktempdir() do dir
+        @test isempty(get_manifest_candidates(dir))
+
+        write(joinpath(dir, "Manifest.toml"), "")
+        @test basename.(get_manifest_candidates(dir)) == ["Manifest.toml"]
+
+        # Pkg prefers the version-specific manifest, so we must index that one.
+        write(joinpath(dir, this_version), "")
+        @test basename.(get_manifest_candidates(dir)) == [this_version, "Manifest.toml"]
+
+        # A manifest for another Julia version is never a candidate: it was
+        # resolved for a Julia this process cannot build caches for.
+        write(joinpath(dir, other_version), "")
+        @test basename.(get_manifest_candidates(dir)) == [this_version, "Manifest.toml"]
+    end
+
+    @test manifest_names(v"1.10.5") ==
+        ["JuliaManifest-v1.10.toml", "Manifest-v1.10.toml", "JuliaManifest.toml", "Manifest.toml"]
+end
+
+@testitem "SymbolServer: _get_missing_packages reads a version-specific manifest" begin
+    using JuliaWorkspaces: JuliaWorkspaces
+
+    uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+    th = "46e44e869b4d90b96bd8ed1fdcf32244fddfb6cc"
+
+    mktempdir() do root
+        proj = joinpath(root, "proj")
+        store = joinpath(root, "store")
+        mkpath(proj)
+
+        # A project that only has a version-specific manifest is a valid
+        # environment; its packages must still be reported as missing, otherwise
+        # nothing ever indexes them.
+        write(joinpath(proj, "Manifest-v$(VERSION.major).$(VERSION.minor).toml"), """
+        julia_version = "$(VERSION.major).$(VERSION.minor).0"
+        manifest_format = "2.0"
+
+        [[deps.Example]]
+        uuid = "$uuid"
+        version = "0.5.3"
+        git-tree-sha1 = "$th"
+        """)
+
+        @test any(m -> m.name == "Example", JuliaWorkspaces._get_missing_packages(proj, store))
+    end
+end


### PR DESCRIPTION
Ports julia-vscode/SymbolServer.jl#303 and extends it to the call sites that appeared after SymbolServer was folded into JW — manifest resolution in the dynamic-indexing path and in layer_projects, which both went by hardcoded name.

A project whose environment lives in Manifest-v1.12.toml (no plain Manifest.toml) is a valid Pkg environment, but JW indexed nothing for it: every import reported "`X` is a declared dependency but its symbols could not be indexed". A folder holding manifests for several Julia versions also bound one of them arbitrarily. All sites now share one ordering, manifest_names(version=VERSION), mirroring Base.manifest_names.

Per #72, only the case where the LS process version matches the version in the manifest name is supported: a manifest for a different Julia version is not bound at all, since the caches it asks for (stdlibs are keyed by julia_version) can't be produced by this process.

I used Claude Opus 4.8 to help me creating this PR.