### PR TITLE
Bind where-clause lower-bounded typevars (T >: X)

### DIFF
--- a/src/StaticLint/bindings.jl
+++ b/src/StaticLint/bindings.jl
@@ -197,6 +197,14 @@ function mark_binding!(x::EXPR, meta_dict, val=x)
         # `isidentifier` guard keeps function-definition assignments (`f() = 0`,
         # whose LHS is a call) on the get_name path below.
         mark_binding!(x.args[1], meta_dict, val)
+    elseif isbinarysyntax(x) && valof(headof(x)) == ">:" && length(x.args) == 2 && isidentifier(x.args[1])
+        # `T >: Missing` in a `where` clause: a LOWER-bounded typevar.
+        # `CSTParser.issubtypedecl`/`get_name` only understand `<:`, so the
+        # generic fallback below would create a NAMELESS binding — `T` then
+        # neither resolves in the signature/body (missing_reference) nor
+        # registers as used (unused_type_parameter).
+        ensuremeta(x, meta_dict)
+        getmeta(x, meta_dict).binding = Binding(x.args[1], val, nothing, [])
     elseif !(isunarysyntax(x) && valof(headof(x)) == "::")
         ensuremeta(x, meta_dict)
         getmeta(x, meta_dict).binding = Binding(CSTParser.get_name(x), val, nothing, [])

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -5097,3 +5097,21 @@ end
         end
         """))
 end
+
+@testitem "where lower-bound typevars bind and count as used" setup=[shared_static_lint] begin
+    SL = JuliaWorkspaces.StaticLint
+    CSTParser = JuliaWorkspaces.CSTParser
+
+    # `T >: Missing` must bind `T` exactly like `T <: Integer` does: uses in
+    # the signature and body resolve, and the parameter counts as used.
+    cst, meta_dict, jw = parse_and_pass("""
+        missings(::Type{T}, dims) where {T >: Missing} = Array{T}(undef, dims)
+        """)
+    @test isempty(collect_hints(cst, meta_dict, jw))
+
+    # A genuinely unused lower-bounded parameter still flags.
+    cst, meta_dict, jw = parse_and_pass("""
+        f(x) where {T >: Missing} = x
+        """)
+    @test any(SL.errorof(x, meta_dict) === SL.UnusedTypeParameter for (_, x) in collect_hints(cst, meta_dict, jw))
+end


### PR DESCRIPTION
From the 2026-08-11 top-100 rerun: `where {T >: Missing}` lower bounds produce false positives in two rules at once — `T` is reported as an unused type parameter AND every use of `T` in the signature/body is a missing reference (Missings.jl's `missings(::Type{T}, dims) where {T >: Missing}`, CSV's `_promote(... ) where {T >: Missing, R, RA}`).

Cause: `mark_binding!`'s fallback names the binding via `CSTParser.get_name`, which (like `issubtypedecl`) only understands `<:` — for a `>:` element it returns a non-identifier, producing a NAMELESS binding that never enters the scope.

Fix: an explicit `mark_binding!` branch for `>:` binary syntax binds `x.args[1]`, mirroring what the fallback achieves for `<:`.

Tests: `T >: Missing` resolves and counts as used; a genuinely unused lower-bounded parameter still flags. Full suite: 1268/1270 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
