### PR TITLE
Warn on dynamic includes and disable some other rules

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -302,7 +302,7 @@ in everyone's `default` at whatever severity a fallback happened to pick.
 | `const_decl` | `info` | Invalid `const` declarations and redefinitions |
 | `unused_binding` | `hint` | Variables assigned but never used |
 | `relative_import` | `info` | A relative import with more dots than available nesting |
-| `include_errors` | `warning` | Circular, duplicate, missing or unreadable `include`s |
+| `include_errors` | `warning` | Circular, duplicate, missing, unreadable, or statically unresolvable (computed-path) `include`s. A computed include also disables missing-reference checks in the module it appears in, since the included file's contents are unknown to the analyzer |
 | `missing_reference` | `warning` | Unresolved references. Option `scope`: `"none"`, `"symbols"`, `"all"` (default) |
 | `unresolved_import` | `warning` | Imports whose target could not be resolved |
 

--- a/src/StaticLint/StaticLint.jl
+++ b/src/StaticLint/StaticLint.jl
@@ -3,6 +3,7 @@ module StaticLint
 import ..derived_has_file
 import ..derived_julia_legacy_syntax_tree
 import ..derived_include_dict
+import ..derived_computed_include_ids
 import ..ItemRef
 import ..MethodArity
 
@@ -568,6 +569,24 @@ or a file exists on the disc that can be loaded.
 If this is successful it traverses the code associated with the loaded file.
 """
 function followinclude(x, state::Toplevel)
+    # A computed include splices UNKNOWN code into the enclosing module: any
+    # bare name there may be defined by the unseen file, so mark the module
+    # scope like an unresolved wildcard `using` (the ComputedInclude
+    # diagnostic at the include site is the user-visible explanation). This
+    # runs in BOTH traversal modes — the flag feeds `collect_hints` either
+    # way — and before the per-file early-return below.
+    if objectid(x) in derived_computed_include_ids(state.runtime, state.uri)
+        scope = retrieve_scope(x, state.meta_dict)
+        while scope isa Scope
+            if CSTParser.defines_module(scope.expr) || !(scope.parent isa Scope)
+                scope.unresolved_wildcard_import = true
+                break
+            end
+            scope = scope.parent
+        end
+        return
+    end
+
     # per-file traversal mode: included files are analyzed separately, their
     # names resolve through the module tree context
     state.follow_includes || return

--- a/src/StaticLint/includes.jl
+++ b/src/StaticLint/includes.jl
@@ -53,29 +53,57 @@ function get_path(x::EXPR, file_dir, meta_dict)
     return nothing
 end
 
-# Shared walker for include-call analyses. Calls `f(x, pos, target)` for every
-# `include(...)`/`includet(...)` call, where `pos` is the 0-based byte offset of
-# the call EXPR and `target` the resolved target `URI` or `nothing`. `file_dir`
-# may be `nothing` (a file without a filesystem path, e.g. an unsaved buffer), in
-# which case only absolute include paths resolve.
-function _walk_include_calls(f, x::EXPR, file_dir, pos)
-    if (CSTParser.fcall_name(x) == "include" || CSTParser.fcall_name(x) == "includet") && length(x.args) == 2
-        path = get_path(x, file_dir, nothing)
+# Shared walker for include-call analyses. Calls `f(x, pos, target, in_function)`
+# for every `include(...)`/`includet(...)` call, where `pos` is the 0-based byte
+# offset of the call EXPR and `target` the resolved target `URI` or `nothing`.
+# `file_dir` may be `nothing` (a file without a filesystem path, e.g. an unsaved
+# buffer), in which case only absolute include paths resolve.
+#
+# Calls inside function/macro bodies are reported with `in_function = true` and
+# always `target = nothing`: a runtime `include` splices into whichever module
+# the enclosing function is called from, so even a literal path has no static
+# splice context — it must never become an include-graph edge, but it IS the
+# "file structure not statically resolvable" signal (ComputedInclude). The
+# *signature* of such a definition is excluded, so custom `include` methods
+# (`include(p::AbstractPath) = ...`, FilePathsBase-style) are not reported.
+function _walk_include_calls(f, x::EXPR, file_dir, pos, in_function::Bool=false, skip::Union{Nothing,EXPR}=nothing)
+    x === skip && return nothing
 
+    if (CSTParser.fcall_name(x) == "include" || CSTParser.fcall_name(x) == "includet") && length(x.args) == 2
         target = nothing
-        if path !== nothing
-            if isabspath(path)
-                target = filepath2uri(path)
-            elseif file_dir !== nothing
-                target = filepath2uri(joinpath(file_dir, path))
+        if !in_function
+            path = get_path(x, file_dir, nothing)
+            if path !== nothing
+                if isabspath(path)
+                    target = filepath2uri(path)
+                elseif file_dir !== nothing
+                    target = filepath2uri(joinpath(file_dir, path))
+                end
             end
         end
 
-        f(x, pos, target)
-    elseif !(CSTParser.defines_function(x) || CSTParser.defines_macro(x) || headof(x) === :export || headof(x) === :public)
+        f(x, pos, target, in_function)
+    elseif CSTParser.defines_function(x) || CSTParser.defines_macro(x)
+        sig = try
+            CSTParser.get_sig(x)
+        catch
+            nothing
+        end
+        # `get_sig` returns the `where` wrapper for `f(x) where T` — unwrap to
+        # the call node so identity comparison excludes the signature itself.
+        while sig isa EXPR && headof(sig) === :where && sig.args !== nothing && !isempty(sig.args)
+            sig = sig.args[1]
+        end
+
         p = pos
         for i in 1:length(x)
-            _walk_include_calls(f, x[i], file_dir, p)
+            _walk_include_calls(f, x[i], file_dir, p, true, sig)
+            p += x[i].fullspan
+        end
+    elseif !(headof(x) === :export || headof(x) === :public)
+        p = pos
+        for i in 1:length(x)
+            _walk_include_calls(f, x[i], file_dir, p, in_function, skip)
             p += x[i].fullspan
         end
     end
@@ -101,8 +129,11 @@ e.g. an unsaved buffer) still resolves absolute include paths.
 """
 function collect_include_calls(cst::EXPR, file_path::Union{Nothing,String})
     results = Tuple{Int,Int,Union{URI,Nothing}}[]
