### PR TITLE
Fix missing_reference false positives on field accesses

### DIFF
--- a/src/StaticLint/bindings.jl
+++ b/src/StaticLint/bindings.jl
@@ -127,6 +127,19 @@ function mark_bindings!(x::EXPR, state)
         if CSTParser.defines_struct(x) # mark field block
             for arg in x.args[3].args
                 CSTParser.defines_function(arg) && continue
+                # A field modifier wraps the declaration in a macrocall whose
+                # last argument is the field (`@atomic a::Int`, or a docstring
+                # via :globalrefdoc). Only macros known to leave the field
+                # declaration in place are unwrapped: an arbitrary macro may
+                # expand to anything, and fabricating a field binding from it
+                # would suppress genuine missing-reference reports. Structs
+                # with unknown macro-wrapped members are instead treated as not
+                # statically enumerable (`struct_fields_statically_enumerable`).
+                if CSTParser.ismacrocall(arg) && arg.args !== nothing && length(arg.args) > 1 &&
+                   (headof(arg.args[1]) === :globalrefdoc ||
+                    _points_to_Base_macro(arg.args[1], Symbol("@atomic"), state))
+                    arg = last(arg.args)
+                end
                 if arg.head === :const
                     arg = arg.args[1]
                 end

--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1385,6 +1385,7 @@ function collect_hints(x::EXPR, env, workspace_packages, meta_dict, missingrefs=
             push!(errs, (pos, x))
         end
     elseif isquoted && missingrefs == :all && should_mark_missing_getfield_ref(x, env, workspace_packages, meta_dict) &&
+            !in_macrocall_arg(x, env, meta_dict) &&
             !in_existence_guarded_branch(x, env, meta_dict)
         push!(errs, (pos, x))
     end
@@ -1480,9 +1481,10 @@ function should_mark_missing_getfield_ref(x, env, workspace_packages, meta_dict)
             if !(lhsref isa Binding)
                 # Not clear what is happening here.
                 return false
-            elseif lhsref.type isa SymbolServer.DataTypeStore && !(isempty(lhsref.type.fieldnames) || isunionfaketype(lhsref.type.name) || has_getproperty_method(lhsref.type, env))
+            elseif lhsref.type isa SymbolServer.DataTypeStore && !(isempty(lhsref.type.fieldnames) || isunionfaketype(lhsref.type.name) || isnamedtuplefaketype(lhsref.type.name) || has_getproperty_method(lhsref.type, env))
                 return true
-            elseif lhsref.type isa Binding && lhsref.type.val isa EXPR && CSTParser.defines_struct(lhsref.type.val) && !has_getproperty_method(lhsref.type)
+            elseif lhsref.type isa Binding && lhsref.type.val isa EXPR && CSTParser.defines_struct(lhsref.type.val) && !has_getproperty_method(lhsref.type) &&
+                   struct_fields_statically_enumerable(lhsref.type.val, meta_dict)
                 # We may have infered the lhs type after the semantic pass that was resolving references.
                 return !scopehasbinding(scopeof(lhsref.type.val, meta_dict), valofid(x))
             end
@@ -1539,6 +1541,26 @@ function is_type_of_call_to_getproperty(x::EXPR)
 end
 
 isunionfaketype(t::SymbolServer.FakeTypeName) = t.name.name === :Union && t.name.parent isa SymbolServer.VarRef && t.name.parent.name === :Core
+
+# `NamedTuple` field sets depend on the value's type parameters, which the
+# static `fieldnames` of the `DataTypeStore` cannot represent.
+isnamedtuplefaketype(t::SymbolServer.FakeTypeName) = t.name.name === :NamedTuple && t.name.parent isa SymbolServer.VarRef && t.name.parent.name === :Core
+
+# Only known field-modifier macros (`@atomic`, docstrings) are unwrapped when
+# struct field bindings are collected (see `mark_bindings!`); a member wrapped
+# in any other macrocall may still declare a field the binding pass cannot see,
+# so the struct's field set cannot be enumerated and a missing-field report
+# would be a guess.
+function struct_fields_statically_enumerable(strct::EXPR, meta_dict)
+    (strct.args !== nothing && length(strct.args) >= 3 && strct.args[3].args !== nothing) || return true
+    for arg in strct.args[3].args
+        CSTParser.defines_function(arg) && continue
+        if CSTParser.ismacrocall(arg) && !(arg.args !== nothing && length(arg.args) > 1 && hasbinding(last(arg.args), meta_dict))
+            return false
+        end
+    end
+    return true
+end
 
 function check_typeparams(x::EXPR, meta_dict)
     if iswhere(x)

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -5295,3 +5295,91 @@ end
         "", Symbol[], Symbol[], [:Core])
     @test SS.maybe_getfield(:sin, bare_store, env.symbols) === nothing
 end
