### PR TITLE
Follow-up to #237: narrow infrastructure I/O classification

### DIFF
--- a/src/dynamic_feature/dynamic_feature.jl
+++ b/src/dynamic_feature/dynamic_feature.jl
@@ -997,23 +997,38 @@ _is_infra_failure(err) = err isa DJPRequestTimeoutException || _is_depot_lock_fa
 
 # A depot file-lock collision (`IOError: stat(...manifest_usage.toml.pid...):
 # permission denied (EACCES)` during concurrent Pkg operations) says nothing
-# about the analyzed project — same infra class as a request timeout.
+# about the analyzed project - same infra class as a request timeout. Errors on
+# arbitrary project files still belong to the project, even when their errno is
+# EACCES or EBUSY.
 #
 # The parent hits the same contention on its own store work (`isfile` under an
 # unreadable store, `mkpath`/`mktempdir` of the download dir), and there the
 # real exception is in hand, so match on its type and errno. A failure raised in
 # the child only crosses the process boundary as rendered text inside a
 # `JSONRPCError`, so that one case has no type left to compare.
+function _mentions_infrastructure_path(msg::AbstractString)
+    occursin(r"(?:manifest|artifact|scratch|preferences)_usage\.toml\.pid", msg) ||
+        occursin("_downloads", msg)
+end
+
 function _is_depot_lock_failure(err)
     if err isa Base.IOError
-        return err.code == Base.UV_EACCES || err.code == Base.UV_EBUSY
+        (err.code == Base.UV_EACCES || err.code == Base.UV_EBUSY) || return false
+        msg = try
+            sprint(showerror, err)
+        catch
+            return false
+        end
+        return _mentions_infrastructure_path(msg)
     elseif err isa JSONRPC.JSONRPCError
         msg = try
             sprint(showerror, err)
         catch
             return false
         end
-        return occursin("IOError", msg) && (occursin("EACCES", msg) || occursin("EBUSY", msg))
+        return occursin("IOError", msg) &&
+            (occursin("EACCES", msg) || occursin("EBUSY", msg)) &&
+            _mentions_infrastructure_path(msg)
     end
     return false
 end

--- a/test/test_dynamic_failures.jl
+++ b/test/test_dynamic_failures.jl
@@ -281,12 +281,15 @@ end
     # Raised by the parent's own store work, so the exception itself is
     # available to inspect: `mkpath`/`mktempdir`/`isfile` all throw `IOError`.
     @test _is_infra_failure(Base.IOError("mkdir(\"…/_downloads\"): permission denied (EACCES)", Base.UV_EACCES))
-    @test _is_infra_failure(Base.IOError("unlink: resource busy or locked (EBUSY)", Base.UV_EBUSY))
+    @test _is_infra_failure(Base.IOError("unlink(\"…/manifest_usage.toml.pid\"): resource busy or locked (EBUSY)", Base.UV_EBUSY))
     @test !_is_infra_failure(Base.IOError("open: no such file or directory (ENOENT)", Base.UV_ENOENT))
+    @test !_is_infra_failure(Base.IOError("open(\"/workspace/Project.toml\"): permission denied (EACCES)", Base.UV_EACCES))
 
     # Raised in the child, where only the rendered text crosses the boundary.
     @test _is_infra_failure(JSONRPC.JSONRPCError(-32000,
         "Failed to index project at /ws/P: IOError: stat(\"…/manifest_usage.toml.pid\"): permission denied (EACCES)", nothing))
+    @test !_is_infra_failure(JSONRPC.JSONRPCError(-32000,
+        "Failed to index project at /ws/P: IOError: open(\"/ws/P/Project.toml\"): permission denied (EACCES)", nothing))
     @test !_is_infra_failure(JSONRPC.JSONRPCError(-32000,
         "Failed to index project at /ws/P: Unsatisfiable requirements detected", nothing))
 


### PR DESCRIPTION
Stacked on #237 for focused review.

- Requires a depot lock or symbol-store download path in addition to EACCES/EBUSY.
- Retains classification for typed `IOError` and rendered child `JSONRPCError` failures.
- Adds negative coverage proving arbitrary `Project.toml` permission failures remain project errors.

Focused test: `Dynamic failures: a depot lock collision is classed as infrastructure` (8/8 assertions passed on Julia 1.12.6).