### PR TITLE
const_decl: fix import-extension, local-rebinding, and quoted-prior false positives

### DIFF
--- a/src/StaticLint/bindings.jl
+++ b/src/StaticLint/bindings.jl
@@ -470,6 +470,15 @@ function add_binding(x, state, scope=state.scope)
                         # do nothing name of `x` will resolve to the root method
                     elseif is_bare_local_decl(existing_binding)
                         # a bare local decl does not assign a value
+                    elseif is_synthetic_import_binding(tls.names[name])
+                        # an UNRESOLVED `import M: f` bound the name
+                        # synthetically ("assumed to exist and will not be
+                        # checked"): it is almost certainly a function being
+                        # extended (`import Statistics: mean` in an extension
+                        # file whose weakdeps env is unavailable). Flagging
+                        # would turn one unresolvable import into a
+                        # "function already has a value" diagnostic per
+                        # method definition.
                     else
                         seterror!(x, CannotDefineFuncAlreadyHasValue, meta_dict)
                     end

--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1626,6 +1626,18 @@ function check_const_decl(name::String, b::Binding, scope, meta_dict)
     # imported/using-ed bindings are never const decls
     is_in_fexpr(b.name, x -> headof(x) === :import || headof(x) === :using) && return
 
+    prev_b = scope.names[name]
+    if prev_b isa Binding
+        # The same definition can reach `add_binding` twice — an `@eval`'d
+        # struct is hoisted by `interpret_eval` AND traversed — and a
+        # definition is never a redefinition of itself.
+        prev_b.val !== nothing && prev_b.val === b.val && return
+        # A "previous definition" inside a quoted expression
+        # (`:(struct MT8 end)`) never executed; it cannot make this
+        # declaration a redefinition.
+        prev_b.val isa EXPR && is_in_fexpr(prev_b.val, quoted) && return
+    end
+
     b.val isa Binding && return check_const_decl(name, b.val, scope, meta_dict)
     if b.val isa EXPR && (CSTParser.defines_datatype(b.val) || is_const(b))
         # Mutually exclusive `if`/`elseif`/`else` branches (the standard
@@ -1639,6 +1651,16 @@ function check_const_decl(name::String, b::Binding, scope, meta_dict)
         end
         seterror!(b.name, CannotDeclareConst, meta_dict)
     else
+        # Implicit-const redefinition (reassigning a name that holds a
+        # datatype) only exists at module/file top level. In any local-ish
+        # scope (functions, `@generated` bodies, `@testset`/`@testitem`
+        # blocks) reassigning a variable is ordinary rebinding, even when it
+        # happens to hold a type value (`T = c ? Int : Float64; T = ...`).
+        # Explicit `const` redeclarations take the arm above and stay
+        # flagged everywhere.
+        if !(scope.expr isa EXPR && (CSTParser.defines_module(scope.expr) || headof(scope.expr) === :file))
+            return
+        end
         prev = scope.names[name]
         if (CoreTypes.isdatatype(prev.type) && !is_mask_binding_of_datatype(prev, meta_dict)) || is_const(prev)
             if b.val isa EXPR && prev.val isa EXPR && !in_same_if_branch(b.val, prev.val)

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -5191,6 +5191,8 @@ end
         f(x) where {T >: Missing} = x
         """)
     @test any(SL.errorof(x, meta_dict) === SL.UnusedTypeParameter for (_, x) in collect_hints(cst, meta_dict, jw))
+end
+
 @testitem "small FP batch: static-if toggle, one IndexFromLength per loop" setup=[shared_static_lint] begin
     SL = JuliaWorkspaces.StaticLint
 
@@ -5218,4 +5220,43 @@ end
         end
         """)
     @test count(==(SL.IndexFromLength), e) == 1
+end
+
+@testitem "const_decl: method extension of an unresolved import is not a redefinition" setup=[shared_static_lint] begin
+    SL = JuliaWorkspaces.StaticLint
+
+    errs(src) = begin
+        cst, meta_dict, jw = parse_and_pass(src)
+        [SL.errorof(x, meta_dict) for (_, x) in collect_hints(cst, meta_dict, jw) if SL.errorof(x, meta_dict) !== nothing]
+    end
+
+    # `Statistics` is unresolvable in this harness env, so `mean` gets a
+    # synthetic import binding — method definitions extend it, they don't
+    # "define a function that already has a value" (ext-file idiom).
+    e = errs("import Statistics: mean\nmean(x::Int) = 1\nmean(x::String) = 2\n")
+    @test !(SL.CannotDefineFuncAlreadyHasValue in e)
+    @test !(SL.InvalidRedefofConst in e)
+end
+
+@testitem "const_decl: local rebinding and quoted priors are not redefinitions" setup=[shared_static_lint] begin
+    SL = JuliaWorkspaces.StaticLint
+
+    errs(src) = begin
+        cst, meta_dict, jw = parse_and_pass(src)
+        [SL.errorof(x, meta_dict) for (_, x) in collect_hints(cst, meta_dict, jw) if SL.errorof(x, meta_dict) !== nothing]
+    end
+
+    # A local variable holding a type value is an ordinary variable.
+    @test isempty(errs("""
+        function f(c)
+            T = c ? Int : Float64
+            T = Union{T, Missing}
+            T
+        end
+        """))
+    # A definition inside a quoted expression never executed.
+    @test isempty(errs("ex = :(struct MT8 end)\nstruct MT8 end\n"))
+    # Genuine toplevel redefinitions still flag.
+    @test SL.InvalidRedefofConst in errs("struct T2 end\nT2 = 1\n")
+    @test SL.CannotDeclareConst in errs("const x = 1\nconst x = 2\n")
 end


### PR DESCRIPTION
From the 2026-08-11 top-100 rerun: `const_decl` sampled at 20/20 false positives with four causes; this fixes the three remaining after the branch-exclusivity fix already on main:

1. **Method extension of an unresolved `import`** (8/20 — `import Statistics: mean; mean(x::Fill) = ...` in extension files, where the weakdeps env is unavailable): the synthetic import binding ("assumed to exist") made every method definition flag `CannotDefineFuncAlreadyHasValue`. A new arm in `add_binding` treats synthetic import bindings like resolved function bindings — one unresolvable import no longer yields a diagnostic per method.
2. **Local rebinding of type-valued variables** (5/20 — `T = c ? Int : Float64; T = Union{T, Missing}` in functions/`@generated`/`@testset`): implicit-const redefinition semantics only exist at module/file top level, so the reassignment arm of `check_const_decl` now returns early in local-ish scopes. Explicit `const` redeclarations keep flagging everywhere (the `@testitem` double-`const` test still passes).
3. **Quoted/`@eval` priors** (4/20): a "previous definition" inside a quoted expression (`:(struct MT8 end)`) never executed, and an `@eval`'d struct reaching `add_binding` twice (hoist + traversal) is not a redefinition of itself — both now guarded at the top of `check_const_decl`.

Genuine redefinitions (`struct T end; T = 1`, double `const x`) still flag — pinned by new tests plus the existing suite.

Full suite: 1269/1271 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
