### PR TITLE
Prevent manifest creation

### DIFF
--- a/juliadynamicanalysisprocess/JuliaDynamicAnalysisProcess/src/JuliaDynamicAnalysisProcess.jl
+++ b/juliadynamicanalysisprocess/JuliaDynamicAnalysisProcess/src/JuliaDynamicAnalysisProcess.jl
@@ -5,6 +5,7 @@ import Sockets, Pkg
 include("pkg_imports.jl")
 include("../../../shared/julia_dynamic_analysis_process_protocol.jl")
 include("symbolserver.jl")
+include("scratch_env.jl")
 
 struct JuliaDynamicAnalysisProcessState
     endpoint::JSONRPC.JSONRPCEndpoint
@@ -32,10 +33,20 @@ end
 
 function index_project_request(params::JuliaDynamicAnalysisProtocol.IndexProjectParams, state::JuliaDynamicAnalysisProcessState, token)
     try
-        Pkg.activate(params.projectPath)
+        if params.package !== nothing && CAN_MIRROR_ENV
+            # `TestEnv.activate` instantiates whatever environment is active, which
+            # would create a `Manifest.toml` in the user's folder. Give it a scratch
+            # mirror of the environment instead.
+            Pkg.activate(materialize_scratch_env(params.projectPath, params.package))
 
-        if params.package!==nothing
-            TestEnv.activate(params.package);
+            TestEnv.activate(params.package)
+        else
+            # Either there is no test environment to build, or this Julia is too
+            # old to mirror one. Reading an environment never writes to it, so
+            # indexing the project where it lies is safe; on the old-Julia path
+            # test files lose their test-only dependencies, which is the lesser
+            # harm compared to writing into the user's folder.
+            Pkg.activate(params.projectPath)
         end
 
         SymbolServer.get_store(params.storePath, progress_reporter(state))

