### PR TITLE
Resolve qualified access through module usings (incl. implicit Base)

### DIFF
--- a/shared/symbolserver/utils.jl
+++ b/shared/symbolserver/utils.jl
@@ -351,8 +351,18 @@ function maybe_getfield(k::Symbol, m::ModuleStore, envstore)
         return m.vals[k]
     else
         for v in m.used_modules
-            !haskey(m.vals, v) && continue
-            submod = m.vals[v]
+            # A used module need not be stored inside `m` itself: `Meta`'s
+            # implicit `using Base` records `:Base` in `used_modules`, but
+            # Base is a TOP-LEVEL entry of the env store. Qualified access
+            # (`Meta.dump` → Base's `dump`) resolves through usings in
+            # Julia, so fall back to the env store for the used module.
+            submod = if haskey(m.vals, v)
+                m.vals[v]
+            elseif envstore isa EnvStore && haskey(envstore, v)
+                envstore[v]
+            else
+                continue
+            end
             if submod isa ModuleStore && k in submod.exportednames && haskey(submod.vals, k)
                 return submod.vals[k]
             elseif submod isa VarRef
@@ -360,6 +370,17 @@ function maybe_getfield(k::Symbol, m::ModuleStore, envstore)
                 if submod isa ModuleStore && k in submod.exportednames && haskey(submod.vals, k)
                     return submod.vals[k]
                 end
+            end
+        end
+        # Every non-bare `module` implicitly does `using Base`, but store
+        # builders frequently miss it in `used_modules` (Base.Meta records
+        # only `[:Core]` while its runtime usings are `[Base]`). Qualified
+        # access through that implicit using is valid Julia (`Meta.dump` is
+        # Base's `dump`), so consult Base's exports as a final fallback.
+        if :Base ∉ m.used_modules && envstore isa EnvStore && haskey(envstore, :Base)
+            bs = envstore[:Base]
+            if bs isa ModuleStore && k in bs.exportednames && haskey(bs.vals, k)
+                return bs.vals[k]
             end
         end
     end

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -5270,3 +5270,16 @@ end
     @test SL.InvalidRedefofConst in errs("struct T2 end\nT2 = 1\n")
     @test SL.CannotDeclareConst in errs("const x = 1\nconst x = 2\n")
 end
+
+@testitem "qualified access resolves through a module's usings" setup=[shared_static_lint] begin
+    SL = JuliaWorkspaces.StaticLint
+
+    # `Meta.dump` is Base's `dump` reached through Meta's implicit
+    # `using Base` — Julia resolves qualified access through usings, so the
+    # store lookup must too (used modules live at the env-store top level,
+    # not inside the module's own vals).
+    for src in ("f(x) = Base.Meta.dump(x)\n", "f(x) = Meta.dump(x)\n")
+        cst, meta_dict, jw = parse_and_pass(src)
+        @test isempty(collect_hints(cst, meta_dict, jw))
+    end
+end


### PR DESCRIPTION
From the 2026-08-11 top-100 rerun (~10% of residual `missing_reference` FPs): qualified access through a submodule's usings fails to resolve — `Base.Meta.dump` (ExprTools), which is Base's `dump` reached through Meta's implicit `using Base`, flags `Missing reference: dump` even though it is perfectly valid Julia (qualified lookup follows usings at runtime).

Two gaps in `SymbolServer.maybe_getfield`:
1. The `used_modules` walk only considered used modules stored inside `m.vals` — but a used module is typically a TOP-LEVEL env entry (`Base` is not stored inside `Meta`). It now falls back to the env store.
2. Store builders frequently miss the implicit `using Base` entirely (Base.Meta's store records `used_modules = [:Core]` while its runtime usings are `[Base]` — verified against a live Julia). Since every non-bare `module` does `using Base`, Base's exports are consulted as a final fallback when `:Base` is absent from `used_modules`.

Tests: `Base.Meta.dump` and bare `Meta.dump` produce no hints. Full suite: 1268/1270 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
