### PR TITLE
missing_reference: suppress inside isdefined/VERSION-guarded branches

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1174,6 +1174,52 @@ end
 # Is `x` inside a scope whose missing-ref checks are disabled by an
 # unresolved wildcard `using`? Stops at module boundaries, mirroring
 # `resolve_ref`: a nested `module` does not inherit its parent's usings.
+# Whether the CONDITION expression mentions an existence/version test:
+# `isdefined(...)`, `@isdefined x`, or a comparison involving `VERSION`.
+function _is_existence_guard(cond::EXPR)
+    if isidentifier(cond)
+        v = valofid(cond)
+        return v == "VERSION" || v == "isdefined"
+    end
+    if CSTParser.ismacrocall(cond) && length(cond.args) >= 1 &&
+            (valof(cond.args[1]) == "@isdefined" ||
+             (CSTParser.is_getfield_w_quotenode(cond.args[1]) && valof(rhs_of_getfield(cond.args[1])) == "@isdefined"))
+        return true
+    end
+    cond.args === nothing && return false
+    return any(a -> a isa EXPR && _is_existence_guard(a), cond.args)
+end
+
+"""
+    in_existence_guarded_branch(x::EXPR) -> Bool
+
+Is `x` inside a branch of an `if`/`elseif` (or the short-circuited side of
+`&&`/`||`) whose condition mentions `isdefined`, `@isdefined`, or `VERSION`?
+Such branches deliberately reference names that only exist on other Julia
+versions or when an optional binding is present — on the analyzing version
+one branch is dead code, so bare missing-reference reporting there is noise
+(`if isdefined(Base, :new_thing); new_thing() else old_thing() end` flags one
+side or the other no matter which Julia runs the analysis). The condition
+itself keeps full checking.
+"""
+function in_existence_guarded_branch(x::EXPR)
+    cur = x
+    while parentof(cur) isa EXPR
+        p = parentof(cur)
+        if headof(p) in (:if, :elseif) && p.args !== nothing && length(p.args) >= 1 &&
+                cur !== p.args[1] && p.args[1] isa EXPR && _is_existence_guard(p.args[1])
+            return true
+        end
+        if isbinarysyntax(p) && (valof(headof(p)) == "&&" || valof(headof(p)) == "||") &&
+                length(p.args) == 2 && cur === p.args[2] &&
+                p.args[1] isa EXPR && _is_existence_guard(p.args[1])
+            return true
+        end
+        cur = p
+    end
+    return false
+end
+
 function in_unresolved_wildcard_import_scope(x::EXPR, meta_dict)
     sc = retrieve_scope(x, meta_dict)
     while sc isa Scope
