### PR TITLE
Follow-up to #235: record exact module using provenance

### DIFF
--- a/shared/symbolserver/symbols.jl
+++ b/shared/symbolserver/symbols.jl
@@ -513,6 +513,8 @@ function usedby(outer, inner)
 end
 istoplevelmodule(m) = parentmodule(m) === m || parentmodule(m) === Main
 
+_module_usings(m::Module) = ccall(:jl_module_usings, Array{Any,1}, (Any,), m)
+
 function getmoduletree(m::Module, amn, visited = Base.IdSet{Module}())
     push!(visited, m)
     cache = ModuleStore(m)
@@ -530,6 +532,16 @@ function getmoduletree(m::Module, amn, visited = Base.IdSet{Module}())
             end
         end
     end
+    # Preserve the runtime's actual `using` provenance. Inferring it from
+    # visible bindings misses implicit usings in submodules such as Base.Meta,
+    # while adding Base during lookup makes bare modules see names they do not
+    # have.
+    for x in _module_usings(m)
+        x isa Module || continue
+        n = nameof(x)
+        haskey(cache, n) || (cache[n] = VarRef(x))
+        n in cache.used_modules || push!(cache.used_modules, n)
+    end
     for n in amn
         if n !== nameof(m) && _isdefinedglobal(m, n)
             ok, x = _try_getglobal(m, n)
@@ -537,9 +549,6 @@ function getmoduletree(m::Module, amn, visited = Base.IdSet{Module}())
             if x isa Module
                 if !haskey(cache, n)
                     cache[n] = VarRef(x)
-                end
-                if x !== Main && usedby(m, x)
-                    push!(cache.used_modules, n)
                 end
             end
         end

--- a/shared/symbolserver/utils.jl
+++ b/shared/symbolserver/utils.jl
@@ -372,17 +372,6 @@ function maybe_getfield(k::Symbol, m::ModuleStore, envstore)
                 end
             end
         end
-        # Every non-bare `module` implicitly does `using Base`, but store
-        # builders frequently miss it in `used_modules` (Base.Meta records
-        # only `[:Core]` while its runtime usings are `[Base]`). Qualified
-        # access through that implicit using is valid Julia (`Meta.dump` is
-        # Base's `dump`), so consult Base's exports as a final fallback.
-        if :Base ∉ m.used_modules && envstore isa EnvStore && haskey(envstore, :Base)
-            bs = envstore[:Base]
-            if bs isa ModuleStore && k in bs.exportednames && haskey(bs.vals, k)
-                return bs.vals[k]
-            end
-        end
     end
 end
 

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -5273,13 +5273,25 @@ end
 
 @testitem "qualified access resolves through a module's usings" setup=[shared_static_lint] begin
     SL = JuliaWorkspaces.StaticLint
+    SS = JuliaWorkspaces.SymbolServer
 
     # `Meta.dump` is Base's `dump` reached through Meta's implicit
     # `using Base` — Julia resolves qualified access through usings, so the
-    # store lookup must too (used modules live at the env-store top level,
-    # not inside the module's own vals).
-    for src in ("f(x) = Base.Meta.dump(x)\n", "f(x) = Meta.dump(x)\n")
-        cst, meta_dict, jw = parse_and_pass(src)
+    # store lookup must too. Runtime using provenance is what distinguishes
+    # this from a module that genuinely does not use Base.
+    parsed = [parse_and_pass(src) for src in
+        ("f(x) = Base.Meta.dump(x)\n", "f(x) = Meta.dump(x)\n")]
+    for (cst, meta_dict, jw) in parsed
         @test isempty(collect_hints(cst, meta_dict, jw))
     end
+
+    env = get_env(parsed[1][3])
+    meta_store = env.symbols[:Base][:Meta]
+    @test :Base in meta_store.used_modules
+
+    # A baremodule implicitly uses Core, not Base. Its store must not inherit
+    # every Base export merely because Base exists in the environment.
+    bare_store = SS.ModuleStore(SS.VarRef(nothing, :Bare), Dict{Symbol,Any}(),
+        "", Symbol[], Symbol[], [:Core])
+    @test SS.maybe_getfield(:sin, bare_store, env.symbols) === nothing
 end


### PR DESCRIPTION
Stacked on #235 for focused review.

- Records the runtime's actual module `using` list when building symbol stores.
- Removes the unconditional Base-export fallback from lookup.
- Preserves `Meta.dump` while proving that a Core-only bare module cannot resolve `Base.sin`.

Focused test: `qualified access resolves through a module's usings` (4/4 assertions passed on Julia 1.12.6).