--- a/juliadynamicanalysisprocess/JuliaDynamicAnalysisProcess/src/scratch_env.jl
+++ b/juliadynamicanalysisprocess/JuliaDynamicAnalysisProcess/src/scratch_env.jl
@@ -1,0 +1,164 @@
+# Materializing a scratch environment
+#
+# `TestEnv.activate` calls `Pkg.instantiate` on whatever environment is active
+# when it runs (`ctx_and_pkgspec` in the vendored TestEnv). For an environment
+# with a `Project.toml` but no `Manifest.toml` that resolves and writes a
+# manifest straight into that directory. Static analysis must never touch the
+# user's working tree, and TestEnv is vendored from upstream so we cannot patch
+# it — therefore we never make the user's environment the active one. Instead we
+# build a throwaway *wrapper* environment that mirrors it and activate that.
+#
+# The wrapper is deliberately nameless (no `name`/`uuid`/`version`) and carries
+# the package under test as an ordinary path-tracked dependency. That is not a
+# stylistic choice: Pkg derives the package's source location from
+# `dirname(env.project_file)` in two places —
+#
+#   * `Pkg.Operations.sandbox_preserve`, which injects the root entry with
+#     `path = dirname(env.project_file)`, and
+#   * TestEnv's `get_test_dir`, which sets `pkgspec.path = dirname(ctx.env.project_file)`
+#     when the package *is* the active project.
+#
+# A verbatim copy of the package's own `Project.toml` would therefore point both
+# of them at the scratch directory, which has no `src/` and no `test/`. Leaving
+# the wrapper nameless routes both through the manifest entry instead, which we
+# aim back at the real package folder.
+
+"""
+    CAN_MIRROR_ENV
+
+Whether this Julia's `Pkg` exposes enough of its environment API for
+[`materialize_scratch_env`](@ref) to work. False before Julia 1.2, where
+`Pkg.Types.Project`/`Manifest` are plain `Dict`s and `Pkg.Operations.abspath!`
+does not exist.
+
+Callers must not fall back to activating the user's environment when this is
+false — that is the very thing we are avoiding.
+"""
+const CAN_MIRROR_ENV =
+    isdefined(Pkg.Types, :Project) &&
+    isdefined(Pkg.Types, :Manifest) &&
+    isdefined(Pkg.Operations, :abspath!)
+
+# The absolute path of the package's source tree, as seen from `src_env`.
+#
+# `manifest` must already have been run through `abspath!`, so a deved entry's
+# `path` is absolute by the time we read it.
+function _package_source_path(src_env, manifest, package_name::String)
+    # The common case: the environment *is* the package (with or without a manifest).
+    if src_env.pkg !== nothing && src_env.pkg.name == package_name
+        return dirname(src_env.project_file)
+    end
+
+    # Otherwise the package is deved into this environment — this is the shape
+    # `_test_environment_key` produces when it routes a workspace package's test
+    # env to the active project rather than to the package folder.
+    uuid = get(src_env.project.deps, package_name, nothing)
+    if uuid !== nothing
+        entry = get(manifest, uuid, nothing)
+        if entry !== nothing && entry.path !== nothing
+            return entry.path
+        end
+    end
+
+    error("Cannot locate the source of package $package_name in the environment at $(dirname(src_env.project_file)).")
+end
+
+# A manifest whose recorded project hash disagrees with the project makes
+# `Pkg.instantiate` warn on every run. The wrapper's dep set differs from the
+# source project's (it gained the package under test), so re-record it. Purely
+# cosmetic, hence best-effort: `record_project_hash` is a Pkg internal.
+function _record_project_hash!(env_dir::String)
+    try
+        env = Pkg.Types.EnvCache(Pkg.Types.projectfile_path(env_dir))
+        Pkg.Operations.record_project_hash(env)
+        Pkg.Types.write_manifest(env.manifest, env.manifest_file)
+    catch err
+        err isa InterruptException && rethrow()
+        @debug "Could not record the project hash of the scratch environment" env_dir exception = (err, catch_backtrace())
+    end
+    return
+end
+
+"""
+    materialize_scratch_env(project_path, package_name) -> String
+
+Build a scratch environment mirroring the one at `project_path` and return its
+directory. The environment at `project_path` is only ever read.
+
+The result is safe to `Pkg.activate` before calling `TestEnv.activate(package_name)`:
+every write TestEnv performs then lands in the scratch directory or in TestEnv's
+own temporary directory, never in the user's folder.
+
+When the source environment has a manifest it is copied over verbatim (with
+relative paths made absolute), so the test environment resolves against exactly
+the versions the user has pinned. When it does not, there is nothing to preserve
+and TestEnv's `Pkg.instantiate` resolves one into the scratch directory.
+"""
+function materialize_scratch_env(project_path::String, package_name::String)
+    src_env = Pkg.Types.EnvCache(Pkg.Types.projectfile_path(project_path))
+
+    # `abspath!` rewrites deved `path` entries relative to the *source* manifest,
+    # so it has to run before anything is written elsewhere. On a manifest-less
+    # environment this is a no-op over an empty dict.
+    manifest = Pkg.Operations.abspath!(src_env, deepcopy(src_env.manifest))
+    package_path = _package_source_path(src_env, manifest, package_name)
+
+    env_dir = mktempdir()
+
+    project = deepcopy(src_env.project)
+
+    @static if VERSION >= v"1.11"
+        # `[sources]` paths are project-relative, so they need the same treatment
+        # as the manifest's. Then pin the package under test to its real location.
+        Pkg.Operations.abspath!(src_env, project)
+        project.sources[package_name] = Dict("path" => package_path)
+    end
+
+    # The source project's own package becomes an ordinary dependency of the wrapper.
+    if src_env.pkg !== nothing
+        project.deps[src_env.pkg.name] = src_env.pkg.uuid
+    end
+
+    project.name = nothing
+    project.uuid = nothing
+    project.version = nothing
+
+    # Meaningless in a nameless environment, and `[targets]`/`[extras]` in
+    # particular would only invite confusion: TestEnv reads those from the real
+    # package's `Project.toml` (via `gen_target_project`), not from here.
+    empty!(project.extras)
+    empty!(project.targets)
+
+    # `[workspace]` members are declared relative to the project file, so copying
+    # the section over would send Pkg looking for them inside the scratch dir.
+    # `[apps]` is simply meaningless without a name. Both sections postdate the
+    # oldest Julia the analysis process runs on, hence the field guards.
+    for section in (:workspace, :apps)
+        hasfield(Pkg.Types.Project, section) && empty!(getfield(project, section))
+    end
+
+    Pkg.Types.write_project(project, joinpath(env_dir, "Project.toml"))
+
+    if isfile(src_env.manifest_file)
+        # Manifest format 2.0 already lists the root package with `path = "."`,
+        # which `abspath!` has resolved for us. Older formats omit it, and a
+        # dependency missing from the manifest is a hard error in
+        # `Pkg.instantiate`, so fill it in either way.
+        if src_env.pkg !== nothing
+            entry = get(manifest, src_env.pkg.uuid, nothing)
+            if entry === nothing
+                entry = Pkg.Types.PackageEntry()
+                manifest[src_env.pkg.uuid] = entry
+            end
+            entry.name = src_env.pkg.name
+            entry.path = package_path
+            entry.version === nothing && (entry.version = src_env.pkg.version)
+            isempty(entry.deps) && (entry.deps = copy(src_env.project.deps))
+        end
+
+        Pkg.Types.write_manifest(manifest, joinpath(env_dir, "Manifest.toml"))
+        _record_project_hash!(env_dir)
+    end
+
+    return env_dir
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,13 @@ using TestItemRunner
 # matches (the rclone workflow sets it to "cache-infra"). Empty runs everything.
 const _JW_TEST_FILTER = get(ENV, "JW_TEST_FILTER", "")
 
