### PR TITLE
invalid_type_declaration: constructor definitions don't shadow their type

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1058,12 +1058,39 @@ function is_never_datatype(b::Binding, env::ExternalEnv, meta_dict=nothing, dept
         r isa Binding && return is_never_datatype(r, env, meta_dict, depth + 1)
         return is_never_datatype(r, env)
     end
+    # A curly-parameterised function definition (`Fill{T, N}(x) = ...`) is a
+    # CONSTRUCTOR: its name necessarily denotes a type. `@eval` constructor
+    # loops hoist such definitions as bindings that SHADOW the type's own
+    # binding with an assignment inferred as `Function` (FillArrays'
+    # `$STYPE{T, N}(F::$TYPE{T, N}) = F` shadowed `AbstractFill`, flagging
+    # all 53 later `::AbstractFill` declarations in the file), so a
+    # constructor-shaped `val` must count as a type, not a function.
+    if b.val isa EXPR && _defines_constructor_method(b.val)
+        return false
+    end
     if b.type !== nothing
         if !any(x -> x isa SymbolServer.DataTypeStore, get_eventual_datatype(ref, env) for ref in b.refs)
             return true
         end
     end
     return false
+end
+
+# Whether `x` defines a method whose signature name is curly-parameterised
+# (`Name{...}(...)`) — an unambiguous constructor definition.
+function _defines_constructor_method(x::EXPR)
+    CSTParser.defines_function(x) || return false
+    sig = CSTParser.get_sig(x)
+    while sig isa EXPR && (headof(sig) === :where || isbracketed(sig)) &&
+            sig.args !== nothing && !isempty(sig.args)
+        sig = sig.args[1]
+    end
+    (sig isa EXPR && iscall(sig) && sig.args !== nothing && !isempty(sig.args)) || return false
+    name = sig.args[1]
+    while name isa EXPR && isbracketed(name) && name.args !== nothing && !isempty(name.args)
+        name = name.args[1]
+    end
+    return name isa EXPR && headof(name) === :curly
 end
 
 function check_datatype_decl(x::EXPR, env::ExternalEnv, meta_dict)

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -1858,6 +1858,35 @@ end
     @test errorof(cst.args[7].args[1].args[2], meta_dict) === InvalidTypeDeclaration
 end
 
+@testitem "constructor definitions do not shadow the type in declarations" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, InvalidTypeDeclaration
+
+    any_error(x, meta_dict, err) =
+        errorof(x, meta_dict) === err ||
+        (x.args !== nothing && any(a -> any_error(a, meta_dict, err), x.args))
+
+    # A curly-parameterised method (`Fill{T, N}(x) = ...`) is a constructor;
+    # even when an @eval loop hoists it as a binding that shadows the type's
+    # own binding (inferred `Function`), the name still denotes a type.
+    cst, meta_dict = parse_and_pass("""
+        abstract type AbstractFill{T, N} end
+        struct Fill{T, N} <: AbstractFill{T, N} end
+        for TYPE in (:Fill,)
+            @eval (AbstractFill{T, N}(F::(\$TYPE){T, N}) where {T, N}) = F
+        end
+        g(A::AbstractFill) = A
+        h(F::Fill) = F
+        """)
+    @test !any_error(cst, meta_dict, InvalidTypeDeclaration)
+
+    # A genuine non-type is still flagged.
+    cst, meta_dict = parse_and_pass("""
+        notype() = 1
+        g(x::notype) = x
+        """)
+    @test any_error(cst, meta_dict, InvalidTypeDeclaration)
+end
+
 @testitem "interpret @eval" setup=[shared_static_lint] begin
     using JuliaWorkspaces.StaticLint: scopeof, scopehasbinding, errorof, IncorrectCallArgs
 


### PR DESCRIPTION
From the 2026-08-11 top-100 rerun (`invalid_type_declaration` 142 rows, 100% FP sampled): the dominant mechanism turned out NOT to be UnionAll rejection per se, but constructor shadowing. Debugged end-to-end on FillArrays:

```julia
for (Typ, ...) in (...)
    @eval ($STYPE){T, N}(F::($TYPE){T, N}) where {T, N} = F
end
```

`interpret_eval` hoists the interpolated constructor definition as a binding named `AbstractFill` whose `val` is the assignment — inferred type `Function` — and that binding **shadows the abstract type's own binding** in the module scope. Every later `x::AbstractFill` declaration then resolves to the Function-typed binding and `is_never_datatype`'s refs fallback flags it: 53 diagnostics in FillArrays' entry file alone; same story in OffsetArrays/StaticArrays.

Fix: a curly-parameterised method definition (`Name{...}(...) = ...`) is unambiguously a constructor, so its name denotes a type — `is_never_datatype` now returns `false` for bindings whose `val` is such a definition (new `_defines_constructor_method`, unwrapping `where`/brackets).

Verified: FillArrays entry file 53 → 0 `invalid_type_declaration` diagnostics via `workspace_from_folders` on the real package; genuine non-types (`g(x::notatype)`) still flag. Full suite: 1268/1270 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
