### PR TITLE
Fix const_decl false positives on conditional and imported bindings

### DIFF
--- a/src/StaticLint/bindings.jl
+++ b/src/StaticLint/bindings.jl
@@ -163,8 +163,10 @@ function mark_bindings!(x::EXPR, state)
 end
 
 function is_bare_local_decl(b)
+    # a bare `global x` declaration (`let ...; global f; function f() ... end`)
+    # assigns no value either — same exemption as bare `local x`
     b isa Binding && b.type === nothing && b.val isa EXPR && isidentifier(b.val) &&
-        parentof(b.val) isa EXPR && headof(parentof(b.val)) === :local
+        parentof(b.val) isa EXPR && (headof(parentof(b.val)) === :local || headof(parentof(b.val)) === :global)
 end
 
 function mark_binding!(x::EXPR, meta_dict, val=x)
@@ -479,6 +481,13 @@ function add_binding(x, state, scope=state.scope)
                         # would turn one unresolvable import into a
                         # "function already has a value" diagnostic per
                         # method definition.
+                    elseif existing_binding isa Binding && existing_binding.val isa EXPR &&
+                           !in_same_if_branch(x, existing_binding.val)
+                        # `if isdefined(...) const f = ... else f() = ... end`:
+                        # mutually exclusive branches never both execute, so the
+                        # function definition does not clash with the other
+                        # branch's value — the same exemption check_const_decl
+                        # applies to const/const branch pairs.
                     else
                         seterror!(x, CannotDefineFuncAlreadyHasValue, meta_dict)
                     end

--- a/src/StaticLint/linting/checks.jl
+++ b/src/StaticLint/linting/checks.jl
@@ -1642,6 +1642,19 @@ end
 
 # Now called from add_binding
 # Should return true/false indicating whether the binding should actually be added?
+# Whether `x` (a binding-name identifier) sits inside a WHOLE-MODULE
+# `import`/`using` statement (`import Printf`), as opposed to a symbol import
+# (`import Base: name`, whose arguments are wrapped in a `:` operator call).
+function _is_in_whole_module_import(x::EXPR)
+    imp = x
+    while imp isa EXPR && !(headof(imp) === :import || headof(imp) === :using)
+        imp = parentof(imp)
+    end
+    imp isa EXPR || return false
+    return !(imp.args !== nothing && length(imp.args) > 0 &&
+             isoperator(headof(imp.args[1])) && valof(headof(imp.args[1])) == ":")
+end
+
 function check_const_decl(name::String, b::Binding, scope, meta_dict)
     # assumes `scopehasbinding(scope, name)`
 
@@ -1658,6 +1671,11 @@ function check_const_decl(name::String, b::Binding, scope, meta_dict)
         # a redefinition. A quote passed directly to `eval` does execute and
         # must retain the warning.
         prev_b.val isa EXPR && _is_in_inert_quote(prev_b.val) && return
+        # `import HDF5; const HDF5 = Base.get_extension(...).HDF5` egal-rebinds
+        # an imported MODULE — legal and idiomatic extension access. Only
+        # whole-module imports are exempt: symbol imports (`import Base: name`)
+        # keep the "already declared as an import" error below.
+        prev_b.name isa EXPR && _is_in_whole_module_import(prev_b.name) && return
     end
 
     b.val isa Binding && return check_const_decl(name, b.val, scope, meta_dict)
@@ -1668,8 +1686,14 @@ function check_const_decl(name::String, b::Binding, scope, meta_dict)
         # per branch is not a redeclaration — the same exemption the
         # InvalidRedefofConst arm below already applies.
         prev = scope.names[name]
-        if prev isa Binding && prev.val isa EXPR && !in_same_if_branch(b.val, prev.val)
-            return
+        if prev isa Binding
+            # an import binding's `.val` may be a store, not an EXPR (`using
+            # Base: @x` in the other @static branch of a `const var"@x"`
+            # shim) — its `.name` EXPR still locates the branch
+            prev_expr = prev.val isa EXPR ? prev.val : (prev.name isa EXPR ? prev.name : nothing)
+            if prev_expr !== nothing && !in_same_if_branch(b.val, prev_expr)
+                return
+            end
         end
         seterror!(b.name, CannotDeclareConst, meta_dict)
     else

--- a/test/staticlint/test_staticlint.jl
+++ b/test/staticlint/test_staticlint.jl
@@ -5295,3 +5295,82 @@ end
         "", Symbol[], Symbol[], [:Core])
     @test SS.maybe_getfield(:sin, bare_store, env.symbols) === nothing
 end