-    _walk_include_calls(cst, _include_file_dir(file_path), 0) do x, pos, target
-        push!(results, (pos, x.span, target))
+    _walk_include_calls(cst, _include_file_dir(file_path), 0) do x, pos, target, in_function
+        # Top-level calls only, matching this function's historical contract;
+        # function-body (runtime) includes are an analysis signal, not part of
+        # the include graph.
+        in_function || push!(results, (pos, x.span, target))
     end
     return results
 end
@@ -121,18 +152,29 @@ Single-pass include analysis for one file. Walks `cst` once and returns a
     CST they were built from and must not outlive it.
   - `records::Vector` — `(offset, span, target)` tuples for every include call
     (including unresolved ones), in source order, for include-graph diagnostics.
+  - `computed_ids::Set{UInt64}` — the `objectid`s of include-call EXPRs whose
+    path could NOT be determined statically (computed includes), for the
+    semantic pass to mark the enclosing module scope. Same lifetime caveat as
+    `include_dict`.
 """
 function collect_include_analysis(cst::EXPR, file_path::Union{Nothing,String})
     edges = Set{URI}()
     include_dict = Dict{UInt64,URI}()
     records = Tuple{Int,Int,Union{URI,Nothing}}[]
-    _walk_include_calls(cst, _include_file_dir(file_path), 0) do x, pos, target
+    computed_ids = Set{UInt64}()
+    _walk_include_calls(cst, _include_file_dir(file_path), 0) do x, pos, target, _
+        # Function-body includes carry `target === nothing` by construction
+        # (see `_walk_include_calls`), so they land in `records` as computed
+        # includes — ComputedInclude diagnostics + suppression signals — but
+        # never become include-graph edges.
         push!(records, (pos, x.span, target))
         if target !== nothing
             push!(edges, target)
             include_dict[UInt64(objectid(x))] = target
+        else
+            push!(computed_ids, UInt64(objectid(x)))
         end
     end
-    return (; edges, include_dict, records)
+    return (; edges, include_dict, records, computed_ids)
 end
 

--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -37,6 +37,7 @@
     DuplicateInclude,
     FunctionHasNoMethods,
     UnresolvedImport,
+    ComputedInclude,
 )
 
 const LintCodeDescriptions = Dict{LintCodes,String}(
@@ -54,6 +55,7 @@ const LintCodeDescriptions = Dict{LintCodes,String}(
     IncludeLoop => "Circular include detected.",
     DuplicateInclude => "This file has already been included.",
     MissingFile => "The included file can not be found.",
+    ComputedInclude => "The include path could not be determined statically. The included file is analyzed without this module's context, and missing-reference checks are disabled in this module.",
     InvalidModuleName => "Module name matches that of its parent.",
     TypePiracy => "An imported function has been extended without using module defined typed arguments.",
     UnusedFunctionArgument => "An argument is included in a function signature but not used within its body.",

--- a/src/layer_file_analysis.jl
+++ b/src/layer_file_analysis.jl
@@ -744,6 +744,32 @@ frame reads the whole `derived_module_tree` value. Consequences:
   reference an actually-shifted name re-execute, and those MUST (their
   outbound `ItemRef`s change).
 """
