### PR TITLE
Skip .git and other VCS/dependency dirs in workspace walkdir scan

### DIFF
--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -106,6 +106,9 @@ function read_text_file_from_uri(uri::URI; return_nothing_on_io_error=false)
     return TextFile(uri, SourceText(content, language_id))
 end
 
+# Directory names that are never worth descending into. See issue #1415 for details.
+const SKIPPED_WALKDIR_DIRNAMES = (".git", ".svn", ".hg", "node_modules")
+
 """
     read_path_into_textdocuments(uri; ignore_io_errors=false, file_limit=nothing)
         -> Union{Vector{TextFile}, Nothing}
@@ -139,8 +142,9 @@ function read_path_into_textdocuments(uri::URI; ignore_io_errors=false, file_lim
     # read; contents are read afterwards with per-file yields.
     candidate_paths = String[]
     julia_file_count = 0
-    for (root, _, files) in walkdir(path, onerror=x -> x)
+    for (root, dirs, files) in walkdir(path, onerror=x -> x)
         yield()
+        filter!(d -> d ∉ SKIPPED_WALKDIR_DIRNAMES, dirs)
         for file in files
             filepath = joinpath(root, file)
             if is_path_julia_file(filepath)

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -107,7 +107,7 @@ function read_text_file_from_uri(uri::URI; return_nothing_on_io_error=false)
 end
 
 # Directory names that are never worth descending into. See issue #1415 for details.
-const SKIPPED_WALKDIR_DIRNAMES = Set([".git", ".svn", ".hg", "node_modules"])
+const SKIPPED_DIRNAMES = Set([".git", ".svn", ".hg", "node_modules"])
 
 """
     read_path_into_textdocuments(uri; ignore_io_errors=false, file_limit=nothing)