+# Items tagged `:integration` resolve real environments, so they need a registry
+# and a warm depot. Off by default; set JW_RUN_INTEGRATION=1 to include them.
+const _JW_RUN_INTEGRATION = get(ENV, "JW_RUN_INTEGRATION", "") != ""
+
 @run_package_tests filter=ti ->
     !startswith(ti.filename, normpath(joinpath(@__DIR__, "..", "testdata"))) &&
     !startswith(ti.filename, joinpath(@__DIR__, "data")) &&
     !(:skip in ti.tags) &&
+    (_JW_RUN_INTEGRATION || !(:integration in ti.tags)) &&
     (isempty(_JW_TEST_FILTER) || occursin(_JW_TEST_FILTER, ti.name))

--- a/test/test_scratch_env.jl
+++ b/test/test_scratch_env.jl
@@ -36,7 +36,11 @@
     @test isempty(project.targets)
 
     @static if VERSION >= v"1.11"
-        @test project.sources["Bare"]["path"] == dir
+        # `EnvCache` realpaths the project file, so the recorded path is the
+        # resolved form — `/private/var/...` on macOS, the long profile name on
+        # Windows — never the raw `mktempdir()` string.
+        @test isabspath(project.sources["Bare"]["path"])
+        @test realpath(project.sources["Bare"]["path"]) == realpath(dir)
     end
 
     @test _snapshot(dir) == before
@@ -68,7 +72,8 @@ end
 
     written = Pkg.Types.read_manifest(joinpath(env_dir, "Manifest.toml"))
     entry = written[Base.UUID(uuid)]
-    @test entry.path == dir
+    @test isabspath(entry.path)
+    @test realpath(entry.path) == realpath(dir)
     @test entry.version == v"0.1.0"
     # The rest of the pinned graph survives, so the test env resolves against
     # exactly the versions the user has.

