### PR TITLE
fix(staticlint): an inner `where` in an annotation reads as the head it wraps

### DIFF
--- a/src/StaticLint/type_inf.jl
+++ b/src/StaticLint/type_inf.jl
@@ -399,23 +399,14 @@ function _settype_from_decl!(binding, t, state)
     end
 end
 
-function infer_type_decl(binding, state, scope)
-    t = binding.val.args[2]
-    if isidentifier(t)
-        resolve_ref(t, scope, state)
-    end
-    if iscurly(t)
-        t = t.args[1]
-        resolve_ref(t, scope, state)
-    end
-    if CSTParser.is_getfield_w_quotenode(t)
-        resolve_getfield(t, scope, state)
-        t = t.args[2].args[1]
-    end
-    _settype_from_decl!(binding, t, state)
-end
+infer_type_decl(binding, state, scope) = infer_type_decl(binding, binding.val.args[2], state, scope)
 
 function infer_type_decl(binding, t, state, scope)
+    # `x::Vector{T} where T` declares `Vector`: the clause narrows the type
+    # ARGUMENTS, which the curly unwrapping below drops anyway.
+    while iswhere(t) && t.args !== nothing && !isempty(t.args)
+        t = t.args[1]
+    end
     if isidentifier(t)
         resolve_ref(t, scope, state)
     end

--- a/test/staticlint/test_inference.jl
+++ b/test/staticlint/test_inference.jl
@@ -739,3 +739,50 @@ end
         @test errorof(cst.args[2], meta_dict) === expected
     end
 end
+
+@testitem "infer_type_decl reads an inner `where` as the head it wraps" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: bindingof, hasbinding, Binding, _basename
+    using JuliaWorkspaces: CSTParser
+
+    # The type of the parameter named `want`, as inferred from its annotation.
+    function param_type(src, want)
+        cst, meta_dict = parse_and_pass(src)
+        found = Ref{Any}(nothing)
+        walk(x) = begin
+            x isa CSTParser.EXPR || return
+            if found[] === nothing && hasbinding(x, meta_dict)
+                b = bindingof(x, meta_dict)
+                b isa Binding && b.name isa CSTParser.EXPR &&
+                    CSTParser.str_value(b.name) == want && (found[] = b.type)
+            end
+            x.args === nothing && return
+            foreach(walk, x.args)
+        end
+        walk(cst)
+        return found[]
+    end
+    basename_of(src) = (t = param_type(src, "x"); t === nothing ? nothing : string(_basename(t)))
+
+    # `Vector{T} where T` IS `Vector` — the clause narrows the type ARGUMENTS, which
+    # the curly unwrapping drops anyway. Before the fix the wrapper was not stripped
+    # and the annotation lost even its head, inferring no type at all.
+    @test basename_of("function f(x::Vector{T} where T) end") == "Core.Array"
+    # the unwrapped spellings are the reference: all three must agree
+    @test basename_of("function f(x::Vector) end") == "Core.Array"
+    @test basename_of("function f(x::Vector{Int}) end") == "Core.Array"
+    # a chain of clauses strips all the way down
+    @test basename_of("function f(x::Vector{T} where T where S) end") == "Core.Array"
+
+    # A bare `S where S` names no type. Unwrapping must not reach for a global of
+    # that name, which would type the parameter as something unrelated.
+    @test param_type("function f(x::(S where S)) end", "x") === nothing
+    @test param_type("struct S end\nfunction f(x::(S where S)) end", "x") === nothing
+
+    # KNOWN RESIDUAL, pinned so a change is deliberate: a clause wrapped in
+    # PARENTHESES is not stripped, because this path has no bracket unwrapping —
+    # the annotation's head is `:brackets`, not `:where`. The cross-file record
+    # side does strip brackets, so the two disagree on this one spelling. Both
+    # answers are permissive (no type, hence no opinion), so nothing is misjudged.
+    @test param_type("function f(x::(Vector{T} where T)) end", "x") === nothing
+    @test param_type("function f(x::(Vector{T} where T) where S) end", "x") === nothing
+end


### PR DESCRIPTION
`x::Vector{T} where T` lost even its head: `infer_type_decl` matched the annotation against identifier / curly / getfield and a `:where` node is none of those, so the parameter inferred no type at all. The clause narrows the type ARGUMENTS, which the curly unwrapping drops anyway, so `Vector{T} where T` IS `Vector` for this purpose and the wrapper can simply be stripped. The two `infer_type_decl` methods collapse into one, the three-argument form delegating to the four.

Extracted from 5ca68a4 on sp/module-inventory-design, which changed the cross-file record side in the same commit; that half depends on the signature record and stays with the type-matching work. The test is new — the original's asserted diagnostics through the cross-file harness.

Known residual, pinned by the test: a clause wrapped in PARENTHESES (`x::(Vector{T} where T)`) is still not stripped, because this path has no bracket unwrapping and the annotation's head is `:brackets`. The record side does strip brackets, so the two paths disagree on that one spelling. Both answers are permissive, so nothing is misjudged either way.