+# Roots we can attribute a splice context to without an include edge: the
+# package entry file, standard tool entry points, and @testitem files (which
+# carry their own analysis context). Every OTHER root exists either because it
+# genuinely is a standalone script or because a computed include loads it —
+# indistinguishable statically.
+function _is_recognized_entry_point(rt, uri)
+    _file_has_testitems(rt, uri) && return true
+
+    fp = uri2filepath(uri)
+    fp === nothing && return false
+    name = lowercase(basename(fp))
+    dir = lowercase(basename(dirname(fp)))
+    name == "runtests.jl" && dir == "test" && return true
+    name == "make.jl" && dir == "docs" && return true
+
+    pkg_folder = derived_package_for_file(rt, uri)
+    if pkg_folder !== nothing
+        pkg = derived_package(rt, pkg_folder)
+        if pkg !== nothing
+            entry = joinpath(uri2filepath(pkg_folder), "src", "$(pkg.name).jl")
+            lowercase(fp) == lowercase(entry) && return true
+        end
+    end
+    return false
+end
+
 Salsa.@derived function derived_file_analysis(rt, root, file)
     @debug "derived_file_analysis" root=root file=file
 
@@ -785,7 +811,20 @@ Salsa.@derived function derived_file_analysis(rt, root, file)
     # keep their hints (matching the old pass's module-boundary rule). The
     # file's OWN failed wildcard usings need no help — `semantic_pass` +
     # `mark_unresolved_imports!` set the flag locally, as always.
-    if derived_module_unresolved_wildcard_using(rt, root, path)
+    # A computed `include` anywhere in the module is the same situation:
+    # unknown code is spliced into the module, so any bare name may be
+    # defined by the unseen file (the ComputedInclude diagnostic at the
+    # include site is the user-visible explanation).
+    # Third case: an ORPHAN root (no include edge reaches it, and it is not a
+    # recognizable entry point) inside a package that has a computed include
+    # somewhere is very likely the *target* of that include — its real module
+    # context (and the usings that come with it) is unknown, so bare
+    # missing-ref reporting against the bare context is unreliable.
+    if derived_module_unresolved_wildcard_using(rt, root, path) ||
+            derived_module_has_computed_include(rt, root, path) ||
+            (root == file && pkg_folder !== nothing &&
+                !_is_recognized_entry_point(rt, file) &&
+                derived_folder_has_computed_include(rt, pkg_folder))
         fscope = StaticLint.scopeof(cst, meta_dict)
         fscope isa StaticLint.Scope && (fscope.unresolved_wildcard_import = true)
     end

--- a/src/layer_includes.jl
+++ b/src/layer_includes.jl
@@ -17,7 +17,7 @@ Salsa.@derived function derived_file_include_data(rt, uri)
     @debug "derived_file_include_data" uri=uri
 
     tf = derived_text_file_content(rt, uri)
-    tf === nothing && return (edges=Set{URI}(), include_dict=Dict{UInt64,URI}(), records=Tuple{Int,Int,Union{URI,Nothing}}[])
+    tf === nothing && return (edges=Set{URI}(), include_dict=Dict{UInt64,URI}(), records=Tuple{Int,Int,Union{URI,Nothing}}[], computed_ids=Set{UInt64}())
 
     cst = derived_julia_legacy_syntax_tree(rt, uri)
 