--- a/test/test_scratch_env.jl
+++ b/test/test_scratch_env.jl
@@ -1,0 +1,147 @@
+# The dynamic analysis process must never write into the folder it is analysing.
+# `scratch_env.jl` is what keeps that promise: it lives in the child project
+# rather than in `JuliaWorkspaces` itself, so these items load it directly.
+#
+# The end-to-end path (a real resolve through TestEnv) is covered by the
+# `:integration` item at the bottom, which is opt-in because it needs a registry.
+#
+# Shared helpers live in `test_scratch_env_helpers.jl`.
+
+@testitem "scratch env: a manifest-less package is mirrored, never written to" begin
+    include(joinpath(@__DIR__, "test_scratch_env_helpers.jl"))
+    import Pkg
+
+    uuid = "aaaaaaaa-1111-2222-3333-444444444444"
+    dir = _write_package(mktempdir(), "Bare", uuid)
+    before = _snapshot(dir)
+
+    env_dir = materialize_scratch_env(dir, "Bare")
+
+    @test env_dir != dir
+    # Nothing to preserve, so no manifest is fabricated here either — TestEnv's
+    # own `Pkg.instantiate` resolves one into the scratch dir later.
+    @test !isfile(joinpath(env_dir, "Manifest.toml"))
+
+    project = Pkg.Types.read_project(joinpath(env_dir, "Project.toml"))
+
+    # Nameless is the whole point: it stops Pkg deriving the package's source
+    # location from `dirname(env.project_file)`, which would be the scratch dir.
+    @test project.name === nothing
+    @test project.uuid === nothing
+    @test project.version === nothing
+
+    @test project.deps["Bare"] == Base.UUID(uuid)
+    @test haskey(project.deps, "Dates")
+    @test isempty(project.extras)
+    @test isempty(project.targets)
+
+    @static if VERSION >= v"1.11"
+        @test project.sources["Bare"]["path"] == dir
+    end
+
+    @test _snapshot(dir) == before
+end
+
+@testitem "scratch env: an existing manifest is carried over with absolute paths" begin
+    include(joinpath(@__DIR__, "test_scratch_env_helpers.jl"))
+    import Pkg
+
+    uuid = "aaaaaaaa-5555-6666-7777-888888888888"
+    # Manifest format 2.0 records the root package as `path = "."`, which has to
+    # end up pointing back at the real package folder.
+    manifest = """
+    manifest_format = "2.0"
+
+    [[deps.Dates]]
+    uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+    [[deps.Pinned]]
+    deps = ["Dates"]
+    path = "."
+    uuid = "$uuid"
+    version = "0.1.0"
+    """
+    dir = _write_package(mktempdir(), "Pinned", uuid; manifest)
+    before = _snapshot(dir)
+
+    env_dir = materialize_scratch_env(dir, "Pinned")
+
+    written = Pkg.Types.read_manifest(joinpath(env_dir, "Manifest.toml"))
+    entry = written[Base.UUID(uuid)]
+    @test entry.path == dir
+    @test entry.version == v"0.1.0"
+    # The rest of the pinned graph survives, so the test env resolves against
+    # exactly the versions the user has.
+    @test haskey(written, Base.UUID("ade2ca70-3891-5945-98fb-dc099432e06a"))
+
+    @test _snapshot(dir) == before
+end
+
+@testitem "scratch env: a deved package resolves to its real source" begin
+    include(joinpath(@__DIR__, "test_scratch_env_helpers.jl"))
+    import Pkg
+
+    # `_test_environment_key` routes a deved package's test env to the project
+    # that devs it, so the package under test is a dependency, not the project.
+    root = mktempdir()
+    child_uuid = "aaaaaaaa-9999-0000-1111-222222222222"
+    child = _write_package(joinpath(root, "Child"), "Child", child_uuid)
+
+    parent = mkpath(joinpath(root, "Parent"))
+    write(
+        joinpath(parent, "Project.toml"), """
+        [deps]
+        Child = "$child_uuid"
+        """
+    )
+    write(
+        joinpath(parent, "Manifest.toml"), """
+        manifest_format = "2.0"
+
+        [[deps.Child]]
+        path = "../Child"
+        uuid = "$child_uuid"
+        version = "0.1.0"
+        """
+    )
+    before_parent, before_child = _snapshot(parent), _snapshot(child)
+
+    env_dir = materialize_scratch_env(parent, "Child")
+
+    entry = Pkg.Types.read_manifest(joinpath(env_dir, "Manifest.toml"))[Base.UUID(child_uuid)]
+    @test isabspath(entry.path)
+    @test realpath(entry.path) == realpath(child)
+
+    @static if VERSION >= v"1.11"
+        sources = Pkg.Types.read_project(joinpath(env_dir, "Project.toml")).sources
+        @test realpath(sources["Child"]["path"]) == realpath(child)
+    end
+
+    @test _snapshot(parent) == before_parent
+    @test _snapshot(child) == before_child
+end
+
+@testitem "scratch env: TestEnv activates against the scratch env" tags = [:integration] begin
+    include(joinpath(@__DIR__, "test_scratch_env_helpers.jl"))
+    import Pkg
+
+    # The failure this guards against only appears once TestEnv runs: if the
+    # scratch env were a plain copy of the package's Project.toml, `get_test_dir`
+    # would look for `<scratch>/test` and find nothing.
+    dir = _write_package(mktempdir(), "Activated", "aaaaaaaa-3333-4444-5555-666666666666")
+    before = _snapshot(dir)
+
+    original_project = Base.active_project()
+    try
+        Pkg.activate(materialize_scratch_env(dir, "Activated"))
+        activate_test_env("Activated")
+
+        # A test-only dep resolving proves the merged env is real, not empty.
+        @test Base.identify_package("Test") !== nothing
+        @test Base.identify_package("Activated") !== nothing
+    finally
+        Pkg.activate(original_project)
+    end
+
+    @test _snapshot(dir) == before
+end

