### PR TITLE
feat(staticlint): a reassigned local settles on the type covering its assignments

### DIFF
--- a/src/StaticLint/StaticLint.jl
+++ b/src/StaticLint/StaticLint.jl
@@ -233,6 +233,10 @@ getsymbolextendeds(env::ExternalEnv) = env.extended_methods
 getsymbols(state::TraverseState) = getsymbols(state.env)
 getsymbolextendeds(state::TraverseState) = getsymbolextendeds(state.env)
 
+# Every binding a rebound name got in one scope, in source order. Pass-local:
+# it exists only to settle the types at the end of a traversal phase.
+const ReboundBindings = Dict{Tuple{Scope,String},Vector{Binding}}
+
 mutable struct Toplevel{RT} <: TraverseState
     uri::URI
     included_files::Vector{URI}
@@ -253,12 +257,13 @@ mutable struct Toplevel{RT} <: TraverseState
     flags::Int
     meta_dict::Dict{UInt64,Meta}
     runtime::RT
+    rebound::ReboundBindings
 end
 
 getpath(state::Toplevel) = URIs2.uri2filepath(state.uri)
 
 Toplevel(uri, included_files, all_included_files, scope, in_modified_expr, modified_exprs, delayed, resolveonly, env, workspace_packages, meta_dict, runtime) =
-    Toplevel(uri, included_files, all_included_files, scope, in_modified_expr, modified_exprs, delayed, resolveonly, env, workspace_packages, Dict{Symbol,TestSetupInfo}(), nothing, true, 0, meta_dict, runtime)
+    Toplevel(uri, included_files, all_included_files, scope, in_modified_expr, modified_exprs, delayed, resolveonly, env, workspace_packages, Dict{Symbol,TestSetupInfo}(), nothing, true, 0, meta_dict, runtime, ReboundBindings())
 
 function process_EXPR(x::EXPR, state::Toplevel)
     resolve_import(x, state)
@@ -299,9 +304,22 @@ mutable struct Delayed <: TraverseState
     meta_dict::Dict{UInt64,Meta}
     urefs::Vector{EXPR} # refs that failed to resolve
     deferred_unused::Vector{Tuple{Binding,Scope}} # unused checks pending parent-scope completion
+    rebound::ReboundBindings
 end
 
-Delayed(scope, env, workspace_packages, meta_dict, flags=0) = Delayed(scope, env, workspace_packages, flags, meta_dict, EXPR[], Tuple{Binding,Scope}[])
+Delayed(scope, env, workspace_packages, meta_dict, flags=0) = Delayed(scope, env, workspace_packages, flags, meta_dict, EXPR[], Tuple{Binding,Scope}[], ReboundBindings())
+
+# Note the binding a plain assignment displaces and the one it installs, so both
+# can be settled together once the phase has seen every assignment. Types are not
+# inferred yet at this point. Only the two binding states collect; the others
+# reach no rebinding.
+_note_rebound!(::TraverseState, _, _, _, _) = nothing
+function _note_rebound!(state::Union{Toplevel,Delayed}, scope, name, displaced, b::Binding)
+    g = get!(() -> Binding[], state.rebound, (scope, name))
+    displaced isa Binding && (isempty(g) || g[end] !== displaced) && push!(g, displaced)
+    push!(g, b)
+    return
+end
 
 function process_EXPR(x::EXPR, state::Delayed)
     meta_dict = state.meta_dict