@@ -34,6 +34,35 @@ end
 
 Salsa.@derived function derived_include_dict(rt, uri)
     return derived_file_include_data(rt, uri).include_dict
+end
+
+# `objectid`s of this file's computed (statically unresolvable) include calls;
+# consumed by `StaticLint.followinclude` to mark the enclosing module scope.
+Salsa.@derived function derived_computed_include_ids(rt, uri)
+    return derived_file_include_data(rt, uri).computed_ids
+end
+
+"""
+    derived_folder_has_computed_include(rt, folder_uri) -> Bool
+
+Whether any Julia file under `folder_uri` contains an `include` whose path
+could not be determined statically. Used to decide whether an orphan root (a
+file no other file includes) in that folder plausibly is the *target* of such
+an include — in which case it is analyzed without its real module context and
+bare missing-reference reporting there is unreliable. Bool-valued and id-free.
+"""
+Salsa.@derived function derived_folder_has_computed_include(rt, folder_uri)
+    folder_path = uri2filepath(folder_uri)
+    folder_path === nothing && return false
+    prefix = lowercase(folder_path) * Base.Filesystem.path_separator
+
+    for uri in derived_all_julia_files(rt)
+        fp = uri2filepath(uri)
+        fp === nothing && continue
+        startswith(lowercase(fp), prefix) || continue
+        any(r -> r[3] === nothing, derived_file_include_records(rt, uri)) && return true
+    end
+    return false
 end
 
 Salsa.@derived function derived_all_julia_files(rt)
@@ -237,7 +266,16 @@ function _collect_include_diagnostics!(rt, uri, stack, visited, result)
     push!(stack, uri)
 
     for (offset, span, target) in derived_file_include_records(rt, uri)
-        target === nothing && continue
+        if target === nothing
+            # A computed include path: the target file cannot be attributed,
+            # so it is analyzed without this module's context and bare
+            # missing-reference checking is unreliable in this module (see
+            # `derived_module_has_computed_include`). One honest diagnostic
+            # here replaces the storm of false missing_reference positives
+            # the unattributed file would otherwise produce.
+            push!(get!(result, uri, Diagnostic[]), _include_diagnostic(offset, span, StaticLint.ComputedInclude))
+            continue
+        end
 
         if derived_text_file_content(rt, target) === nothing
             push!(get!(result, uri, Diagnostic[]), _include_diagnostic(offset, span, StaticLint.MissingFile))

--- a/src/layer_visibility.jl
+++ b/src/layer_visibility.jl
@@ -1115,6 +1115,38 @@ Salsa.@derived function derived_module_unresolved_wildcard_using(rt, root, path)
     return false
 end
 
+"""
+    derived_module_has_computed_include(rt, root, path) -> Bool
+
+Whether module `path` in `root`'s tree contains an `include` whose path could
+not be determined statically (any declaring file). Such an include splices
+UNKNOWN code into exactly this module — any bare name used in the module may
+be defined by the unseen file — so bare missing-reference reporting there is
+meaningless noise, the same situation as an unresolved wildcard `using`
+(`derived_module_unresolved_wildcard_using` above). Consumers treat the two
+flags identically. Pollution does not propagate to nested modules: a Julia
+`module` does not inherit its parent's bindings, mirroring the module-boundary
+stop in `in_unresolved_wildcard_import_scope`.
+
+The user-visible explanation is the `ComputedInclude` diagnostic emitted at
+the include site (`_collect_include_diagnostics!`, layer_includes.jl).
+
+Bool-valued and id-free, like its wildcard sibling.
+"""
+Salsa.@derived function derived_module_has_computed_include(rt, root, path)
+    @debug "derived_module_has_computed_include" root=root path=path
+
+    tree = derived_module_tree(rt, root)
+    for (file_uri, file_splice) in tree.file_modules
+        inv = derived_file_inventory(rt, file_uri)
+        for inc in inv.includes
+            inc.target === nothing || continue
+            vcat(file_splice, inc.parent_module) == path && return true
+        end
+    end
+    return false
+end
+
 # Resolvability of one wildcard `using`'s target, mirroring what the
 # visibility passes would do with it: `:tree` targets always resolve;
 # `:external` targets resolve iff their store exists; `:unresolved` targets
