### PR TITLE
fix(staticlint): suppress missing refs in non-function scopes in macros

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1120,14 +1120,19 @@ function is_test_throws_macrocall(x::EXPR, env, meta_dict)
 end
 
 """
-    in_macrocall_arg(x::EXPR)
+    in_macrocall_arg(x::EXPR, env, meta_dict)
 
 True if walking up from `x` we reach a macrocall (with `x` in its argument list,
-not the macroname) without first crossing a scope-introducing expression
-(function/let/struct/...).
+not the macroname) without first crossing a function/macro definition.
 
-If a user-written scope sits between the identifier and the macrocall, we assume
-the macro respects normal Julia scoping.
+Macros wrapping a function definition (`@inline`, `@memoize`, …) rarely rewrite
+its body, so a definition in between re-enables checking. Other scope-introducing
+constructs (struct/let/...) don't: an unknown macro frequently reinterprets those
+(`@with_kw`-style field defaults), so they stay suppressed.
+
+Macros whose semantics the analysis models are transparent to the walk: the doc
+macro doesn't rewrite its argument, and `Base.@kwdef` field bindings are handled
+in `mark_bindings!`, so their contents are still checked.
 
 The BODY block of a fully-analyzed test macro (`@testitem`/`@testmodule`/
 `@testsnippet` get prebuilt scopes, `@testset`/`@safetestset` ordinary scopes)
@@ -1136,7 +1141,7 @@ does not suppress — the walk continues so an enclosing unknown macro still
 suppresses the whole construct. Their non-body args (name, kwargs) stay
 suppressed.
 """
-function in_macrocall_arg(x::EXPR)
+function in_macrocall_arg(x::EXPR, env, meta_dict)
     cur = x
     while parentof(cur) isa EXPR
         p = parentof(cur)
@@ -1149,12 +1154,14 @@ function in_macrocall_arg(x::EXPR)
                 cur = p
                 continue
             end
+            if headof(p.args[1]) === :globalrefdoc ||
+               _points_to_Base_macro(p.args[1], Symbol("@kwdef"), env, meta_dict)
+                cur = p
+                continue
+            end
             return true
         end
-        h = headof(p)
-        if h === :function || h === :macro || h === :for || h === :while ||
-           h === :let || h === :generator || h === :try || h === :do ||
-           h === :module || h === :abstract || h === :primitive || h === :struct
+        if headof(p) === :macro || CSTParser.defines_function(p)
             return false
         end
         cur = p
@@ -1199,7 +1206,7 @@ function collect_hints(x::EXPR, env, workspace_packages, meta_dict, missingrefs=
         elseif missingrefs != :none && isidentifier(x) && !hasref(x, meta_dict) &&
             !(valof(x) == "var" && parentof(x) isa EXPR && isnonstdid(parentof(x))) &&
             !((valof(x) == "stdcall" || valof(x) == "cdecl" || valof(x) == "fastcall" || valof(x) == "thiscall" || valof(x) == "llvmcall") && is_in_fexpr(x, x -> iscall(x) && isidentifier(x.args[1]) && valof(x.args[1]) == "ccall")) &&
-            !in_macrocall_arg(x) &&
+            !in_macrocall_arg(x, env, meta_dict) &&
             # inside using/import statements the UnresolvedImport marking
             # pass is the sole reporter
             !is_in_fexpr(x, y -> headof(y) === :using || headof(y) === :import) &&

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -4321,8 +4321,8 @@ end
         @test isempty(collect_hints(cst, meta_dict, jw))
     end
 
-    # But identifiers in a user-written local scope (here a function body, even
-    # when the function is wrapped by the doc macro) are still checked.
+    # But identifiers in a wrapped function definition (here doc-macro-wrapped)
+    # are still checked.
     let (cst, meta_dict, jw) = parse_and_pass("""
         \"\"\"
         docstring
@@ -4334,6 +4334,104 @@ end
         hints = collect_hints(cst, meta_dict, jw)
         @test length(hints) == 1
         @test CSTParser.valof(hints[1][2]) == "undefined_in_body"
+    end
+end
+
+@testitem "no missing refs in scoped constructs under unknown macro" setup=[shared_static_lint] begin
+    CSTParser = JuliaWorkspaces.CSTParser
+
+    # Unknown macros may rewrite struct bodies (`@with_kw`-style field
+    # defaults), so identifiers there must not be flagged.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        macro with_kw(x)
+            x
+        end
+        @with_kw struct Foo
+            a::T = 2
+            b::T = 2
+        end
+        @with_kw mutable struct Bar
+            a::T = 2
+        end
+        """)
+        @test isempty(collect_hints(cst, meta_dict, jw))
+    end
+
+    # Other non-function scopes stay suppressed too.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        macro foo(x)
+            x
+        end
+        @foo let
+            undefined_var
+        end
+        """)
+        @test isempty(collect_hints(cst, meta_dict, jw))
+    end
+
+    # Function definitions re-enable checking: macros wrapping a function
+    # (`@inline`-style) rarely rewrite its body.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        macro foo(x)
+            x
+        end
+        @foo function bar()
+            undefined_in_body
+        end
+        """)
+        hints = collect_hints(cst, meta_dict, jw)
+        @test length(hints) == 1
+        @test CSTParser.valof(hints[1][2]) == "undefined_in_body"
+    end
+
+    # Base macros with normal semantics keep function bodies fully linted.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        @inline function bar()
+            undefined_in_body
+        end
+        Base.@noinline baz() = another_undefined
+        @views function qux(x)
+            x[1:2] .+ yet_another_undefined
+        end
+        """)
+        hints = collect_hints(cst, meta_dict, jw)
+        @test map(h -> CSTParser.valof(h[2]), hints) ==
+            ["undefined_in_body", "another_undefined", "yet_another_undefined"]
+    end
+
+    # The doc macro doesn't rewrite its argument — a doc-wrapped struct body
+    # is still checked.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        \"\"\"
+        doc
+        \"\"\"
+        struct Foo
+            a::T
+        end
+        """)
+        hints = collect_hints(cst, meta_dict, jw)
+        @test length(hints) == 1
+        @test CSTParser.valof(hints[1][2]) == "T"
+    end
+
+    # `Base.@kwdef` field semantics are modeled — its struct body is still
+    # checked.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        Base.@kwdef struct Foo
+            a::T = 2
+        end
+        """)
+        hints = collect_hints(cst, meta_dict, jw)
+        @test length(hints) == 1
+        @test CSTParser.valof(hints[1][2]) == "T"
+    end
+
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        @kwdef struct Foo
+            a::Int = 2
+        end
+        """)
+        @test isempty(collect_hints(cst, meta_dict, jw))
     end
 end
 


### PR DESCRIPTION
Identifiers inside a macrocall argument were exempt from missing-ref suppression as soon as any scope-introducing expression (struct, let, for, ...) sat between them and the macrocall, so e.g. `@with_kw` structs with field defaults flagged every field and type. An unknown macro frequently reinterprets such constructs, so they no longer re-enable checking.

Function/macro definitions still do — macros wrapping a function (`@inline`, `@memoize`, ...) rarely rewrite its body — and short-form definitions now count as well, matching their long-form equivalents. Macros whose semantics the analysis models also stay checked: the doc macro is transparent to the walk, as is `Base.@kwdef` (field bindings handled in mark_bindings!), and test-macro bodies keep their existing handling.