@@ -1212,7 +1258,8 @@ function collect_hints(x::EXPR, env, workspace_packages, meta_dict, missingrefs=
             # inside using/import statements the UnresolvedImport marking
             # pass is the sole reporter
             !is_in_fexpr(x, y -> headof(y) === :using || headof(y) === :import) &&
-            !in_unresolved_wildcard_import_scope(x, meta_dict)
+            !in_unresolved_wildcard_import_scope(x, meta_dict) &&
+            !in_existence_guarded_branch(x)
             push!(errs, (pos, x))
         end
     elseif isquoted && missingrefs == :all && should_mark_missing_getfield_ref(x, env, workspace_packages, meta_dict)

--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1174,58 +1174,81 @@ end
 # Is `x` inside a scope whose missing-ref checks are disabled by an
 # unresolved wildcard `using`? Stops at module boundaries, mirroring
 # `resolve_ref`: a nested `module` does not inherit its parent's usings.
-# Whether the CONDITION expression mentions an existence/version test:
-# `isdefined(...)`, `@isdefined x`, or a comparison involving `VERSION`.
-function _is_existence_guard(cond::EXPR)
-    if isidentifier(cond)
-        v = valofid(cond)
-        return v == "VERSION" || v == "isdefined"
-    end
-    if CSTParser.ismacrocall(cond) && length(cond.args) >= 1 &&
-            (valof(cond.args[1]) == "@isdefined" ||
-             (CSTParser.is_getfield_w_quotenode(cond.args[1]) && valof(rhs_of_getfield(cond.args[1])) == "@isdefined"))
-        return true
-    end
-    cond.args === nothing && return false
-    return any(a -> a isa EXPR && _is_existence_guard(a), cond.args)
-end
-
-"""
-    in_existence_guarded_branch(x::EXPR) -> Bool
-
-Is `x` inside a branch of an `if`/`elseif` (or the short-circuited side of
-`&&`/`||`) whose condition mentions `isdefined`, `@isdefined`, or `VERSION`?
-Such branches deliberately reference names that only exist on other Julia
-versions or when an optional binding is present — on the analyzing version
-one branch is dead code, so bare missing-reference reporting there is noise
-(`if isdefined(Base, :new_thing); new_thing() else old_thing() end` flags one
-side or the other no matter which Julia runs the analysis). The condition
-itself keeps full checking.
-"""
-function in_existence_guarded_branch(x::EXPR)
-    cur = x
-    while parentof(cur) isa EXPR
-        p = parentof(cur)
-        if headof(p) in (:if, :elseif) && p.args !== nothing && length(p.args) >= 1 &&
-                cur !== p.args[1] && p.args[1] isa EXPR && _is_existence_guard(p.args[1])
-            return true
-        end
-        if isbinarysyntax(p) && (valof(headof(p)) == "&&" || valof(headof(p)) == "||") &&
-                length(p.args) == 2 && cur === p.args[2] &&
-                p.args[1] isa EXPR && _is_existence_guard(p.args[1])
-            return true
-        end
-        cur = p
-    end
-    return false
-end
-
 function in_unresolved_wildcard_import_scope(x::EXPR, meta_dict)
     sc = retrieve_scope(x, meta_dict)
     while sc isa Scope
         sc.unresolved_wildcard_import && return true
         CSTParser.defines_module(sc.expr) && return false
         sc = parentof(sc)
+    end
+    return false
+end
+
+# Does `x` reference `Base.name` (or the `Core.name` Base re-exports)? Goes
+# through the resolved binding, so a quoted `:isdefined`, a config's own
+# `.VERSION` field, or a local definition shadowing the name is not a guard.
+# (`_points_to_arbitrary_macro` is a module-binding lookup despite its name, and
+# handles the qualified spelling.)
+function _refers_to_base_name(x::EXPR, name::Symbol, env, meta_dict)
+    # `rhs_of_getfield` passes plain identifiers through, so one test covers
+    # both `VERSION` and `Base.VERSION` - and keeps the lookups below off the
+    # condition nodes that aren't spelled like a guard in the first place.
+    id = rhs_of_getfield(x)
+    (isidentifier(id) && Symbol(valofid(id)) === name) || return false
+    return _points_to_arbitrary_macro(x, :Base, name, env, meta_dict) ||
+        _points_to_arbitrary_macro(x, :Core, name, env, meta_dict)
+end
+
+# Whether the CONDITION expression contains an existence/version test:
+# `isdefined(...)`, `@isdefined x`, or a comparison against `VERSION`.
+function _is_existence_guard(cond::EXPR, env, meta_dict)
+    if _refers_to_base_name(cond, :VERSION, env, meta_dict)
+        return true
+    elseif iscall(cond) && length(cond.args) >= 1 && cond.args[1] isa EXPR &&
+            _refers_to_base_name(cond.args[1], :isdefined, env, meta_dict)
+        return true
+    elseif CSTParser.ismacrocall(cond) && length(cond.args) >= 1 && cond.args[1] isa EXPR &&
+            _refers_to_base_name(cond.args[1], Symbol("@isdefined"), env, meta_dict)
+        return true
+    end
+    cond.args === nothing && return false
+    return any(a -> a isa EXPR && _is_existence_guard(a, env, meta_dict), cond.args)
+end
+
+"""
+    in_existence_guarded_branch(x::EXPR, env, meta_dict) -> Bool
+
+Is `x` inside a branch of an `if`/`elseif` (or the short-circuited side of
+`&&`/`||`) whose condition tests `isdefined`, `@isdefined`, or `VERSION`?
+Such branches deliberately reference names that only exist on other Julia
+versions or when an optional binding is present — on the analyzing version
+one branch is dead code, so missing-reference reporting there is noise
+(`if isdefined(Base, :new_thing); new_thing() else old_thing() end` flags one
+side or the other no matter which Julia runs the analysis).
+
+Since the condition isn't evaluated, no branch of the construct is judged:
+`else` and `elseif` arms are suppressed along with the guarded one, and so are
+the `elseif` conditions, which only run when an earlier arm was not taken. The
+guarding condition itself keeps full checking.
+
+Guard names are matched through their resolved bindings, so code that merely
+borrows the spelling (`mode === :isdefined`, a config's own `.VERSION` field, a
+local `isdefined`) is not a guard.
+"""
+function in_existence_guarded_branch(x::EXPR, env, meta_dict)
+    cur = x
+    while parentof(cur) isa EXPR
+        p = parentof(cur)
+        if headof(p) in (:if, :elseif) && p.args !== nothing && length(p.args) >= 1 &&
+                cur !== p.args[1] && p.args[1] isa EXPR && _is_existence_guard(p.args[1], env, meta_dict)
+            return true
+        end
+        if isbinarysyntax(p) && (valof(headof(p)) == "&&" || valof(headof(p)) == "||") &&
+                length(p.args) == 2 && cur === p.args[2] &&
+                p.args[1] isa EXPR && _is_existence_guard(p.args[1], env, meta_dict)
+            return true
+        end
+        cur = p
     end
     return false
 end
@@ -1249,8 +1272,13 @@ function collect_hints(x::EXPR, env, workspace_packages, meta_dict, missingrefs=
         push!(errs, (pos, x))
     elseif !isquoted
         if haserror(x, meta_dict) && errorof(x, meta_dict) isa StaticLint.LintCodes
-            # collect lint hints
-            push!(errs, (pos, x))
+            # collect lint hints - except an UnresolvedImport under an
+            # existence guard, which is the missing-reference report for
+            # using/import statements and is suppressed like the bare names
+            # below. Other lint codes don't depend on which branch runs.
+            if !(errorof(x, meta_dict) === UnresolvedImport && in_existence_guarded_branch(x, env, meta_dict))
+                push!(errs, (pos, x))
+            end
         elseif missingrefs != :none && isidentifier(x) && !hasref(x, meta_dict) &&
             !(valof(x) == "var" && parentof(x) isa EXPR && isnonstdid(parentof(x))) &&
             !((valof(x) == "stdcall" || valof(x) == "cdecl" || valof(x) == "fastcall" || valof(x) == "thiscall" || valof(x) == "llvmcall") && is_in_fexpr(x, x -> iscall(x) && isidentifier(x.args[1]) && valof(x.args[1]) == "ccall")) &&
@@ -1259,10 +1287,11 @@ function collect_hints(x::EXPR, env, workspace_packages, meta_dict, missingrefs=
             # pass is the sole reporter
             !is_in_fexpr(x, y -> headof(y) === :using || headof(y) === :import) &&
             !in_unresolved_wildcard_import_scope(x, meta_dict) &&
-            !in_existence_guarded_branch(x)
+            !in_existence_guarded_branch(x, env, meta_dict)
             push!(errs, (pos, x))
         end
-    elseif isquoted && missingrefs == :all && should_mark_missing_getfield_ref(x, env, workspace_packages, meta_dict)
+    elseif isquoted && missingrefs == :all && should_mark_missing_getfield_ref(x, env, workspace_packages, meta_dict) &&
+            !in_existence_guarded_branch(x, env, meta_dict)
         push!(errs, (pos, x))
     end
 

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -4773,6 +4773,10 @@ end
         cst, meta_dict, jw = parse_and_pass(src)
         [CSTParser.valof(x) for (_, x) in collect_hints(cst, meta_dict, jw) if CSTParser.isidentifier(x)]
     end
+    hint_codes(src) = begin
+        cst, meta_dict, jw = parse_and_pass(src)
+        [SL.errorof(x, meta_dict) for (_, x) in collect_hints(cst, meta_dict, jw) if SL.errorof(x, meta_dict) isa SL.LintCodes]
+    end
 
     # Names in either branch of an isdefined-guarded `if` only exist on some
     # Julia versions — one branch is always dead code on the analyzing
@@ -4784,25 +4788,95 @@ end
             legacy_fallback()
         end
         """))
+    # A bare (non-`@static`) version guard — `@static` bodies are already
+    # covered by `in_macrocall_arg`, so this is what exercises the walk.
+    @test isempty(hint_names("""
+        if VERSION < v"1.6"
+            pre16_only_name()
+        end
+        """))
     @test isempty(hint_names("""
         @static if VERSION < v"1.6"
             pre16_only_name()
         end
         """))
+    # Qualified references in a guarded branch — the common spelling of the
+    # idiom, since a name that only exists elsewhere can't be used bare.
+    @test isempty(hint_names("""
+        if isdefined(Base, :notarealname_xyz)
+            Base.notarealname_xyz()
+        end
+        """))
+    # `using`/`import` under a guard: reported by the UnresolvedImport
+    # marking pass, suppressed here for the same reason.
+    @test SL.UnresolvedImport ∉ hint_codes("""
+        if isdefined(Base, :NotARealModXYZ)
+            using Base.NotARealModXYZ
+        end
+        """)
+    @test SL.UnresolvedImport ∉ hint_codes("""
+        @static if VERSION >= v"9.11"
+            using Base.NotARealModXYZ
+        end
+        """)
+    # Other lint codes don't depend on which branch runs, so a guard does not
+    # silence them.
+    @test SL.NothingEquality in hint_codes("""
+        if VERSION < v"1.6"
+            x = nothing == 1
+        end
+        """)
     # Short-circuit form.
     @test isempty(hint_names("isdefined(Base, :foo) && guarded_use()"))
     @test isempty(hint_names("VERSION < v\"1.4\" || modern_only()"))
 
-    # Unguarded conditions keep full checking...
-    @test "unguarded_name" in hint_names("""
-        if some_flag
-            unguarded_name()
-        end
-        """) || "some_flag" in hint_names("""
+    # Unguarded conditions keep full checking, in the condition and the body.
+    unguarded = hint_names("""
         if some_flag
             unguarded_name()
         end
         """)
-    # ...and the guard's own condition does too.
+    @test "unguarded_name" in unguarded
+    @test "some_flag" in unguarded
+    # ...and so does the guard's own condition.
     @test "not_a_guard" in hint_names("if isdefined(Base, :x) & not_a_guard\nend")
+
+    # A guard is recognized by what the condition's names resolve to, not by
+    # spelling: a quoted `:isdefined` symbol, a non-Base `.VERSION` field and
+    # locally shadowed names are ordinary code and must not disable checking.
+    @test "misspeled_function" in hint_names("""
+        mode = :a
+        if mode === :isdefined
+            misspeled_function()
+        end
+        """)
+    @test "misspeled_function" in hint_names("""
+        cfg = (VERSION = 3,)
+        if cfg.VERSION > 2
+            misspeled_function()
+        end
+        """)
+    @test "misspeled_function" in hint_names("""
+        isdefined(x) = x > 1
+        if isdefined(2)
+            misspeled_function()
+        end
+        """)
+    @test "misspeled_function" in hint_names("""
+        VERSION = 3
+        if VERSION > 2
+            misspeled_function()
+        end
+        """)
+    # Explicitly qualified guards still count.
+    @test isempty(hint_names("""
+        if Base.VERSION < v"1.6"
+            pre16_only_name()
+        end
+        """))
+    @test isempty(hint_names("""
+        if Base.isdefined(Base, :contains)
+            only_when_defined()
+        end
+        """))
 end

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -4764,3 +4764,45 @@ end
     @test spec_error("x = 1\nfor i in x\nend\n") === SL.IncorrectIterSpec
     @test spec_error("x = \"s\"\nfor i in x\nend\n") === nothing
 end
+
+@testitem "missing refs suppressed in isdefined/VERSION-guarded branches" setup=[shared_static_lint] begin
+    SL = JuliaWorkspaces.StaticLint
+    CSTParser = JuliaWorkspaces.CSTParser
+
+    hint_names(src) = begin
+        cst, meta_dict, jw = parse_and_pass(src)
+        [CSTParser.valof(x) for (_, x) in collect_hints(cst, meta_dict, jw) if CSTParser.isidentifier(x)]
+    end
+
+    # Names in either branch of an isdefined-guarded `if` only exist on some
+    # Julia versions — one branch is always dead code on the analyzing
+    # version, so neither side reports bare missing refs.
+    @test isempty(hint_names("""
+        if isdefined(Base, :contains)
+            only_when_defined()
+        else
+            legacy_fallback()
+        end
+        """))
+    @test isempty(hint_names("""
+        @static if VERSION < v"1.6"
+            pre16_only_name()
+        end
+        """))
+    # Short-circuit form.
+    @test isempty(hint_names("isdefined(Base, :foo) && guarded_use()"))
+    @test isempty(hint_names("VERSION < v\"1.4\" || modern_only()"))
+
+    # Unguarded conditions keep full checking...
+    @test "unguarded_name" in hint_names("""
+        if some_flag
+            unguarded_name()
+        end
+        """) || "some_flag" in hint_names("""
+        if some_flag
+            unguarded_name()
+        end
+        """)
+    # ...and the guard's own condition does too.
+    @test "not_a_guard" in hint_names("if isdefined(Base, :x) & not_a_guard\nend")
+end


### PR DESCRIPTION
From the top-100 registry lint sweep (~15% of sampled `missing_reference` false positives): code guarded by `isdefined(...)`, `@isdefined`, or a `VERSION` comparison deliberately references names that only exist on other Julia versions or when an optional binding is present. One branch of such an `if` is always dead code on the analyzing Julia, so one side or the other flags no matter what (LaTeXStrings' pre-1.6 fallback, Formatting's `VERSION < v"1.4"` Printf branch, GR's guarded `import`).

New `in_existence_guarded_branch` guard in `collect_hints`' missing-reference condition: any enclosing `if`/`elseif` branch (or the short-circuited side of `&&`/`||`) whose condition mentions `isdefined`/`@isdefined`/`VERSION` suppresses bare missing-ref reporting. The condition expression itself keeps full checking.

Accepted cost: genuinely wrong names inside such guards are no longer reported — the guard declares "this code is version-dependent", which the analyzer cannot adjudicate.

Tests: both branches of an `isdefined` if, `@static if VERSION`, both short-circuit forms; unguarded conditions and the guard condition itself still report.

Full suite: 1255/1257 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