+
+@testitem "struct fields behind field-modifier macros are not missing references" setup=[shared_static_lint] begin
+    # `@atomic` is a known field modifier: the wrapped declaration still gets a
+    # field binding, so accesses resolve and are not hinted.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        mutable struct T
+            @atomic field::Int
+        end
+        f(arg::T) = arg.field
+        """)
+        @test isempty(collect_hints(cst, meta_dict, jw))
+    end
+
+    # Same for a docstring-wrapped field.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        struct T
+            "a documented field"
+            field::Int
+        end
+        f(arg::T) = arg.field
+        """)
+        @test isempty(collect_hints(cst, meta_dict, jw))
+    end
+
+    # A member wrapped in an arbitrary macro may declare fields the binding
+    # pass cannot see, so the struct's field set is not enumerable: accesses to
+    # unknown names must not be flagged...
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        macro addfield(x)
+            esc(x)
+        end
+        struct T
+            @addfield hidden
+            x::Int
+        end
+        f(arg::T) = arg.hidden
+        """)
+        @test isempty(collect_hints(cst, meta_dict, jw))
+    end
+
+    # ...but a plain struct without macro members still flags unknown fields.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        struct T
+            x::Int
+        end
+        f(arg::T) = arg.missing_field
+        """)
+        hints = collect_hints(cst, meta_dict, jw)
+        @test length(hints) == 1
+    end
+
+    # A docstring-wrapped field keeps the struct enumerable: unknown fields on
+    # a documented struct are still flagged.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        struct T
+            "a documented field"
+            field::Int
+        end
+        f(arg::T) = arg.missing_field
+        """)
+        hints = collect_hints(cst, meta_dict, jw)
+        @test length(hints) == 1
+    end
+end
+
+@testitem "getfield inside macro args is not a missing reference" setup=[shared_static_lint] begin
+    # The plain-identifier arm already suppresses names inside opaque macro
+    # calls; the getfield arm must do the same for `a.b` field names.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        macro m(x)
+        end
+        struct T
+            x::Int
+        end
+        t = T(1)
+        @m t.some_field
+        """)
+        @test isempty(collect_hints(cst, meta_dict, jw))
+    end
+end
+
+@testitem "NamedTuple field access is not a missing reference" setup=[shared_static_lint] begin
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        f(nt::NamedTuple) = nt.some_key
+        """)
+        @test isempty(collect_hints(cst, meta_dict, jw))
+    end
+end


### PR DESCRIPTION
Three gaps made `a.b` field names surface as missing references (8/40 of sampled missing_reference FPs in the 2026-08-12 top-100 corpus sweep):

- **Macro-wrapped struct fields had no binding.** `@atomic a::Int` and docstring-wrapped fields were skipped when collecting struct field bindings, so every later access to them was flagged. Known field-leaving wrappers (`@atomic`, `:globalrefdoc` docstrings) are now unwrapped, mirroring the name-free unwrap the inventory already does — but deliberately restricted to known macros here, since fabricating a field binding from an arbitrary macro would suppress genuine missing-reference reports.
- **Unknown macro-wrapped members now make the struct non-enumerable.** A member wrapped in any other macrocall may declare fields the binding pass cannot see, so `should_mark_missing_getfield_ref` no longer guesses at missing fields for such structs (new `struct_fields_statically_enumerable` guard).
- **Getfield-arm parity in `collect_hints`.** The quoted (field-name) arm now suppresses names inside opaque macro calls via `in_macrocall_arg`, matching the plain-identifier arm, and `NamedTuple`-typed LHSes get an escape hatch since their field sets depend on type parameters.

Corpus examples fixed: HTTP `src/http1.jl` (`.field` reads), BenchmarkTools `src/trials.jl`, Parameters/JSON/PrettyTables test/bench field accesses.

Tests: new testitems covering @atomic fields, docstring-wrapped fields (positive and still-flagging negative), unknown-macro structs, macro-arg getfields, and NamedTuple access. Full suite green (1281 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)