### PR TITLE
invalid_type_declaration: accept const type aliases

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1010,11 +1010,40 @@ function is_never_datatype(b::Binding, env::ExternalEnv)
     return false
 end
 
+# A `const Alias = SomeType` binding IS a type even though the binding's
+# inferred `type` slot is not the DataType lattice value: its assigned VALUE
+# is a type. Unwraps `where`/`curly` so parameterised aliases
+# (`const OffsetVector = OffsetArray{T, 1} where T`) count too.
+function _binding_assigned_from_type(b::Binding, env::ExternalEnv, meta_dict)
+    (b.val isa EXPR && CSTParser.isassignment(b.val) && length(b.val.args) == 2) || return false
+    rhs = b.val.args[2]
+    while rhs isa EXPR && (headof(rhs) === :where || headof(rhs) === :curly) &&
+            rhs.args !== nothing && !isempty(rhs.args)
+        rhs = rhs.args[1]
+    end
+    rhs isa EXPR || return false
+    r = refof_maybe_getfield(rhs, meta_dict)
+    r isa SymbolServer.DataTypeStore && return true
+    # Env types commonly resolve to their CONSTRUCTOR FunctionStore
+    # (`Int16`) — `resolves_to_datatype` follows `extends` to the type.
+    r isa SymbolServer.FunctionStore && return resolves_to_datatype(r, env)
+    r isa Binding || return false
+    return CoreTypes.isdatatype(r.type) ||
+        r.val isa SymbolServer.DataTypeStore ||
+        (r.val isa EXPR && CSTParser.defines_datatype(r.val))
+end
+
 function check_datatype_decl(x::EXPR, env::ExternalEnv, meta_dict)
     # Only call in function signatures?
     if isdeclaration(x) && parentof(x) isa EXPR && iscall(parentof(x))
         if (dt = refof_maybe_getfield(last(x.args), meta_dict)) !== nothing
-            if is_never_datatype(dt, env)
+            # const type aliases (`const ReturnCode = Int16`) resolve to a
+            # Binding whose inferred type is not DataType — but they are
+            # valid in declarations, and were ~all of this rule's sampled
+            # false positives in a top-100 registry sweep.
+            if dt isa Binding && _binding_assigned_from_type(dt, env, meta_dict)
+                # valid type alias
+            elseif is_never_datatype(dt, env)
                 seterror!(x, InvalidTypeDeclaration, meta_dict)
             end
         elseif CSTParser.isliteral(last(x.args))

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -1779,6 +1779,38 @@ end
     @test errorof(cst.args[7].args[1].args[2], meta_dict) === InvalidTypeDeclaration
 end
 
+@testitem "const type aliases are valid in type declarations" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, InvalidTypeDeclaration
+
+    any_error(x, meta_dict, err) =
+        errorof(x, meta_dict) === err ||
+        (x.args !== nothing && any(a -> any_error(a, meta_dict, err), x.args))
+
+    # `const Alias = SomeType` resolves to a Binding whose inferred type is
+    # not DataType (env types resolve to their constructor FunctionStore),
+    # but the alias IS a type and must be accepted in declarations.
+    cst, meta_dict = parse_and_pass("""
+        const ReturnCode = Int16
+        g(r::ReturnCode) = r
+        """)
+    @test !any_error(cst, meta_dict, InvalidTypeDeclaration)
+
+    # Parameterised alias of a local struct, `where`-wrapped.
+    cst, meta_dict = parse_and_pass("""
+        struct A{T, N} end
+        const AVec = A{T, 1} where T
+        g(v::AVec) = v
+        """)
+    @test !any_error(cst, meta_dict, InvalidTypeDeclaration)
+
+    # A genuine non-type still flags.
+    cst, meta_dict = parse_and_pass("""
+        const notatype = sin
+        g(x::notatype) = x
+        """)
+    @test any_error(cst, meta_dict, InvalidTypeDeclaration)
+end
+
 @testitem "interpret @eval" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: scopeof, scopehasbinding, errorof, IncorrectCallArgs
 


### PR DESCRIPTION
From the top-100 registry lint sweep: `invalid_type_declaration` sampled at 100% false positives, with const type aliases as a confirmed mechanism — `const ReturnCode = Int16` followed by `g(r::ReturnCode)` flags because the alias binding's inferred type is `Function`: env types like `Int16` resolve to their **constructor `FunctionStore`**, so `is_never_datatype`'s refs-based fallback condemns the binding (reproduced end-to-end; Parsers' `ReturnCode` at `src/utils.jl:75/78/79` is exactly this).

`check_datatype_decl` now consults a new `_binding_assigned_from_type` first: a binding assigned from a `DataTypeStore`, a constructor `FunctionStore` that `resolves_to_datatype`, or a workspace datatype binding — unwrapping `where`/`curly`, so parameterised aliases (`const AVec = A{T, 1} where T`, the OffsetArrays `OffsetVector` shape) count too. Aliases of genuine non-types (`const notatype = sin`) still flag.

Tests: plain alias, where-wrapped parameterised alias of a local struct, and the non-type control.

Full suite: 1255/1257 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
