### PR TITLE
index_from_length: only flag ranges that start at 1

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -285,7 +285,7 @@ in everyone's `default` at whatever severity a fallback happened to pick.
 | `environment_errors` | `info` | A project/test environment that could not be resolved, reported on its `Project.toml` |
 | `incorrect_call_args` | `info` | Wrong argument count/type; calls to method-less functions |
 | `incorrect_iter_spec` | `info` | Loop iterators that will likely error |
-| `index_from_length` | `info` | Indexing off `length`/`size` instead of `eachindex`/`axes` |
+| `index_from_length` | `info` | Indexing off `1:length(...)`/`1:size(...)` instead of `eachindex`/`axes`. Ranges that don't start at 1 (`2:length(x)`) are not flagged — they have no direct rewrite |
 | `nothing_comparison` | `info` | `== nothing` / `!= nothing` instead of `isnothing`/`===` |
 | `const_if_condition` | `info` | Boolean literal or unbracketed assignment as an `if` condition |
 | `pointless_boolean` | `info` | `&&`/`\|\|` whose first argument is a boolean literal |

--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -860,6 +860,12 @@ function check_incorrect_iter_spec(x, body, env, meta_dict)
         elseif iscall(rng) && valof(rng.args[1]) == ":" &&
             length(rng.args) === 3 &&
             headof(rng.args[2]) === :INTEGER &&
+            # Only `1:length(x)` has an `eachindex`/`axes` rewrite. A range
+            # starting elsewhere (`2:length(x)` — Horner tails, look-back
+            # loops using `x[i-1]`) cannot take the suggested fix, so the
+            # diagnostic would only be noise (40% of the flags in a top-100
+            # registry sweep were of this shape).
+            valof(rng.args[2]) == "1" &&
             iscall(rng.args[3]) &&
             length(rng.args[3].args) > 1 && (
                 refof(rng.args[3].args[1], meta_dict) === getsymbols(env)[:Base][:length] ||

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -3010,6 +3010,18 @@ end
     cst, meta_dict, jw = parse_and_pass("arr = []; [i for i in 1:length(arr)]")
     @test length(collect_hints(cst, meta_dict, jw)) == 0
 
+    # A range that doesn't start at 1 has no `eachindex`/`axes` rewrite
+    # (look-back loops, Horner tails) — not flagged.
+    cst, meta_dict, jw = parse_and_pass("arr = []; [arr[i] + arr[i-1] for i in 2:length(arr)]")
+    @test isempty(collect_hints(cst, meta_dict, jw))
+    cst, meta_dict, jw = parse_and_pass("""
+    arr = []
+    for i in 2:length(arr)
+        arr[i]
+    end
+    """)
+    @test isempty(collect_hints(cst, meta_dict, jw))
+
     cst, meta_dict, jw = parse_and_pass("""
     arr = []
     for _ in 1:length(arr)


### PR DESCRIPTION
From the top-100 registry lint sweep: `index_from_length` had a 0% false-positive rate but ~40% of its flags were not actionable — they fired on ranges like `2:length(x)` (look-back loops using `x[i-1]`, Horner tails), where the suggested `eachindex`/`axes` rewrite does not exist.

The check now additionally requires the range's start literal to be `1`, so every remaining flag can actually take the suggested rewrite.

- `check_incorrect_iter_spec` (StaticLint/linting/checks.jl): require `valof(rng.args[2]) == "1"` in the `IndexFromLength` branch
- tests: `2:length(arr)` comprehension and for-loop no longer flagged; existing `1:length` expectations unchanged
- docs: rule table entry clarified

Full suite: 1254/1256 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)