### PR TITLE
pointless_boolean: don't claim the literal is the first argument

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -48,7 +48,10 @@ const LintCodeDescriptions = Dict{LintCodes,String}(
     ConstIfCondition => "A boolean literal has been used as the conditional of an if statement - it will either always or never run.",
     EqInIfConditional => "Unbracketed assignment in if conditional statements is not allowed, did you mean to use ==?",
     PointlessOR => "The first argument of a `||` call is a boolean literal.",
-    PointlessAND => "The first argument of a `&&` call is a boolean literal.",
+    # check_lazy flags a literal in EITHER position of `&&`, so the message
+    # must not claim it is the first one (`iszero(x) && false` — a real
+    # pattern found in released packages — flags on the SECOND argument).
+    PointlessAND => "An argument of a `&&` call is a boolean literal.",
     UnusedBinding => "Variable has been assigned but not used.",
     InvalidTypeDeclaration => "A non-DataType has been used in a type declaration statement.",
     UnusedTypeParameter => "A DataType parameter has been specified but not used.",


### PR DESCRIPTION
From the top-100 registry lint sweep: `check_lazy` flags a boolean literal in EITHER position of `&&`, but the `PointlessAND` message always said "The first argument of a `&&` call is a boolean literal." — wrong for real findings like AbstractAlgebra's `iszero(a.unit) && false` (likely a missing `return`), where the literal is second.

Message is now position-neutral: "An argument of a `&&` call is a boolean literal." `PointlessOR` is unchanged (only the first argument is checked there, so its message is accurate).

Full suite: 1254/1256 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
