### PR TITLE
fix(staticlint): every Vararg spelling is variadic

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -259,10 +259,7 @@ function func_nargs(x::EXPR, env=nothing, meta_dict=nothing)
                 else
                     maxargs !== typemax(Int) && (maxargs += 1)
                 end
-            elseif issplat(arg) ||
-                (isdeclaration(arg) &&
-                ((isidentifier(arg.args[2]) && valofid(arg.args[2]) == "Vararg") ||
-                (iscurly(arg.args[2]) && isidentifier(arg.args[2].args[1]) && valofid(arg.args[2].args[1]) == "Vararg")))
+            elseif issplat(arg) || is_explicit_vararg_decl(arg)
                 bn = bounded_vararg_N(arg)
                 if bn !== nothing
                     minargs += bn

--- a/src/StaticLint/methodmatching.jl
+++ b/src/StaticLint/methodmatching.jl
@@ -179,12 +179,44 @@ True if `arg` is a method-arg declaration of the form `x::Vararg` or
 `x::Vararg{...}` (the explicit `::Vararg` spelling, not the `x...` splat).
 """
 function is_explicit_vararg_decl(arg)
-    isdeclaration(arg) || return false
-    length(arg.args) >= 2 || return false
-    t = arg.args[2]
-    isidentifier(t) && valofid(t) == "Vararg" && return true
-    iscurly(t) && length(t.args) >= 1 && isidentifier(t.args[1]) && valofid(t.args[1]) == "Vararg" && return true
+    t = arg_decl_type(arg)
+    t === nothing && return false
+    names_vararg(t) && return true
+    iscurly(t) && length(t.args) >= 1 && names_vararg(t.args[1]) && return true
     return false
+end
+
+"Does this type expression name `Vararg`, bare or dotted (`Base.Vararg`)?"
+function names_vararg(t)
+    t isa EXPR || return false
+    isidentifier(t) && return valofid(t) == "Vararg"
+    if is_getfield_w_quotenode(t)
+        q = t.args[2]
+        return q isa EXPR && q.args !== nothing && !isempty(q.args) &&
+            isidentifier(q.args[1]) && valofid(q.args[1]) == "Vararg"
+    end
+    return false
+end
+
+"""
+    arg_decl_type(arg)
+
+The type expression of a method-arg declaration, for both the bound `x::T` form
+and the anonymous `::T` form; `nothing` for anything else. The anonymous form is
+UNARY `::`, so it has one argument rather than two and `isdeclaration` is false
+for it — reading only the binary form silently treats `f(::Vararg{Int})` as one
+ordinary positional.
+"""
+function arg_decl_type(arg)
+    arg isa EXPR || return nothing
+    if isdeclaration(arg)
+        return length(arg.args) >= 2 ? arg.args[2] : nothing
+    end
+    h = headof(arg)
+    if h isa EXPR && isoperator(h) && valof(h) == "::" && arg.args !== nothing && length(arg.args) == 1
+        return arg.args[1]
+    end
+    return nothing
 end
 
 """
@@ -196,12 +228,11 @@ with an integer literal `N`; otherwise `nothing`. Distinguishes bounded
 parametric `Vararg{T,N} where N`.
 """
 function bounded_vararg_N(arg)
-    isdeclaration(arg) || return nothing
-    length(arg.args) >= 2 || return nothing
-    t = arg.args[2]
+    t = arg_decl_type(arg)
+    t === nothing && return nothing
     iscurly(t) || return nothing
     length(t.args) == 3 || return nothing
-    isidentifier(t.args[1]) && valofid(t.args[1]) == "Vararg" || return nothing
+    names_vararg(t.args[1]) || return nothing
     N_expr = t.args[3]
     CSTParser.headof(N_expr) === :INTEGER || return nothing
     N_expr.val isa AbstractString || return nothing

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -3513,6 +3513,41 @@ end
         end""")
 end
 
+@testitem "every Vararg spelling is variadic" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: func_nargs, is_explicit_vararg_decl, bounded_vararg_N
+    using JuliaWorkspaces.CSTParser: parse
+
+    inf = typemax(Int)
+
+    # A unary `::T` is not `isdeclaration` — it carries one argument, not two — so
+    # the anonymous spelling was counted as an ordinary positional, and the dotted
+    # one was missed because its head is a getfield rather than an identifier. Both
+    # produced arity false positives.
+    @test func_nargs(parse("f(x, ::Vararg{Int}) = 1")) == (1, inf, Symbol[], false)
+    @test func_nargs(parse("f(::Vararg{Int}) = 1")) == (0, inf, Symbol[], false)
+    @test func_nargs(parse("f(x, ::Vararg) = 1")) == (1, inf, Symbol[], false)
+    @test func_nargs(parse("f(x, ::Base.Vararg{Int}) = 1")) == (1, inf, Symbol[], false)
+    # a bounded anonymous Vararg consumes exactly N, as the bound form does
+    @test func_nargs(parse("f(x, ::Vararg{Int,3}) = 1")) == (4, 4, Symbol[], false)
+    @test func_nargs(parse("f(::Vararg{Int,2}) = 1")) == (2, 2, Symbol[], false)
+
+    # the spellings that were already correct must not move
+    @test func_nargs(parse("f(x, y::Vararg{Int}) = 1")) == (1, inf, Symbol[], false)
+    @test func_nargs(parse("f(x, ys...) = 1")) == (1, inf, Symbol[], false)
+    @test func_nargs(parse("f(x, y::Vararg{Int,3}) = 1")) == (4, 4, Symbol[], false)
+    @test func_nargs(parse("f(x, ::Int) = 1")) == (2, 2, Symbol[], false)
+    @test func_nargs(parse("f(x::Int, y) = 1")) == (2, 2, Symbol[], false)
+
+    # the helpers `func_nargs` now shares with the rest of the arity machinery
+    argof(src) = parse(src).args[1].args[3]      # the second parameter
+    @test is_explicit_vararg_decl(argof("f(x, ::Vararg{Int}) = 1"))
+    @test is_explicit_vararg_decl(argof("f(x, ::Base.Vararg) = 1"))
+    @test is_explicit_vararg_decl(argof("f(x, y::Vararg{Int}) = 1"))
+    @test !is_explicit_vararg_decl(argof("f(x, ::Int) = 1"))
+    @test bounded_vararg_N(argof("f(x, ::Vararg{Int,3}) = 1")) == 3
+    @test bounded_vararg_N(argof("f(x, ::Vararg{Int}) = 1")) === nothing
+end
+
 @testitem "@nospecialize without argument (#390)" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: func_nargs
     using JuliaWorkspaces.CSTParser: parse, EXPR


### PR DESCRIPTION
A unary `::T` is not `isdeclaration` — it carries one argument, not two — so every Vararg test missed the anonymous spelling and counted `f(x, ::Vararg{Int})` as two ordinary positionals instead of one-or-more. The dotted `::Base.Vararg` was missed for a second reason: the head is a getfield, not an identifier. Both produced arity false positives.

`func_nargs` duplicated `is_explicit_vararg_decl`'s logic inline; it now calls it, so the two cannot drift. `arg_decl_type` reads the type from either spelling, and `names_vararg` accepts the dotted form, which also lets `bounded_vararg_N` read N out of an anonymous or dotted Vararg.

Extracted from 8c68003 on sp/module-inventory-design, which fixed the same bug on the cross-file signature-record side at the same time; that half depends on the record and stays with the type-matching work. The tests here are new — the original's pinned the record's arity, which does not exist independently of it.