--- a/test/test_scratch_env_helpers.jl
+++ b/test/test_scratch_env_helpers.jl
@@ -1,0 +1,66 @@
+# Helpers for `test_scratch_env.jl`. Included from inside each `@testitem`,
+# since test items run in isolated modules and cannot see each other's globals.
+# Deliberately holds no `@testitem`, so it contributes no tests of its own.
+
+# `scratch_env.jl` lives in the child project, which is not a dependency of the
+# test environment, so it has to be loaded at runtime into a throwaway module.
+# It only needs `Pkg`.
+const _SCRATCH_ENV_MODULE = Ref{Module}()
+
+function _scratch_env_module()
+    isassigned(_SCRATCH_ENV_MODULE) && return _SCRATCH_ENV_MODULE[]
+    path = normpath(
+        joinpath(
+            @__DIR__, "..", "juliadynamicanalysisprocess",
+            "JuliaDynamicAnalysisProcess", "src", "scratch_env.jl"
+        )
+    )
+    mod = Module(:ScratchEnvUnderTest)
+    Core.eval(mod, :(import Pkg))
+    Base.include(mod, path)
+    return _SCRATCH_ENV_MODULE[] = mod
+end
+
+# A test item body is a single top-level scope, so anything defined by the
+# runtime `include` above lands in a newer world age than the code calling it.
+# Hence `invokelatest` on every crossing.
+materialize_scratch_env(project_path, package_name) =
+    Base.invokelatest(_scratch_env_module().materialize_scratch_env, project_path, package_name)
+
+# Same story for the vendored TestEnv.
+function activate_test_env(package_name)
+    mod = Module(:TestEnvUnderTest)
+    Base.include(mod, normpath(joinpath(@__DIR__, "..", "packages", "TestEnv", "src", "TestEnv.jl")))
+    return Base.invokelatest(mod.TestEnv.activate, package_name)
+end
+
+# Every file under `dir`, keyed by relative path, for before/after comparison.
+_snapshot(dir) = Dict(
+    relpath(joinpath(root, f), dir) => read(joinpath(root, f))
+    for (root, _, files) in walkdir(dir) for f in files
+)
+
+function _write_package(dir, name, uuid; manifest = nothing)
+    mkpath(joinpath(dir, "src"))
+    mkpath(joinpath(dir, "test"))
+    write(
+        joinpath(dir, "Project.toml"), """
+        name = "$name"
+        uuid = "$uuid"
+        version = "0.1.0"
+
+        [deps]
+        Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+        [extras]
+        Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+        [targets]
+        test = ["Test"]
+        """
+    )
+    write(joinpath(dir, "src", "$name.jl"), "module $name\nusing Dates\nend\n")
+    write(joinpath(dir, "test", "runtests.jl"), "using $name, Test\n@test true\n")
+    manifest === nothing || write(joinpath(dir, "Manifest.toml"), manifest)
+    return dir
+end


### PR DESCRIPTION
Currently the DJP creates manifests in user folders, but one principle we should follow is that the JW never makes any change to a user folder. This should prevent the manifest from being created, by never instantiating a project in the user folder, but instead copying the project over to a temp folder and then activating and instantiating it there.