@@ -1126,8 +1158,14 @@ end
 # names from its own deps — reporting bare missing references against it
 # produces storms of false positives (every export defined in a
 # computed-include file). Same conservatism as `_mark_cst_wildcard_using!`
-# on the whole-closure pass; drop both once the CST module view chases
-# computed includes and re-exports.
+# on the whole-closure pass.
+#
+# Deliberately NOT narrowed to `derived_module_has_computed_include(target)`:
+# that would cover the computed-include half but not macro-opaque re-exports
+# (`@reexport using InvertedIndices` — DataFrames' `Not`), which the
+# inventory cannot see. Narrow both together once export opacity is tracked;
+# drop entirely once the CST module view chases computed includes and
+# re-exports.
 function _wildcard_using_unresolved(rt, root, path::Vector{String}, ri::ResolvedImport)
     t = ri.target
     if t.sort === :tree

--- a/src/lint_rules.jl
+++ b/src/lint_rules.jl
@@ -164,6 +164,7 @@ const LINT_RULES = LintRule[
             StaticLint.IncludePathContainsNULL,
             StaticLint.FileTooBig,
             StaticLint.FileNotAvailable,
+            StaticLint.ComputedInclude,
         ]),
     LintRule(id = :missing_reference, tier = TierSemantic,
         severity_default = :warning, severity_strict = :warning,

--- a/test/test_includes.jl
+++ b/test/test_includes.jl
@@ -411,3 +411,200 @@ end
     @test JuliaWorkspaces.derived_has_content(rt, a_uri) == true
     @test isequal(JuliaWorkspaces.derived_include_closure(rt, root_uri), closure_before)
 end
+
+@testitem "computed include: ComputedInclude diagnostic is emitted at the include site" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    root_uri = URI("file:///computedincl/src/CompIncl.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///computedincl/Project.toml"), SourceText("""
+    name = "CompIncl"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeef01"
+    version = "0.1.0"
+    """, "toml")))
+    add_file!(jw, TextFile(URI("file:///computedincl/Manifest.toml"), SourceText("""
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """, "toml")))
+    add_file!(jw, TextFile(root_uri, SourceText("""
+    module CompIncl
+    for f in readdir(@__DIR__)
+        include(f)
+    end
+    end
+    """, "julia")))
+
+    diags = get_diagnostic(jw, root_uri)
+    @test count(d -> contains(d.message, "could not be determined statically"), diags) == 1
+end
+
+@testitem "computed include: custom include method definitions are not flagged" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    root_uri = URI("file:///customincl/src/CustIncl.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///customincl/Project.toml"), SourceText("""
+    name = "CustIncl"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeef02"
+    version = "0.1.0"
+    """, "toml")))
+    add_file!(jw, TextFile(URI("file:///customincl/Manifest.toml"), SourceText("""
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """, "toml")))
+    # FilePathsBase-style: method definitions ON `include` are signatures,
+    # not calls — never flagged. The runtime CALL inside `load`'s body IS a
+    # dynamic include (splices into an unknown module at call time), so it
+    # gets exactly one ComputedInclude.
+    add_file!(jw, TextFile(root_uri, SourceText("""
+    module CustIncl
+    struct MyPath end
+    include(path::MyPath) = 1
+    function include(mapexpr::Function, path::MyPath); 2; end
+    load(p) = include(p)
+    end
+    """, "julia")))
+
+    diags = get_diagnostic(jw, root_uri)
+    @test count(d -> contains(d.message, "could not be determined statically"), diags) == 1
+end
+
+@testitem "computed include: function-body includes flag and suppress like computed ones" begin
+    using JuliaWorkspaces: set_input_env_ready!
+    using JuliaWorkspaces.URIs2: URI
+
+    # ColorSchemes-style: literal-looking includes inside a loader function,
+    # data file is an orphan. Both the diagnostic and the orphan suppression
+    # must fire even though no top-level include exists.
+    root_uri = URI("file:///fnincl/src/FnIncl.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///fnincl/Project.toml"), SourceText("""
+    name = "FnIncl"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeef06"
+    version = "0.1.0"
+    """, "toml")))
+    add_file!(jw, TextFile(URI("file:///fnincl/Manifest.toml"), SourceText("""
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """, "toml")))
+    add_file!(jw, TextFile(root_uri, SourceText("""
+    module FnIncl
+    function loadall()
+        datadir = joinpath(dirname(@__DIR__), "data")
+        include(joinpath(datadir, "schemes.jl"))
+    end
+    end
+    """, "julia")))
+    orphan = URI("file:///fnincl/data/schemes.jl")
+    add_file!(jw, TextFile(orphan, SourceText("register(undefined_helper)\n", "julia")))
+
+    set_input_env_ready!(jw.runtime, true)
+
+    @test count(d -> contains(d.message, "could not be determined statically"), get_diagnostic(jw, root_uri)) == 1
+    @test !any(d -> contains(d.message, "undefined_helper"), get_diagnostic(jw, orphan))
+end
+
+@testitem "computed include: missing_reference suppressed in the polluted module only" begin
+    using JuliaWorkspaces: set_input_env_ready!
+    using JuliaWorkspaces.URIs2: URI
+
+    root_uri = URI("file:///pollutedmod/src/PollutedMod.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///pollutedmod/Project.toml"), SourceText("""
+    name = "PollutedMod"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeef03"
+    version = "0.1.0"
+    """, "toml")))
+    add_file!(jw, TextFile(URI("file:///pollutedmod/Manifest.toml"), SourceText("""
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """, "toml")))
+    add_file!(jw, TextFile(root_uri, SourceText("""
+    module PollutedMod
+    module Polluted
+    for f in ["x.jl"]
+        include(f)
+    end
+    p() = undefined_in_polluted
+    end
+    module Clean
+    c() = undefined_in_clean
+    end
+    end
+    """, "julia")))
+    set_input_env_ready!(jw.runtime, true)
+
+    msgs = [d.message for d in get_diagnostic(jw, root_uri)]
+    @test !any(contains("undefined_in_polluted"), msgs)
+    @test any(contains("undefined_in_clean"), msgs)
+end
+
+@testitem "computed include: orphan roots suppressed only in computed-include packages" begin
+    using JuliaWorkspaces: set_input_env_ready!
+    using JuliaWorkspaces.URIs2: URI
+
+    jw = JuliaWorkspace()
+    # Package A: entry has a computed include; data.jl is an orphan (nothing
+    # statically includes it) — it is very likely the computed include's
+    # target, so its bare missing refs are suppressed.
+    add_file!(jw, TextFile(URI("file:///orphA/Project.toml"), SourceText("""
+    name = "OrphA"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeef04"
+    version = "0.1.0"
+    """, "toml")))
+    add_file!(jw, TextFile(URI("file:///orphA/Manifest.toml"), SourceText("""
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """, "toml")))
+    add_file!(jw, TextFile(URI("file:///orphA/src/OrphA.jl"), SourceText("""
+    module OrphA
+    for f in ["data.jl"]
+        include(f)
+    end
+    end
+    """, "julia")))
+    orphan_a = URI("file:///orphA/src/data.jl")
+    add_file!(jw, TextFile(orphan_a, SourceText("a() = undefined_in_orpha\n", "julia")))
+
+    # Package B: fully static; loose.jl is an orphan by accident and keeps
+    # full checking.
+    add_file!(jw, TextFile(URI("file:///orphB/Project.toml"), SourceText("""
+    name = "OrphB"
+    uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeef05"
+    version = "0.1.0"
+    """, "toml")))
+    add_file!(jw, TextFile(URI("file:///orphB/Manifest.toml"), SourceText("""
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    project_hash = "abc123"
+
+    [deps]
+    """, "toml")))
+    add_file!(jw, TextFile(URI("file:///orphB/src/OrphB.jl"), SourceText("module OrphB\nend\n", "julia")))
+    orphan_b = URI("file:///orphB/src/loose.jl")
+    add_file!(jw, TextFile(orphan_b, SourceText("b() = undefined_in_orphb\n", "julia")))
+
+    set_input_env_ready!(jw.runtime, true)
+
+    @test !any(d -> contains(d.message, "undefined_in_orpha"), get_diagnostic(jw, orphan_a))
+    @test any(d -> contains(d.message, "undefined_in_orphb"), get_diagnostic(jw, orphan_b))
+end


### PR DESCRIPTION
If we come across a dynamic `include` call (say in a for loop), we now a) warn that we can't handle that and b) disable missing refs for anything that might be affected by that `include`.