### PR TITLE
fix(staticlint): a where-bounded type variable resolves to its upper bound

### DIFF
--- a/src/StaticLint/methodmatching.jl
+++ b/src/StaticLint/methodmatching.jl
@@ -20,9 +20,13 @@ function arg_type(arg, ismethod, meta_dict, store=nothing)
                     type = type.val
                 elseif type isa Binding && CoreTypes.isdatatype(type.type)
                     # Bound through a typevar (the link's `.type` is the
-                    # `DataType` meta-type). We don't know the concrete
-                    # constraint statically — fall back to `Any`.
-                    return CoreTypes.Any
+                    # `DataType` meta-type). A `where` clause may still give an
+                    # UPPER bound, and the method can only ever instantiate at a
+                    # subtype of it, so the bound is sound for ruling a call out.
+                    # `>:` gives a lower bound and licenses nothing.
+                    ub = store === nothing ? nothing : where_upper_bound_expr(type)
+                    ub === nothing && return CoreTypes.Any
+                    return _resolve_type_expr(ub, store, meta_dict)
                 end
                 return type
             end
@@ -56,6 +60,30 @@ function arg_type(arg, ismethod, meta_dict, store=nothing)
 end
 
 isquotedsymbol(x) = x isa EXPR && x.head === :quotenode && length(x.args) == 1 && x.args[1].head === :IDENTIFIER && hastrivia(x)
+
+"""
+    where_upper_bound_expr(b::Binding)
+
+The type expression of a `where`-bound type variable's UPPER bound, or `nothing`
+when it has none: a bare `T`, a lower bound (`T>:B`), or a descending chain. A
+typevar's binding keeps the `where` argument as its `.val`, so the bound is
+readable from the binding alone.
+"""
+function where_upper_bound_expr(b::Binding)
+    a = b.val
+    a isa EXPR || return nothing
+    CSTParser.iswhere(parentof(a)) || return nothing
+    if a.head isa EXPR && isoperator(a.head) && valof(a.head) == "<:" &&
+            a.args !== nothing && length(a.args) == 2 && isidentifier(a.args[1])
+        return a.args[2]
+    elseif headof(a) === :comparison && a.args !== nothing && length(a.args) == 5 &&
+            headof(a.args[2]) === :OPERATOR && headof(a.args[4]) === :OPERATOR &&
+            valof(a.args[2]) == "<:" && valof(a.args[4]) == "<:" && isidentifier(a.args[3])
+        # `Lo<:T<:Hi`: only the ascending chain has a readable upper bound.
+        return a.args[5]
+    end
+    return nothing
+end
 
 # Extract the name from a kwarg in a `:parameters` block. The entry may be a
 # bare identifier (sig form `f(a; p)`), a kwarg with default (`p = v`), or a

--- a/test/staticlint/test_inference.jl
+++ b/test/staticlint/test_inference.jl
@@ -739,3 +739,32 @@ end
         @test errorof(cst.args[2], meta_dict) === expected
     end
 end
+
+@testitem "a where-bounded type variable rules out by its upper bound" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, IncorrectCallArgs
+
+    # A typevar parameter used to fall back to `Any`, so a `where` bound ruled
+    # nothing out. The method can only ever instantiate at a SUBTYPE of an upper
+    # bound, so an argument that cannot intersect the bound matches no
+    # instantiation — sound for ruling a call out.
+    for (src, expected) in [
+        ("f(x::T) where T<:Real = x\nf(\"s\")"      => IncorrectCallArgs),
+        ("f(x::T) where T<:Real = x\nf(1)"          => nothing),
+        ("f(x::T) where T<:Integer = x\nf(1)"       => nothing),
+        ("f(x::T) where T<:AbstractString = x\nf(1)" => IncorrectCallArgs),
+        # an unbounded variable licenses nothing: `T` may well be `String`
+        ("f(x::T) where T = x\nf(\"s\")"            => nothing),
+        # ...and a LOWER bound licenses nothing either, for a rule-out check
+        ("f(x::T) where T>:Int = x\nf(\"s\")"       => nothing),
+        # a second method that does accept the call keeps it quiet
+        ("f(x::T) where T<:Real = x\nf(x::String) = x\nf(\"s\")" => nothing),
+        # KNOWN RESIDUAL, pinned: an ascending chain rules nothing out here,
+        # because `mark_binding!` binds no name for the middle identifier of a
+        # `:comparison`, so there is no typevar binding to read a bound from.
+        # Permissive, and upstream of this substitution.
+        ("f(x::T) where Int<:T<:Real = x\nf(\"s\")" => nothing),
+    ]
+        cst, meta_dict = parse_and_pass(src)
+        @test errorof(cst.args[end], meta_dict) === expected
+    end
+end


### PR DESCRIPTION
`arg_type` discarded a typevar parameter's constraint and returned `Any`, so `f(x::T) where T<:Real` ruled nothing out and `f("s")` went unflagged. A method can only ever be instantiated at a SUBTYPE of an upper bound, so an argument that cannot intersect the bound matches no instantiation — sound for a rule-out check. A lower bound (`T>:B`) licenses nothing and still answers `Any`.

Extracted from b935441 on sp/module-inventory-design, whose test asserted this through the cross-file harness; the test here is new and local. The commit's cross-file counterpart (cdbfb90) substitutes the same bound on the record side and stays with the type-matching work.

Known residual, pinned by the test: an ascending chain (`where Int<:T<:Real`) still rules nothing out, because `mark_binding!` binds no name for the middle identifier of a `:comparison`, so there is no typevar binding to read a bound from. Permissive, and upstream of this substitution.