### PR TITLE
const_decl: consts in mutually exclusive if branches are not redeclarations

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1449,6 +1449,15 @@ function check_const_decl(name::String, b::Binding, scope, meta_dict)
 
     b.val isa Binding && return check_const_decl(name, b.val, scope, meta_dict)
     if b.val isa EXPR && (CSTParser.defines_datatype(b.val) || is_const(b))
+        # Mutually exclusive `if`/`elseif`/`else` branches (the standard
+        # platform/version-conditional `const` idiom, usually under
+        # `@static if`) never both execute, so a const/datatype declared once
+        # per branch is not a redeclaration — the same exemption the
+        # InvalidRedefofConst arm below already applies.
+        prev = scope.names[name]
+        if prev isa Binding && prev.val isa EXPR && !in_same_if_branch(b.val, prev.val)
+            return
+        end
         seterror!(b.name, CannotDeclareConst, meta_dict)
     else
         prev = scope.names[name]

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -1467,6 +1467,44 @@ end
     @test !any_error(cst, meta_dict, CannotDeclareConst)
 end
 
+@testitem "const decls in exclusive if branches are not redeclarations" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, CannotDeclareConst
+
+    any_error(x, meta_dict, err) =
+        errorof(x, meta_dict) === err ||
+        (x.args !== nothing && any(a -> any_error(a, meta_dict, err), x.args))
+
+    # The standard platform/version-conditional idiom: only one branch ever
+    # executes, so one `const` per branch is a single declaration.
+    cst, meta_dict = parse_and_pass("""
+        if Sys.iswindows()
+            const libpath = "a.dll"
+        else
+            const libpath = "a.so"
+        end
+        """)
+    @test !any_error(cst, meta_dict, CannotDeclareConst)
+
+    # Mixed shapes across branches (const in one, function in the other).
+    cst, meta_dict = parse_and_pass("""
+        @static if VERSION >= v"1.12"
+            const task_local_thing = 1
+        else
+            function task_local_thing end
+        end
+        """)
+    @test !any_error(cst, meta_dict, CannotDeclareConst)
+
+    # Two consts in the SAME branch still flag.
+    cst, meta_dict = parse_and_pass("""
+        if Sys.iswindows()
+            const zz = 1
+            const zz = 2
+        end
+        """)
+    @test any_error(cst, meta_dict, CannotDeclareConst)
+end
+
 @testitem "const redefinition invalid redefinition" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: getmeta, InvalidRedefofConst
 


### PR DESCRIPTION
From the top-100 registry lint sweep: `const_decl` sampled at ~100% false positives, and roughly half traced to one gap — the standard platform/version-conditional idiom

```julia
@static if Sys.iswindows()
    const libpath = "a.dll"
else
    const libpath = "a.so"
end
```

flagged `CannotDeclareConst` on the second branch (OpenSSL, FilePathsBase, JLLWrappers, SortingAlgorithms, Parsers, URIs…). `check_const_decl` already exempts mutually exclusive `if` branches in its `InvalidRedefofConst` arm via `in_same_if_branch`; the `CannotDeclareConst` arm lacked the same exemption. This applies it there too.

Tests: const-per-branch and const-vs-`function` across `@static if` branches no longer flag; two consts in the *same* branch still do; existing redeclaration tests unchanged.

Full suite: 1255/1257 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
