### PR TITLE
Small lint FP batch: @static if toggle, IndexFromLength duplicates, depot-lock as infra

### DIFF
--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -922,7 +922,9 @@ function check_is_used_in_getindex(expr, lhs, arr, meta_dict)
         if hasref(this_arr, meta_dict) && hasref(arr, meta_dict) && refof(this_arr, meta_dict) == refof(arr, meta_dict)
             for index_arg in expr.args[2:end]
                 if hasref(index_arg, meta_dict) && hasref(lhs, meta_dict) && refof(index_arg, meta_dict) == refof(lhs, meta_dict)
-                    seterror!(expr, IndexFromLength, meta_dict)
+                    # One diagnostic per loop: the caller marks the iterator
+                    # spec; marking the use site too reported every such loop
+                    # twice.
                     return true
                 end
             end
@@ -991,6 +993,14 @@ function check_if_conds(x::EXPR, meta_dict)
     if headof(x) === :if
         cond = x.args[1]
         if headof(cond) === :TRUE || headof(cond) === :FALSE
+            # `@static if false ... end` is a deliberate compile-time toggle
+            # (dead-code switch), not an accidental constant condition.
+            p = parentof(x)
+            if p isa EXPR && CSTParser.ismacrocall(p) && length(p.args) >= 1 &&
+                    (valof(p.args[1]) == "@static" ||
+                     (CSTParser.is_getfield_w_quotenode(p.args[1]) && valof(rhs_of_getfield(p.args[1])) == "@static"))
+                return
+            end
             seterror!(cond, ConstIfCondition, meta_dict)
         elseif isassignment(cond)
             seterror!(cond, EqInIfConditional, meta_dict)

