### PR TITLE
type_piracy: credit owned types resolved through the module tree

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1545,7 +1545,16 @@ end
 
 function refers_to_nonimported_type(arg::EXPR, meta_dict)
     arg = CSTParser.rem_wheres(arg)
-    if hasref(arg, meta_dict) && refof(arg, meta_dict) isa Binding
+    r = hasref(arg, meta_dict) ? refof(arg, meta_dict) : nothing
+    if r isa Binding
+        return true
+    elseif r isa TreeRef && r.kind !== :external_symbol
+        # Per-file traversal mode: a type resolved through the module tree
+        # (defined in a SIBLING file of this package — `HTTP.Stream` used in
+        # http_stream.jl but defined in http_server.jl) is owned by the
+        # package just like a same-file `Binding`; a method mentioning it is
+        # not piracy. `:external_symbol` stand-ins are genuinely foreign and
+        # keep the check.
         return true
     elseif isunarysyntax(arg) && (valof(headof(arg)) == "::" || valof(headof(arg)) == "<:")
         return refers_to_nonimported_type(arg.args[1], meta_dict)

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -5097,3 +5097,48 @@ end
         end
         """))
 end
+
+@testitem "type_piracy credits types defined in sibling files" begin
+    using JuliaWorkspaces
+    using JuliaWorkspaces: JuliaWorkspace, TextFile, SourceText, add_file!, get_diagnostic, set_input_env_ready!
+    using JuliaWorkspaces.URIs2: URI
+
+    piracy(files...) = begin
+        jw = JuliaWorkspace()
+        add_file!(jw, TextFile(URI("file:///tpp/Project.toml"), SourceText("""
+        name = "TPP"
+        uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeef30"
+        version = "0.1.0"
+        """, "toml")))
+        add_file!(jw, TextFile(URI("file:///tpp/Manifest.toml"), SourceText("""
+        julia_version = "1.11.0"
+        manifest_format = "2.0"
+        project_hash = "abc"
+
+        [deps]
+        """, "toml")))
+        for (path, src) in files
+            add_file!(jw, TextFile(URI("file:///tpp/src/" * path), SourceText(src, "julia")))
+        end
+        set_input_env_ready!(jw.runtime, true)
+        n = 0
+        for (path, _) in files
+            n += count(d -> contains(d.message, "imported function has been extended"),
+                       get_diagnostic(jw, URI("file:///tpp/src/" * path)))
+        end
+        n
+    end
+
+    # A method whose signature mentions a type defined in a SIBLING included
+    # file (resolved as a TreeRef in per-file mode) extends over an owned
+    # type — not piracy, even with a literal type parameter.
+    @test piracy(
+        "TPP.jl" => "module TPP\ninclude(\"a.jl\")\ninclude(\"b.jl\")\nend\n",
+        "a.jl" => "struct Stream{T} end\n",
+        "b.jl" => "import Base: getindex\ngetindex(s::Stream{true}, i) = 1\n") == 0
+
+    # Extending an imported Base function over entirely foreign types is
+    # still piracy.
+    @test piracy(
+        "TPP.jl" => "module TPP\nimport Base: length\nlength(x::Vector{Int}) = 1\nend\n") == 1
+end


### PR DESCRIPTION
From the 2026-08-11 top-100 rerun (`type_piracy` 85% FP sampled): `refers_to_nonimported_type` only credits ownership when a signature type's ref is a `Binding` — i.e. defined in the SAME analysis unit. In per-file traversal mode, a package's own type defined in a *sibling included file* resolves as a `TreeRef` (HTTP's `Stream{true}` in `http_stream.jl`, defined in `http_server.jl`; `PrettyTables.RowTable`; `OrderedCollections.OrderedDict`), so every method extension over it was flagged as piracy — including through literal type parameters and const aliases, which resolve through the same tree refs.

Fix: a non-`:external_symbol` `TreeRef` is by construction a name defined in this workspace/package — credit it as owned.

Verified on the real packages (`workspace_from_folders`): HTTP 28 → 1, PrettyTables 8 → 0, OrderedCollections 6 → 0 — while ColorVectorSpace keeps all 17 (the sample's confirmed GENUINE piracy: `Base.atan`/`hypot`/`isless` over foreign ColorTypes types). Tests: sibling-file type with literal param not flagged; foreign-type extension still flagged.

Full suite: 1268/1270 (the 2 errors are the pre-existing testdata fixture items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