@@ -142,12 +142,23 @@ function read_path_into_textdocuments(uri::URI; ignore_io_errors=false, file_lim
     # read; contents are read afterwards with per-file yields.
     candidate_paths = String[]
     julia_file_count = 0
-    for (root, dirs, files) in walkdir(path, onerror=x -> x)
+    # Explicit walk instead of `walkdir` because it's hard to stop it from
+    # recursing into the skipped directories
+    remaining_dirs = [path]
+    while !isempty(remaining_dirs)
+        dir = popfirst!(remaining_dirs)
         yield()
-        filter!(d -> d ∉ SKIPPED_WALKDIR_DIRNAMES, dirs)
-        for file in files
-            filepath = joinpath(root, file)
-            if is_path_julia_file(filepath)
+        entries = try
+            readdir(dir, join=true)
+        catch
+            continue
+        end
+        for filepath in entries
+            if !islink(filepath) && isdir(filepath)
+                if basename(filepath) ∉ SKIPPED_DIRNAMES
+                    push!(remaining_dirs, filepath)
+                end
+            elseif is_path_julia_file(filepath)
                 julia_file_count += 1
                 if file_limit !== nothing && julia_file_count > file_limit
                     return nothing

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -107,7 +107,7 @@ function read_text_file_from_uri(uri::URI; return_nothing_on_io_error=false)
 end
 
 # Directory names that are never worth descending into. See issue #1415 for details.
-const SKIPPED_WALKDIR_DIRNAMES = (".git", ".svn", ".hg", "node_modules")
+const SKIPPED_WALKDIR_DIRNAMES = Set([".git", ".svn", ".hg", "node_modules"])
 
 """
     read_path_into_textdocuments(uri; ignore_io_errors=false, file_limit=nothing)

--- a/test/test_fileio.jl
+++ b/test/test_fileio.jl
@@ -19,36 +19,38 @@ end
     using JuliaWorkspaces: read_path_into_textdocuments
     using JuliaWorkspaces.URIs2: filepath2uri
 
-    dir = mktempdir()
-    for i in 1:5
-        write(joinpath(dir, "f$i.jl"), "f$i() = $i\n")
+    mktempdir() do dir
+        for i in 1:5
+            write(joinpath(dir, "f$i.jl"), "f$i() = $i\n")
+        end
+        write(joinpath(dir, "Project.toml"), "name = \"X\"\n")
+
+        unlimited = read_path_into_textdocuments(filepath2uri(dir))
+        @test length(unlimited) == 6
+
+        # Only Julia files count against the limit.
+        at_limit = read_path_into_textdocuments(filepath2uri(dir), file_limit=5)
+        @test length(at_limit) == 6
+
+        @test read_path_into_textdocuments(filepath2uri(dir), file_limit=4) === nothing
     end
-    write(joinpath(dir, "Project.toml"), "name = \"X\"\n")
-
-    unlimited = read_path_into_textdocuments(filepath2uri(dir))
-    @test length(unlimited) == 6
-
-    # Only Julia files count against the limit.
-    at_limit = read_path_into_textdocuments(filepath2uri(dir), file_limit=5)
-    @test length(at_limit) == 6
-
-    @test read_path_into_textdocuments(filepath2uri(dir), file_limit=4) === nothing
 end
 
 @testitem "read_path_into_textdocuments skips .git and other VCS/dependency dirs" begin
     using JuliaWorkspaces: read_path_into_textdocuments
     using JuliaWorkspaces.URIs2: filepath2uri
 
-    dir = mktempdir()
-    write(joinpath(dir, "a.jl"), "a() = 1\n")
+    mktempdir() do dir
+        write(joinpath(dir, "a.jl"), "a() = 1\n")
 
-    for skipped in (".git", ".svn", ".hg", "node_modules")
-        skipped_dir = joinpath(dir, skipped, "nested")
-        mkpath(skipped_dir)
-        write(joinpath(skipped_dir, "b.jl"), "b() = 2\n")
+        for skipped in (".git", ".svn", ".hg", "node_modules")
+            skipped_dir = joinpath(dir, skipped, "nested")
+            mkpath(skipped_dir)
+            write(joinpath(skipped_dir, "b.jl"), "b() = 2\n")
+        end
+
+        files = read_path_into_textdocuments(filepath2uri(dir))
+        @test length(files) == 1
+        @test only(files).uri == filepath2uri(joinpath(dir, "a.jl"))
     end
-
-    files = read_path_into_textdocuments(filepath2uri(dir))
-    @test length(files) == 1
-    @test only(files).uri == filepath2uri(joinpath(dir, "a.jl"))
 end

--- a/test/test_fileio.jl
+++ b/test/test_fileio.jl
@@ -34,3 +34,21 @@ end
 
     @test read_path_into_textdocuments(filepath2uri(dir), file_limit=4) === nothing
 end
+
+@testitem "read_path_into_textdocuments skips .git and other VCS/dependency dirs" begin
+    using JuliaWorkspaces: read_path_into_textdocuments
+    using JuliaWorkspaces.URIs2: filepath2uri
+
+    dir = mktempdir()
+    write(joinpath(dir, "a.jl"), "a() = 1\n")
+
+    for skipped in (".git", ".svn", ".hg", "node_modules")
+        skipped_dir = joinpath(dir, skipped, "nested")
+        mkpath(skipped_dir)
+        write(joinpath(skipped_dir, "b.jl"), "b() = 2\n")
+    end
+
+    files = read_path_into_textdocuments(filepath2uri(dir))
+    @test length(files) == 1
+    @test only(files).uri == filepath2uri(joinpath(dir, "a.jl"))
+end


### PR DESCRIPTION
Fixes julia-vscode/LanguageServer.jl#1415

`read_path_into_textdocuments` walked the entire workspace tree with `walkdir(path, onerror=x -> x)`, discarding the `dirs` array that `walkdir` yields for pruning. This meant the scan always descended into `.git` (and any other VCS or dependency directory), which is harmless on a local disk but can turn into a multi-minute hang on cloud-synced/virtual filesystems,  where each entry under `.git/objects` can cost a network round-trip.

This captures `dirs` and filters out `.git`, `.svn`, `.hg`, and
`node_modules` before continuing the walk, so these directories are never
descended into. Added a test covering all four skipped directory names.