--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -148,7 +148,7 @@ function check_all(x::EXPR, opts::LintOptions, env::ExternalEnv, meta_dict, tree
     opts.call && check_call(x, env, meta_dict, tree_visible, tree_extended, tree_arities, tree_in_scope)
     opts.iter && check_loop_iter(x, env, meta_dict)
     opts.nothingcomp && check_nothing_equality(x, env, meta_dict)
-    opts.constif && check_if_conds(x, meta_dict)
+    opts.constif && check_if_conds(x, env, meta_dict)
     opts.lazy && check_lazy(x, meta_dict)
     opts.datadecl && check_datatype_decl(x, env, meta_dict)
     opts.typeparam && check_typeparams(x, meta_dict)
@@ -989,16 +989,17 @@ function _get_global_scope(s::Scope)
     end
 end
 
-function check_if_conds(x::EXPR, meta_dict)
+function check_if_conds(x::EXPR, env::ExternalEnv, meta_dict)
     if headof(x) === :if
         cond = x.args[1]
         if headof(cond) === :TRUE || headof(cond) === :FALSE
             # `@static if false ... end` is a deliberate compile-time toggle
-            # (dead-code switch), not an accidental constant condition.
+            # (dead-code switch), not an accidental constant condition. Resolved
+            # by identity, so a local macro that merely shares the name doesn't
+            # buy the same suppression.
             p = parentof(x)
             if p isa EXPR && CSTParser.ismacrocall(p) && length(p.args) >= 1 &&
-                    (valof(p.args[1]) == "@static" ||
-                     (CSTParser.is_getfield_w_quotenode(p.args[1]) && valof(rhs_of_getfield(p.args[1])) == "@static"))
+                    _points_to_Base_macro(p.args[1], Symbol("@static"), env, meta_dict)
                 return
             end
             seterror!(cond, ConstIfCondition, meta_dict)

--- a/src/StaticLint/macros.jl
+++ b/src/StaticLint/macros.jl
@@ -10,10 +10,10 @@ function handle_macro(x::EXPR, state)
                 end
             elseif CSTParser.is_func_call(x.args[4])
                 sig = (x.args[4])
-                if sig isa EXPR 
+                if sig isa EXPR
                     hasscope(sig, meta_dict) && return # We've already done this, don't repeat
                     setscope!(sig, Scope(sig), meta_dict)
-                    mark_sig_args!(sig, meta_dict)                    
+                    mark_sig_args!(sig, meta_dict)
                 end
                 if state isa Toplevel
                     push!(state.resolveonly, x)
@@ -183,8 +183,8 @@ end
 # but not for the inventory walk (layer_inventory.jl) — and only ever as a
 # disqualifier, since an unresolved name must keep its name verdict: "effects
 # unknown" marks the module like a wildcard `using` and would otherwise flip as
-# indexing completes. Future escape hatch: user-declared macro effects in
-# JuliaLint.toml.
+# indexing completes. Future escape hatch: call-site or definition-site annotations
+# that define which symbols/methods etc get defined by the macro
 const EFFECT_FREE_MACROS = Set{String}([
     # Base/Core annotations & wrappers
     "@inline", "@noinline", "@propagate_inbounds", "@generated",

--- a/src/StaticLint/macros.jl
+++ b/src/StaticLint/macros.jl
@@ -176,10 +176,15 @@ end
 # beyond what the plain-Julia traversal of their arguments already registers
 # (pass-through wrappers, logging/timing/testing, value-producing macros).
 #
-# Name-based on purpose (like `_is_symbolics_vardef_macro`): resolution can
-# tell where a macro comes from, never what it expands to, so a curated list
-# of implemented/vetted semantics is the only legitimate "known". Future
-# escape hatch: user-declared macro effects in JuliaLint.toml.
+# Curated because resolution can say where a macro comes from, never what it
+# expands to. Testing membership by NAME is the separate, weaker choice: a user
+# macro shadowing `@inline`/`@show` buys the same treatment. Identity could
+# rule that out for the two resolving callers (checks.jl, `handle_macro` above)
+# but not for the inventory walk (layer_inventory.jl) — and only ever as a
+# disqualifier, since an unresolved name must keep its name verdict: "effects
+# unknown" marks the module like a wildcard `using` and would otherwise flip as
+# indexing completes. Future escape hatch: user-declared macro effects in
+# JuliaLint.toml.
 const EFFECT_FREE_MACROS = Set{String}([
     # Base/Core annotations & wrappers
     "@inline", "@noinline", "@propagate_inbounds", "@generated",

--- a/src/dynamic_feature/dynamic_feature.jl
+++ b/src/dynamic_feature/dynamic_feature.jl
@@ -998,13 +998,24 @@ _is_infra_failure(err) = err isa DJPRequestTimeoutException || _is_depot_lock_fa
 # A depot file-lock collision (`IOError: stat(...manifest_usage.toml.pid...):
 # permission denied (EACCES)` during concurrent Pkg operations) says nothing
 # about the analyzed project — same infra class as a request timeout.
+#
+# The parent hits the same contention on its own store work (`isfile` under an
+# unreadable store, `mkpath`/`mktempdir` of the download dir), and there the
+# real exception is in hand, so match on its type and errno. A failure raised in
+# the child only crosses the process boundary as rendered text inside a
+# `JSONRPCError`, so that one case has no type left to compare.
 function _is_depot_lock_failure(err)
-    msg = try
-        sprint(showerror, err)
-    catch
-        return false
+    if err isa Base.IOError
+        return err.code == Base.UV_EACCES || err.code == Base.UV_EBUSY
+    elseif err isa JSONRPC.JSONRPCError
+        msg = try
+            sprint(showerror, err)
+        catch
+            return false
+        end
+        return occursin("IOError", msg) && (occursin("EACCES", msg) || occursin("EBUSY", msg))
     end
-    return occursin("IOError", msg) && (occursin("EACCES", msg) || occursin("EBUSY", msg))
+    return false
 end
 
 # Whether work for `key` must not be attempted again.

--- a/src/dynamic_feature/dynamic_feature.jl
+++ b/src/dynamic_feature/dynamic_feature.jl
@@ -993,7 +993,19 @@ end
 # user's Project.toml, unlike e.g. an unsatisfiable-requirements Pkg error.
 # Infra failures are logged, get one free retry, and never surface as
 # `environment_errors` diagnostics on the user's project files.
-_is_infra_failure(err) = err isa DJPRequestTimeoutException
+_is_infra_failure(err) = err isa DJPRequestTimeoutException || _is_depot_lock_failure(err)
+
+# A depot file-lock collision (`IOError: stat(...manifest_usage.toml.pid...):
+# permission denied (EACCES)` during concurrent Pkg operations) says nothing
+# about the analyzed project — same infra class as a request timeout.
+function _is_depot_lock_failure(err)
+    msg = try
+        sprint(showerror, err)
+    catch
+        return false
+    end
+    return occursin("IOError", msg) && (occursin("EACCES", msg) || occursin("EBUSY", msg))
+end
 
 # Whether work for `key` must not be attempted again.
 function _is_exhausted(df::DynamicFeature, key::DJPKey)

--- a/src/layer_inventory.jl
+++ b/src/layer_inventory.jl
@@ -629,10 +629,11 @@ end
 # Match by macro *name* rather than `StaticLint._points_to_Base_macro`, which
 # needs resolution state (a `Binding` ref pointing at the real `Base.@enum`)
 # that the inventory must not depend on — see the module docstring's firewall
-# note. A user shadowing `@enum` with an unrelated macro of the same name will
-# misclassify identically to how `mark_bindings!`'s conservatism already
-# accepts false positives elsewhere; this is a deliberate, spec-directed
-# deviation from macros.jl:55, not an oversight.
+# note. That firewall defers identity, it does not drop it: `MacroDeclarationRule`
+# records an owner and has it confirmed in layer_visibility.jl
+# (`_macro_owner_confirmed`), which is what rules out a local macro shadowing
+# the name. `@enum` rows carry no spelling, so nothing confirms them and a
+# shadowing `@enum` misclassifies — a known hole, not a constraint of this layer.
 _is_enum_macro(x::CSTParser.EXPR) = _macro_name_string(x.args[1]) == "@enum"
 
 # An `@enum` member/type-name argument may be wrapped in an explicit-value

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -5201,8 +5201,12 @@ end
 
     # `@static if false` is a deliberate compile-time toggle.
     @test !(SL.ConstIfCondition in errs("@static if false\n    f() = 1\nend\n"))
+    @test !(SL.ConstIfCondition in errs("Base.@static if false\n    f() = 1\nend\n"))
     # A bare `if false` still flags.
     @test SL.ConstIfCondition in errs("if false\n    f() = 1\nend\n")
+    # Suppression is keyed on Base's macro, not on the name: a local macro that
+    # happens to be called `@static` says nothing about the condition.
+    @test SL.ConstIfCondition in errs("macro static(ex) end\n@static if false\n    f() = 1\nend\n")
 
     # One diagnostic per 1:length loop, not one at the iterator spec AND one
     # at each use site.

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -3117,7 +3117,7 @@ end
     cst, meta_dict, jw = parse_and_pass("arr = []; [1 for _ in 1:length(arr)]")
     @test isempty(collect_hints(cst, meta_dict, jw))
     cst, meta_dict, jw = parse_and_pass("arr = []; [arr[i] for i in 1:length(arr)]")
-    @test length(collect_hints(cst, meta_dict, jw)) == 2
+    @test length(collect_hints(cst, meta_dict, jw)) == 1
     cst, meta_dict, jw = parse_and_pass("arr = []; [i for i in 1:length(arr)]")
     @test length(collect_hints(cst, meta_dict, jw)) == 0
 
@@ -3145,7 +3145,7 @@ end
         arr[i]
     end
     """)
-    @test length(collect_hints(cst, meta_dict, jw)) == 2
+    @test length(collect_hints(cst, meta_dict, jw)) == 1
     cst, meta_dict, jw = parse_and_pass("""
     arr = []
     for i in 1:length(arr)
@@ -3166,7 +3166,7 @@ end
         arr[i] + arr[j]
     end
     """)
-    @test length(collect_hints(cst, meta_dict, jw)) == 4
+    @test length(collect_hints(cst, meta_dict, jw)) == 2
     cst, meta_dict, jw = parse_and_pass("""
     arr = []
     for i in 1:length(arr), j in 1:length(arr)
@@ -3218,7 +3218,7 @@ end
         end
     end
     """)
-    @test length(collect_hints(cst, meta_dict, jw)) == 4
+    @test length(collect_hints(cst, meta_dict, jw)) == 2
 
     cst, meta_dict, jw = parse_and_pass("""
     function f(arr)
@@ -3227,7 +3227,7 @@ end
         end
     end
     """)
-    @test length(collect_hints(cst, meta_dict, jw)) == 4
+    @test length(collect_hints(cst, meta_dict, jw)) == 2
 end
 
 @testitem "assigned but not used with loops" setup=[shared_static_lint] begin
@@ -5191,4 +5191,27 @@ end
         f(x) where {T >: Missing} = x
         """)
     @test any(SL.errorof(x, meta_dict) === SL.UnusedTypeParameter for (_, x) in collect_hints(cst, meta_dict, jw))
+@testitem "small FP batch: static-if toggle, one IndexFromLength per loop" setup=[shared_static_lint] begin
+    SL = JuliaWorkspaces.StaticLint
+
+    errs(src) = begin
+        cst, meta_dict, jw = parse_and_pass(src)
+        [SL.errorof(x, meta_dict) for (_, x) in collect_hints(cst, meta_dict, jw) if SL.errorof(x, meta_dict) !== nothing]
+    end
+
+    # `@static if false` is a deliberate compile-time toggle.
+    @test !(SL.ConstIfCondition in errs("@static if false\n    f() = 1\nend\n"))
+    # A bare `if false` still flags.
+    @test SL.ConstIfCondition in errs("if false\n    f() = 1\nend\n")
+
+    # One diagnostic per 1:length loop, not one at the iterator spec AND one
+    # at each use site.
+    e = errs("""
+        function g(args)
+            for i = 1:length(args)
+                println(args[i])
+            end
+        end
+        """)
+    @test count(==(SL.IndexFromLength), e) == 1
 end

--- a/test/test_dynamic_failures.jl
+++ b/test/test_dynamic_failures.jl
@@ -273,3 +273,23 @@ end
         try close(outbound) catch end
     end
 end
+
+@testitem "Dynamic failures: a depot lock collision is classed as infrastructure" begin
+    using JuliaWorkspaces: _is_infra_failure
+    using JuliaWorkspaces: JSONRPC
+
+    # Raised by the parent's own store work, so the exception itself is
+    # available to inspect: `mkpath`/`mktempdir`/`isfile` all throw `IOError`.
+    @test _is_infra_failure(Base.IOError("mkdir(\"…/_downloads\"): permission denied (EACCES)", Base.UV_EACCES))
+    @test _is_infra_failure(Base.IOError("unlink: resource busy or locked (EBUSY)", Base.UV_EBUSY))
+    @test !_is_infra_failure(Base.IOError("open: no such file or directory (ENOENT)", Base.UV_ENOENT))
+
+    # Raised in the child, where only the rendered text crosses the boundary.
+    @test _is_infra_failure(JSONRPC.JSONRPCError(-32000,
+        "Failed to index project at /ws/P: IOError: stat(\"…/manifest_usage.toml.pid\"): permission denied (EACCES)", nothing))
+    @test !_is_infra_failure(JSONRPC.JSONRPCError(-32000,
+        "Failed to index project at /ws/P: Unsatisfiable requirements detected", nothing))
+
+    # A project failure that merely quotes those words is the project's problem.
+    @test !_is_infra_failure(ErrorException("IOError: EACCES"))
+end


### PR DESCRIPTION
Three small false-positive fixes from the 2026-08-11 top-100 rerun, batched:

1. **`const_if_condition`: exempt `@static if <literal>`** — `@static if false ... end` is a deliberate compile-time toggle (Plots' GR backend), not an accidental constant condition. A bare `if false` still flags.
2. **`index_from_length`: one diagnostic per loop** — `check_is_used_in_getindex` marked the use site while its caller marked the iterator spec, so every flagged loop reported twice (2 duplicate pairs in the 25-row sample). Only the iterator spec is marked now; existing count expectations updated.
3. **Depot file-lock failures are infra, not package errors** — a child-process failure like `IOError: stat(...manifest_usage.toml.pid): permission denied (EACCES)` during concurrent Pkg operations (seen on IterTools in the parallel sweep) surfaced as an `environment_errors` diagnostic on the package's Project.toml. `_is_infra_failure` now also matches IOError/EACCES/EBUSY shapes, so these get the timeout treatment: one retry, a logged warning, no user-facing diagnostic.

Full suite (via juliamcp): 1268/1270 — the 2 errors are the pre-existing testdata fixture items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