@@ -386,8 +404,9 @@ function semantic_pass(uri, cst, env, meta_dict, rt, modified_expr = nothing; wo
     root_modules = Dict{Symbol,Any}(:Base => env.symbols[:Base], :Core => env.symbols[:Core])
     module_context !== nothing && (root_modules[:__tree__] = module_context)
     setscope!(cst, Scope(nothing, cst, Dict(), root_modules, nothing), meta_dict)
-    state = Toplevel(uri, [uri], Set([uri]), scopeof(cst, meta_dict), modified_expr === nothing, modified_expr, EXPR[], EXPR[], env, workspace_packages, test_setups, self_package_name, module_context === nothing, 0, meta_dict, rt)
+    state = Toplevel(uri, [uri], Set([uri]), scopeof(cst, meta_dict), modified_expr === nothing, modified_expr, EXPR[], EXPR[], env, workspace_packages, test_setups, self_package_name, module_context === nothing, 0, meta_dict, rt, ReboundBindings())
     process_EXPR(cst, state)
+    _unify_rebound_types!(state)
     unique!(state.delayed)
     for x in state.delayed
         if hasscope(x, meta_dict)
@@ -402,6 +421,7 @@ function semantic_pass(uri, cst, env, meta_dict, rt, modified_expr = nothing; wo
             traverse(x, ds)
             retry_urefs!(ds)
         end
+        _unify_rebound_types!(ds)
         for (b, sc) in ds.deferred_unused
             check_unused_binding(b, sc, meta_dict)
         end

--- a/src/StaticLint/bindings.jl
+++ b/src/StaticLint/bindings.jl
@@ -488,6 +488,7 @@ function add_binding(x, state, scope=state.scope)
                 check_const_decl(name, b, scope, meta_dict)
             end
 
+            _note_rebound!(state, scope, name, scope.names[name], b)
             scope.names[name] = b
         elseif is_soft_scope(scope) && parentof(scope) isa Scope && isidentifier(b.name) && scopehasbinding(parentof(scope), valofid(b.name)) && !enforce_hard_scope(x, scope)
             add_binding(x, state, scope.parent)

--- a/src/StaticLint/type_inf.jl
+++ b/src/StaticLint/type_inf.jl
@@ -415,6 +415,92 @@ function infer_type_decl(binding, state, scope)
     _settype_from_decl!(binding, t, state)
 end
 
+# Do two settled types name the same type? Store values for the same type are not
+# guaranteed to be the same object, so compare by name, not by identity.
+function _same_inferred_type(a, b)
+    a === b && return true
+    (a === nothing || b === nothing) && return false
+    na, nb = _basename(a), _basename(b)
+    return na !== nothing && na == nb
+end
+
+# A type's supertypes, nearest first. Stops at `Any`, at a type that supertypes
+# to itself, and at a fixed depth, so a malformed chain cannot spin.
+function _ancestry(t, store, meta_dict)
+    out = Any[t]
+    cur = t
+    for _ in 1:32
+        _isany(cur) && break
+        nxt = _super(cur, store, meta_dict)
+        (nxt === nothing || _same_inferred_type(nxt, cur)) && break
+        push!(out, nxt)
+        cur = nxt
+    end
+    return out
+end
+
+# The nearest type every one of `types` sits beneath. `Any` whenever the chains
+# do not meet — a workspace type's supertype can dead-end outside this file.
+function _join_types(types, store, meta_dict)
+    for cand in _ancestry(first(types), store, meta_dict)
+        all(t -> any(a -> _same_inferred_type(a, cand), _ancestry(t, store, meta_dict)), types) &&
+            return cand
+    end
+    return CoreTypes.Any
+end
+
+# Settle the type of every name that was assigned more than once in a scope. The
+# assignments disagree when they name two different types, or when one of them
+# never inferred a type at all — in both cases a use can see a value the binding
+# it resolves to does not describe, so no one assignment's type may be claimed.
+#
+# What they settle on is the nearest type that covers them all: `Int` and
+# `Float64` settle on `Real`, which still rules out a `String` parameter. An
+# un-inferred assignment could hold anything, so it joins at `Any`.
+#
+# A join, not a union: `_type_compare` has only a right-side union method, so a
+# union-typed argument would rule out every member that is a proper subtype of an
+# abstract parameter. Widening only ever removes an opinion, never adds one.
+#
+# Only bindings that already inferred a type are written. `nothing` means "not
+# inferred", which consumers answer with by-use inference of their own.
+
+# Was this binding's value written with an explicit `::T`? `x = x::Child1` and
+# `x::Child1 = v` assert a type rather than infer one, and the assertion holds
+# wherever it was written — including one branch of an `if`. Those types are the
+# author's, and a use reads the binding live where it sits, so they are left as
+# written.
+function _asserts_its_type(b::Binding)
+    v = b.val
+    (v isa EXPR && isassignment(v) && v.args !== nothing && length(v.args) == 2) || return false
+    return isdeclaration(v.args[1]) || isdeclaration(v.args[2])
+end
+
+function _unify_rebound_types!(state)
+    for (_, group) in state.rebound
+        length(group) > 1 || continue
+        any(_asserts_its_type, group) && continue
+        known = Any[]
+        any_unknown = false
+        for b in group
+            if b.type === nothing
+                any_unknown = true
+            elseif !any(k -> _same_inferred_type(k, b.type), known)
+                push!(known, b.type)
+            end
+        end
+        isempty(known) && continue
+        (any_unknown || length(known) > 1) || continue
+        settled = any_unknown ? CoreTypes.Any :
+            _join_types(known, getsymbols(state), state.meta_dict)
+        for b in group
+            b.type === nothing || settype!(b, settled)
+        end
+    end
+    empty!(state.rebound)
+    return
+end
+
 function infer_type_decl(binding, t, state, scope)
     if isidentifier(t)
         resolve_ref(t, scope, state)

--- a/test/staticlint/test_inference.jl
+++ b/test/staticlint/test_inference.jl
@@ -739,3 +739,67 @@ end
         @test errorof(cst.args[2], meta_dict) === expected
     end
 end
+
+@testitem "a rebound local's type unifies to Any when its assignments disagree" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: bindingof, Binding, _isany, _basename
+
+    # Every binding created for `name`, in source order, with its settled type.
+    function types_of(src, name)
+        cst, meta_dict = parse_and_pass(src)
+        out = []
+        walk(x) = begin
+            if x.head === :IDENTIFIER && JuliaWorkspaces.CSTParser.valof(x) == name
+                b = bindingof(x, meta_dict)
+                b isa Binding && push!(out, b.type)
+            end
+            x.args === nothing || foreach(walk, x.args)
+        end
+        walk(cst)
+        out
+    end
+    nm(t) = t === nothing ? "nothing" : _isany(t) ? "Any" : string(_basename(t))
+
+    # Disagreeing assignments: BOTH bindings widen, including the earlier one —
+    # a use between them can still see the later value at runtime.
+    @test nm.(types_of("function f(c)\n    x = nothing\n    g(x)\n    x = 1\nend\n", "x")) ==
+        ["Any", "Any"]
+
+    # Agreement is left alone
+    @test nm.(types_of("function f(c)\n    x = 1\n    g(x)\n    x = 2\nend\n", "x")) == ["Core.Int64", "Core.Int64"]
+
+    # They settle on the nearest type covering both, not on `Any`: `Real` still
+    # rules out a `String` parameter, which `Any` would not.
+    @test nm.(types_of("function f(c)\n    x = 1\n    g(x)\n    x = 2.0\nend\n", "x")) ==
+        ["Core.Real", "Core.Real"]
+
+    # One known type alongside an un-inferred binding also disagrees: the known
+    # one widens, and the un-inferred one is never written (consumers fall back
+    # to by-use inference when they see `nothing`).
+    @test nm.(types_of("function f(node, m)\n    if m\n        node = GlobalRef(m, node)\n    end\n    g(node)\nend\n", "node")) ==
+        ["nothing", "Any"]
+
+    # A name assigned once is untouched
+    @test nm.(types_of("function f()\n    x = 1\n    g(x)\nend\n", "x")) == ["Core.Int64"]
+
+    # Method accumulation is not rebinding
+    @test all(t -> !_isany(t), types_of("f(x) = 1\nf(x, y) = 2\n", "f"))
+
+    # Grouping is per (scope, name). The closure takes `x` as a PARAMETER, which
+    # is a fresh local — a plain assignment there would reassign the captured
+    # outer `x` instead, making it one group rather than two.
+    outer = types_of("""
+    function f()
+        x = 1
+        h = function (x)
+            x = nothing
+            g(x)
+            x = "s"
+        end
+        g(x)
+    end
+    """, "x")
+    # the outer `x` is assigned once and keeps its type
+    @test nm(outer[1]) == "Core.Int64"
+    # the closure's parameter stays un-inferred, its two assignments widen
+    @test nm.(outer[2:end]) == ["nothing", "Any", "Any"]
+end

--- a/test/test_hover.jl
+++ b/test/test_hover.jl
@@ -1353,3 +1353,32 @@ end
     @test occursin("is a function with", h)
     @test occursin("in `Iterators`", h)
 end
+
+@testitem "Hover: a reassigned local reports the type covering its assignments" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_hover_text
+    using JuliaWorkspaces.URIs2: URI
+
+    # User-visible consequence of settling a rebound local's type: hover reports
+    # what covers every assignment, not whichever one the traversal reached last.
+    source = """
+    function f()
+        x = 1
+        x = 2.0
+        x
+    end
+    function g()
+        y = 1
+        y = nothing
+        y
+    end
+    """
+    uri = URI("file:///hoverrebind/test.jl")
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(uri, SourceText(source, "julia")))
+    hover(marker) = get_hover_text(jw, uri, findlast(marker, source)[end])
+
+    # Int and Float64 are both Reals
+    @test occursin("Real", hover("\n    x\n"))
+    # nothing shares only Any with Int
+    @test occursin("Any", hover("\n    y\n"))
+end


### PR DESCRIPTION
A name assigned more than once in a scope resolved to whichever binding the pass left in `scope.names`, so every use — the lint, `isa`, hover, completions — read a type that only one of the assignments actually justified. The assignments of a rebound name are now collected during the pass and settled together at the end of each phase, so back-filling makes every `refof`-based consumer correct at once.

Two departures from the obvious rule, both deliberate:

- **The join, not `Any`.** `Int` and `Float64` settle on `Real`, which still rules out a `String` parameter. An un-inferred assignment could hold anything, so it joins at `Any`.
- **An explicit `::T` is left alone.** `x = x::Child1` and the per-branch `y = x::Child1` / `y = x::Child2` idiom are assertions, not inferences; widening them would silently break type-assertion narrowing in completions.

Extracted from 49836ae on sp/module-inventory-design. The code is unchanged apart from keeping `main`'s `infer_type_decl` (the inner-`where` strip it was sitting on is its own branch), and the tests here are the original's — its cross-file diagnostic assertions and its sweep-result documentation stay with the type-matching work, which is where those numbers were measured.