+
+@testitem "const/function pairs in mutually exclusive branches" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, CannotDefineFuncAlreadyHasValue, CannotDeclareConst
+
+    has_error(cst, meta_dict, jw, err) =
+        any(errorof(x, meta_dict) === err for (_, x) in collect_hints(cst, meta_dict, jw))
+
+    # `const` in one branch, assignment-form function in the other (Parsers'
+    # OncePerTask fallback idiom): only one branch ever runs.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        if isdefined(Base, :OncePerTask)
+            const _get_bigint = Base.OncePerTask{BigInt}(() -> BigInt())
+        else
+            _get_bigint() = 1
+        end
+        """)
+        @test !has_error(cst, meta_dict, jw, CannotDefineFuncAlreadyHasValue)
+    end
+
+    # `using Base: @x` in one @static branch, `const var"@x" = ...` in the
+    # other (StaticArrays' @_inline_meta shim).
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        @static if VERSION < v"1.8.0-DEV.410"
+            using Base: @_inline_meta
+        else
+            const var"@_inline_meta" = Base.var"@inline"
+        end
+        """)
+        @test !has_error(cst, meta_dict, jw, CannotDeclareConst)
+    end
+
+    # A genuine same-branch clash is still reported.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        const f = 1
+        f() = 2
+        """)
+        @test has_error(cst, meta_dict, jw, CannotDefineFuncAlreadyHasValue)
+    end
+end
+
+@testitem "let-global function with additional top-level methods" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, CannotDefineFuncAlreadyHasValue
+
+    has_error(cst, meta_dict, jw, err) =
+        any(errorof(x, meta_dict) === err for (_, x) in collect_hints(cst, meta_dict, jw))
+
+    # UnicodeFun's closure-capture idiom: `global f` + `function f(...)` inside
+    # `let`, plus more methods of `f` at top level. All are method additions.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        let subscript_map = Dict('a' => 'b')
+            global to_subscript
+            function to_subscript(x::Char)
+                subscript_map[x]
+            end
+        end
+        function to_subscript(x::Int)
+            Char(x)
+        end
+        """)
+        @test !has_error(cst, meta_dict, jw, CannotDefineFuncAlreadyHasValue)
+    end
+end
+
+@testitem "const rebinding of an imported name" setup=[shared_static_lint] begin
+    using JuliaWorkspaces.StaticLint: errorof, CannotDeclareConst, InvalidRedefofConst
+
+    has_error(cst, meta_dict, jw, err) =
+        any(errorof(x, meta_dict) === err for (_, x) in collect_hints(cst, meta_dict, jw))
+
+    # `import HDF5; const HDF5 = Base.get_extension(...).HDF5` — an egal
+    # rebind of the imported module, legal at runtime.
+    let (cst, meta_dict, jw) = parse_and_pass("""
+        import Printf
+        const Printf = Base.get_extension(Main, :Whatever).Printf
+        """)
+        @test !has_error(cst, meta_dict, jw, CannotDeclareConst)
+        @test !has_error(cst, meta_dict, jw, InvalidRedefofConst)
+    end
+end


### PR DESCRIPTION
`const_decl` was 100% FP in the 2026-08-12 top-100 corpus sweep (10/10 sampled). Three exemptions, each mirroring a rule the checker already applies elsewhere:

- **Mutually exclusive branches, const vs function.** `if isdefined(Base, :OncePerTask) const _get_bigint = ... else _get_bigint() = 1 end` (Parsers) reported "Cannot define function; it already has a value". `check_const_decl` already exempted const/const pairs across `if` branches via `in_same_if_branch`; the `CannotDefineFuncAlreadyHasValue` arm in `add_binding` now applies the same check. The `CannotDeclareConst` arm additionally falls back to the previous binding's *name* expression when its `val` is a store rather than an EXPR — the `using Base: @_inline_meta` / `const var"@_inline_meta" = ...` shim in StaticArrays.
- **Bare `global x` assigns no value.** UnicodeFun's `let ...; global to_subscript; function to_subscript(x::Char) ... end; end` plus more top-level methods are all method additions. Extends the existing bare-`local` exemption in `is_bare_local_decl`.
- **Egal const rebind of an imported module.** `import HDF5; const HDF5 = Base.get_extension(...).HDF5` is legal. Deliberately scoped to whole-module imports (new `_is_in_whole_module_import` helper distinguishes them from `import M: name` by the `:` operator wrapper), so the #352 behavior — `const` over an imported *symbol* is still "Cannot declare constant" — is preserved and still covered by its test.

Corpus effect: Parsers 2→0, UnicodeFun 2→0, URIs 1→0, StaticArrays 1→0, Plots 1→0.

Tests: branch-exclusivity pairs (both directions) with a same-branch negative control, the let-global idiom, and the module rebind. Full suite green (1281 passed); all 62 const-related testitems pass, including the #352 suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)