### PR TITLE
Make test items their own inventory type

### DIFF
--- a/src/StaticLint/StaticLint.jl
+++ b/src/StaticLint/StaticLint.jl
@@ -4,6 +4,7 @@ import ..derived_has_file
 import ..derived_julia_legacy_syntax_tree
 import ..derived_include_dict
 import ..derived_computed_include_ids
+import ..derived_testitem_segments
 import ..ItemRef
 import ..MethodArity
 
@@ -309,6 +310,13 @@ mutable struct Toplevel{RT} <: TraverseState
     # data, and where a nested `@testitem setup=[...]` (including one
     # swallowed into an unclosed enclosing block by parser recovery) would
     # otherwise re-enter this same query and cycle.
+    #
+    # Deliberately does NOT gate `_seed_testitem_tree_context!`: that seeds
+    # the body's own module-tree node, which is structure rather than runtime
+    # simulation, and its dependency chain (`derived_testitem_segments` and
+    # the `derived_module_*` selectors) reaches only the inventory and the
+    # CST — never `derived_test_setups_in_file` or `derived_file_analysis` —
+    # so the re-entry this flag guards against cannot happen there.
     simulate_testitem_runtime::Bool
     flags::Int
     meta_dict::Dict{UInt64,Meta}
@@ -578,7 +586,12 @@ function followinclude(x, state::Toplevel)
     if objectid(x) in derived_computed_include_ids(state.runtime, state.uri)
         scope = retrieve_scope(x, state.meta_dict)
         while scope isa Scope
-            if CSTParser.defines_module(scope.expr) || !(scope.parent isa Scope)
+            # A testitem-family body is its own module at runtime, so a computed
+            # include there splices unknown code into THAT body — stopping only
+            # at a `module`/the file root would suppress every other test item
+            # in the file too.
+            if CSTParser.defines_module(scope.expr) || _is_testitem_scope_macrocall(scope.expr) ||
+                    !(scope.parent isa Scope)
                 scope.unresolved_wildcard_import = true
                 break
             end

--- a/src/StaticLint/macros.jl
+++ b/src/StaticLint/macros.jl
@@ -570,6 +570,12 @@ function _handle_testitem(x::EXPR, state::Toplevel)
     # item_scope we just created).
     tctx = enclosing_tree_context(state.scope)
 
+    # The body's own module-tree node — this is what makes names from a file
+    # `include`d in the body resolve. Seeded before the injections below so
+    # they can overwrite nothing of it (they only touch `names` and other
+    # `modules` keys).
+    _seed_testitem_tree_context!(item_scope, x, state, tctx)
+
     # If default_imports=true, add Test and the parent package module
     default_imports && state.simulate_testitem_runtime && _inject_testitem_default_imports!(item_scope, state, tctx)
 
@@ -638,6 +644,43 @@ function _handle_testitem(x::EXPR, state::Toplevel)
     # NOTE: We intentionally do NOT call process_EXPR(body, state) here.
     # The body will be processed by the standard traverse() in process_EXPR,
     # which will use the scope we just created (pushed by scopes()).
+    return
+end
+
+"""
+    _seed_testitem_tree_context!(scope, x, state, tctx)
+
+Point the testitem-family body's scope at its OWN node in the module tree.
+
+The inventory walker records a `@testitem`/`@testmodule`/`@testsnippet` body as
+a `:testitem` node (`InventoryTestItem`), so an `include(...)` written in the
+body splices the target's declarations there rather than into the enclosing
+file's module — which is what actually happens at runtime. Re-seeding
+`:__tree__` to the child context for that node is what lets `resolve_ref`'s
+existing `scope.modules` lookup find those names.
+
+The segment comes from `derived_testitem_segments` rather than being
+re-derived here: the inventory walker only visits top-level-ish statements
+while StaticLint traverses everything, so an independent implementation would
+drift and silently point at a node that does not exist.
+
+Deliberately NOT gated on `state.simulate_testitem_runtime` (unlike the
+default-imports and setup injections): this is tree structure, not runtime
+simulation, and it cannot cycle — `derived_testitem_segments` and the
+`derived_module_*` queries reach only the inventory and the CST, never
+`derived_test_setups_in_file` or `derived_file_analysis`.
+"""
+function _seed_testitem_tree_context!(scope::Scope, x::EXPR, state::Toplevel, tctx)
+    # Whole-closure mode has no tree context to descend from — there,
+    # `followinclude` really does traverse the target into this scope.
+    tctx === nothing && return
+    seg = get(derived_testitem_segments(state.runtime, state.uri), UInt64(objectid(x)), nothing)
+    seg === nothing && return
+    scope.modules[:__tree__] = child_module_context(tctx, seg)
+    # Plain data, so it survives `strip_module_contexts!` and the freeze: this
+    # is how the absolute-module-path walk recovers the segment at request time
+    # (`_in_file_module_names`), when the context handle above is long gone.
+    scope.testitem_segment = seg
     return
 end
 
@@ -745,6 +788,7 @@ function _handle_testmodule(x::EXPR, state::Toplevel)
     mod_scope.modules = Dict{Symbol,Any}()
     mod_scope.modules[:Base] = getsymbols(state)[:Base]
     mod_scope.modules[:Core] = getsymbols(state)[:Core]
+    _seed_testitem_tree_context!(mod_scope, x, state, enclosing_tree_context(state.scope))
 
     # Create a binding for the module name
     binding = Binding(name_expr, x, nothing, EXPR[], true)
@@ -789,7 +833,10 @@ function _handle_testsnippet(x::EXPR, state::Toplevel)
     snip_scope.modules[:Base] = getsymbols(state)[:Base]
     snip_scope.modules[:Core] = getsymbols(state)[:Core]
 
-    default_imports && state.simulate_testitem_runtime && _inject_testitem_default_imports!(snip_scope, state, enclosing_tree_context(state.scope))
+    tctx = enclosing_tree_context(state.scope)
+    _seed_testitem_tree_context!(snip_scope, x, state, tctx)
+
+    default_imports && state.simulate_testitem_runtime && _inject_testitem_default_imports!(snip_scope, state, tctx)
 
     # Body will be traversed by the standard traverse() in process_EXPR,
     # using this isolating scope (pushed by scopes()).

--- a/src/StaticLint/scope.jl
+++ b/src/StaticLint/scope.jl
@@ -7,8 +7,20 @@ mutable struct Scope
     # a wildcard `using X` in this scope failed to resolve: any unresolved
     # identifier in this scope could be an export of the unknown module
     unresolved_wildcard_import::Bool
+    # For a `@testitem`/`@testmodule`/`@testsnippet` body scope: the module-tree
+    # segment naming its `:testitem` node (see `_seed_testitem_tree_context!`).
+    # `nothing` everywhere else.
+    #
+    # Recorded on the scope rather than looked up per query because a test-item
+    # scope's `expr` is a MACROCALL, so the module-path walk that reads module
+    # nesting off the scope chain (`_in_file_module_names`) cannot otherwise
+    # tell it apart from a plain block — and unlike `modules[:__tree__]`, this
+    # is plain data, so it survives `strip_module_contexts!` and the freeze into
+    # the per-file analysis value.
+    testitem_segment::Union{Nothing,String}
 end
-Scope(parent, expr, names, modules, overloaded) = Scope(parent, expr, names, modules, overloaded, false)
+Scope(parent, expr, names, modules, overloaded) = Scope(parent, expr, names, modules, overloaded, false, nothing)
+Scope(parent, expr, names, modules, overloaded, uwi) = Scope(parent, expr, names, modules, overloaded, uwi, nothing)
 Scope(expr) = Scope(nothing, expr, Dict{Symbol,Binding}(), nothing, nothing)
 function Base.show(io::IO, s::Scope)
     printstyled(io, headof(s.expr))

--- a/src/layer_file_analysis.jl
+++ b/src/layer_file_analysis.jl
@@ -80,11 +80,21 @@ end
 # outermost-first, read off the scope chain (works after
 # `strip_module_contexts!` — module nesting survives the handle strip).
 # `vcat(splice_path, this)` is `x`'s absolute module path.
+#
+# A `@testitem`/`@testmodule`/`@testsnippet` body is a module too (it opens a
+# `:testitem` node in the tree), but its scope's `expr` is a MACROCALL, so
+# `defines_module` cannot see it — the segment is read from the scope's own
+# `testitem_segment`, recorded by `_seed_testitem_tree_context!`. Without this,
+# every consumer computing an absolute path for a call site inside a test item
+# (the method-set and arity lints, hover, references, completions) would look
+# in the ENCLOSING module and miss everything the test item includes.
 function _in_file_module_names(x, meta_dict)
     names = String[]
     s = StaticLint.retrieve_scope(x, meta_dict)
     while s isa StaticLint.Scope
-        if s.expr isa CSTParser.EXPR && CSTParser.defines_module(s.expr)
+        if s.testitem_segment !== nothing
+            pushfirst!(names, s.testitem_segment)
+        elseif s.expr isa CSTParser.EXPR && CSTParser.defines_module(s.expr)
             mn = CSTParser.get_name(s.expr)
             nm = mn isa CSTParser.EXPR && CSTParser.isidentifier(mn) ? StaticLint.valofid(mn) : nothing
             nm !== nothing && pushfirst!(names, nm)
@@ -335,8 +345,8 @@ end
 # For `using` at module toplevel no `scope.modules` entry is needed: the
 # bring-ins are part of the module's `derived_module_visible_names` face and
 # the seeded `:__tree__` context covers them. A `using` anywhere else (a
-# `@testitem`/`@testset` body — those macrocalls are opaque to the
-# inventory) has no face to lean on, so its exported names are materialized
+# `@testset` body, or a non-toplevel `using` in a testitem-family body) has
+# no face to lean on, so its exported names are materialized
 # as an export-filtered context on the current scope; the wrapper holds a
 # runtime handle and is removed by `strip_module_contexts!` before freezing.
 function StaticLint._mark_import_arg(arg, par::TreeModuleContext, state, usinged, meta_dict)
@@ -823,9 +833,20 @@ Salsa.@derived function derived_file_analysis(rt, root, file)
     # somewhere is very likely the *target* of that include — its real module
     # context (and the usings that come with it) is unknown, so bare
     # missing-ref reporting against the bare context is unreliable.
+    # Fifth case: the file is spliced INTO a test-item body (a helper a
+    # `@testitem` `include`s). At runtime that body also runs `using Test` and
+    # `using <the package under test>`, which `_inject_testitem_default_imports!`
+    # simulates on the TEST ITEM's scope — but those are not written anywhere in
+    # the tree, so they are invisible from the helper's own analysis, which would
+    # otherwise report `@test` and every package name in it as missing. Worse,
+    # the same helper is typically included from many test items with different
+    # `setup=[...]`, so the real context is not even single-valued. The honest
+    # answer is the same as for an orphan root: names resolve, bare missing-ref
+    # reporting does not.
     if derived_module_unresolved_wildcard_using(rt, root, path) ||
             derived_module_has_computed_include(rt, root, path) ||
             derived_module_has_opaque_macrocall(rt, root, path) ||
+            is_testitem_path(rt, root, path) ||
             (root == file && pkg_folder !== nothing &&
                 !_is_recognized_entry_point(rt, file) &&
                 derived_folder_has_computed_include(rt, pkg_folder))

--- a/src/layer_inventory.jl
+++ b/src/layer_inventory.jl
@@ -4,7 +4,8 @@
 # Strings, Ints, vectors/structs of those) — never an EXPR reference, an
 # objectid, a byte offset, or a docstring — so that body edits produce
 # `isequal` inventories and Salsa's early-exit stops invalidation here.
-# Position/EXPR reattachment lives exclusively in `derived_item_positions`.
+# Position/EXPR reattachment lives exclusively in `derived_item_positions` and
+# `derived_testitem_segments`.
 
 """
     MethodArity(minargs, maxargs, kws, kwsplat)
@@ -135,6 +136,32 @@ end
 end
 
 """
+A `@testitem`/`@testmodule`/`@testsnippet` declared in this file.
+
+TestItemRunner evaluates each of these bodies in a fresh module, so an
+`include(...)` inside one splices into THAT module rather than the enclosing
+one. The record opens a node in the module tree (`ModuleNode.kind ===
+:testitem`) at `vcat(parent_module, [segment])`, and the body's items/includes/
+imports are recorded with that extended `parent_module` — which is what makes
+the ordinary splice machinery place an included helper's declarations where the
+test item can see them.
+
+A test item is NOT a module in any user-facing sense: it declares nothing in
+its parent node, binds no name of its own, and is filtered out of workspace
+symbols. `segment` is an opaque node key, not a name — see
+`_mint_testitem_segment!` for why it is `#`-prefixed and how it stays
+position-free.
+"""
+@auto_hash_equals struct InventoryTestItem
+    order::Int
+    id::Int64
+    kind::Symbol                   # :testitem | :testmodule | :testsnippet
+    label::String                  # the name as written; "" when malformed
+    segment::String                # the module-tree node key for the body
+    parent_module::Vector{String}  # file-relative path of the ENCLOSING module
+end
+
+"""
     FileInventory
 
 The complete top-level API summary of one file. Structural equality (via
@@ -149,11 +176,12 @@ whitespace, comments, or docstrings.
     includes::Vector{InventoryInclude}
     modules::Vector{InventoryModule}
     opaque_macros::Vector{InventoryOpaqueMacro}
+    testitems::Vector{InventoryTestItem}
 end
 
 const EMPTY_FILE_INVENTORY = FileInventory(
     InventoryItem[], InventoryImport[], InventoryExport[], InventoryInclude[], InventoryModule[],
-    InventoryOpaqueMacro[])
+    InventoryOpaqueMacro[], InventoryTestItem[])
 
 # Detect a doc-macro wrapper: a 4-arg :macrocall whose first arg is a doc-macro
 # name (`StaticLint.is_doc_macro_name` — the implicit `globalrefdoc` or an
@@ -170,10 +198,16 @@ end
 """
     _foreach_toplevel_item(f, cst)
 
-Call `f(x, order, id, parent_module, offset)` for every top-level item-like node
-of a `:file` CST in pre-order: the file's direct children, plus — for
-`module`/`baremodule` declarations — the module node itself and then the
-children of its body block (never the bodies of functions, structs, etc.).
+Call `f(x, order, id, parent_module, offset, testitem_segment)` for every
+top-level item-like node of a `:file` CST in pre-order: the file's direct
+children, plus — for `module`/`baremodule` declarations — the module node itself
+and then the children of its body block (never the bodies of functions, structs,
+etc.).
+
+`testitem_segment` is `nothing` for every node except a testitem-family
+macrocall (`@testitem`/`@testmodule`/`@testsnippet`) with a body block, where it
+is the module-tree node key minted for that body; the body's own statements are
+then walked with `parent_module` extended by it. See `InventoryTestItem`.
 
 `order` is sequential in visit order and is what the module tree sorts on to
 recover textual-splice semantics. `id` is the statement's identity, which is
@@ -189,6 +223,9 @@ arm for `:if`/`:block`, so definitions inside them bind at the enclosing
 level): their statement lists are walked as if they were direct siblings of
 the container, at the same `parent_module` and continuing the same order
 sequence; the container node itself gets no order/id and is never passed to `f`.
+Testitem-family macrocalls are descended into, but their statements land in a
+`:testitem` node of their own rather than at the enclosing level — see
+`_testitem_family_kind`. `@testset`/`@safetestset` stay opaque.
 Non-isolating macrocalls (everything except the testitem/testset families and
 `@enum`, see `_is_isolated_scope_macrocall`) are transparent the same way:
 StaticLint traverses a macrocall's arguments in the enclosing scope, so
@@ -229,8 +266,10 @@ mutable struct _ItemIdAllocator
     order::Int
     buckets::Dict{_IdKey,Int}
     assigned::Set{Int64}
+    testitem_counts::Dict{Tuple{Symbol,String},Int}
 end
-_ItemIdAllocator() = _ItemIdAllocator(0, Dict{_IdKey,Int}(), Set{Int64}())
+_ItemIdAllocator() = _ItemIdAllocator(0, Dict{_IdKey,Int}(), Set{Int64}(),
+                                     Dict{Tuple{Symbol,String},Int}())
 
 # Mint the `(order, id)` pair for one statement. Called exactly once per visited
 # statement, so every record the classifier derives from it shares both.
@@ -340,15 +379,30 @@ function _walk_one!(f, a, parent_module::Vector{String}, offset::Int, alloc::_It
     # its `?` operator token. So only descend when `trivia[1]` is the
     # real keyword; a ternary falls through to the `else` branch below and
     # is treated as a single opaque item (no descent into its arms).
+    ti_kind = _testitem_family_kind(item)
+    ti_body = ti_kind === nothing ? nothing : _testitem_body(item, item_offset)
+
     if CSTParser.headof(item) === :if && CSTParser.headof(item.trivia[1]) === :IF
         _walk_if_chain!(f, item, parent_module, item_offset, alloc)
     elseif CSTParser.headof(item) === :block
         _walk_transparent_block!(f, item, parent_module, item_offset, alloc)
+    elseif ti_body !== nothing
+        # A testitem-family body is a fresh module at runtime, so it gets its
+        # own node and its statements are recorded under it. The macrocall
+        # itself still produces the `:opaque_macrocall` usage row in the
+        # ENCLOSING module (via `f` below, unchanged) — consumers filter on
+        # that kind and must keep seeing it.
+        order, id = _mint_ids!(alloc, item, parent_module)
+        segment = _mint_testitem_segment!(alloc, ti_kind, _testitem_label(ti_kind, item))
+        f(item, order, id, parent_module, item_offset, segment)
+
+        body, body_offset = ti_body
+        _walk_transparent_block!(f, body, vcat(parent_module, [segment]), body_offset, alloc)
     elseif CSTParser.ismacrocall(item) && !_is_enum_macro(item) && !_is_isolated_scope_macrocall(item)
         _walk_macrocall!(f, item, parent_module, item_offset, alloc)
     else
         order, id = _mint_ids!(alloc, item, parent_module)
-        f(item, order, id, parent_module, item_offset)
+        f(item, order, id, parent_module, item_offset, nothing)
 
         if CSTParser.defines_module(item) && item.args !== nothing && length(item.args) >= 3
             mod_name = CSTParser.isidentifier(item.args[2]) ? StaticLint.valofid(item.args[2]) : nothing
@@ -387,6 +441,91 @@ function _is_isolated_scope_macrocall(x::CSTParser.EXPR)
         mname == "@testmodule" || mname == "@testsnippet"
 end
 
+# The testitem-family subset of `_is_isolated_scope_macrocall`: the three macros
+# whose body really is a fresh MODULE at runtime, so an `include` inside splices
+# into that module. `_walk_one!` descends into these (into a `:testitem` node),
+# while `@testset`/`@safetestset` stay opaque — see `InventoryTestItem` and the
+# module-tree `:testitem` event.
+#
+# Delegates to StaticLint's own matchers rather than restating the names, so the
+# two cannot drift and the qualified `TestItems.@testitem` form is recognised
+# identically on both sides.
+function _testitem_family_kind(x::CSTParser.EXPR)
+    CSTParser.ismacrocall(x) || return nothing
+    (x.args === nothing || isempty(x.args)) && return nothing
+    name = x.args[1]
+    name isa CSTParser.EXPR || return nothing
+    StaticLint._is_testitem_macro(name) && return :testitem
+    StaticLint._is_testmodule_macro(name) && return :testmodule
+    StaticLint._is_testsnippet_macro(name) && return :testsnippet
+    return nothing
+end
+
+# The test item's name as written: the string literal for `@testitem`, the
+# identifier for `@testmodule`/`@testsnippet` (both name a setup, and
+# `derived_test_setups_in_file` reads them the same way). `""` when the
+# macrocall is malformed — the segment stays unique via the occurrence counter
+# regardless.
+function _testitem_label(kind::Symbol, x::CSTParser.EXPR)
+    args = x.args
+    (args === nothing || length(args) < 3) && return ""
+    name_expr = args[3]
+    name_expr isa CSTParser.EXPR || return ""
+    if kind === :testmodule || kind === :testsnippet
+        nm = _item_name(name_expr)
+        return nm === nothing ? "" : nm
+    end
+    CSTParser.isstringliteral(name_expr) || return ""
+    v = CSTParser.str_value(name_expr)
+    return v isa AbstractString ? String(v) : ""
+end
+
+# The body block of a testitem-family macrocall, with its 0-based byte offset:
+# the first `:block` argument. Offsets come from CSTParser's source-order child
+# iteration (`for c in x`, which interleaves args and trivia), the same
+# technique `_walk_macrocall!` uses — summing arg fullspans alone would drift
+# for the call form `@testitem("n", begin … end)`, where paren/comma trivia sit
+# between the args.
+function _testitem_body(x::CSTParser.EXPR, offset::Int)
+    args = x.args
+    args === nothing && return nothing
+    child_offset = offset
+    for c in x
+        if CSTParser.headof(c) === :block && any(j -> args[j] === c, 3:length(args))
+            return (c, child_offset)
+        end
+        child_offset += c.fullspan
+    end
+    return nothing
+end
+
+# The module-tree node key for one test-item body.
+#
+# `"#" * kind * "#" * label * "#" * n`, where `n` is the 1-based occurrence
+# index of that `(kind, label)` pair WITHIN THE FILE — test-item names repeat,
+# so a counter is required.
+#
+# Two properties this scheme exists for:
+#
+#   * Position-free. The header's rule (no offsets in inventory values) is what
+#     makes a body edit produce an `isequal` inventory and stop Salsa's
+#     invalidation here; an offset-derived key would re-invalidate the whole
+#     root's module tree on every keystroke. This is exactly as stable as
+#     `_mint_ids!`'s bucket disambiguator, and keeping the LABEL in the key
+#     (rather than a bare running counter) means inserting a test item shifts
+#     only its same-labelled siblings instead of everything after it.
+#   * Unwritable. The leading `#` makes the segment impossible to name in Julia
+#     source, so no `using` can reach the node and `_classify_import`'s anchor
+#     walk can never land on it. That is a safety guarantee only — the semantic
+#     test for "this is a test item, not a module" is always
+#     `ModuleNode.kind === :testitem`.
+function _mint_testitem_segment!(alloc::_ItemIdAllocator, kind::Symbol, label::String)
+    key = (kind, label)
+    n = get(alloc.testitem_counts, key, 0) + 1
+    alloc.testitem_counts[key] = n
+    return string('#', kind, '#', label, '#', n)
+end
+
 # Walks a non-isolating macrocall's macro ARGUMENTS as top-level items: the
 # macro-name component (`args[1]`) and the parameters placeholder (`args[2]`,
 # a zero-span `:NOTHING` node) are skipped; every remaining arg goes through
@@ -406,7 +545,7 @@ function _walk_macrocall!(f, mc::CSTParser.EXPR, parent_module::Vector{String}, 
     # definitions inside still become ordinary items.
     if !StaticLint._macro_name_effects_known(_macro_name_string(margs[1]))
         order, id = _mint_ids!(alloc, mc, parent_module)
-        f(mc, order, id, parent_module, offset)
+        f(mc, order, id, parent_module, offset, nothing)
     end
 
     child_offset = offset
@@ -477,11 +616,19 @@ Salsa.@derived function derived_file_inventory(rt, uri)
         offset => target for (offset, _, target, _) in include_records)
 
     acc = (items=InventoryItem[], imports=InventoryImport[], exports=InventoryExport[],
-           includes=InventoryInclude[], modules=InventoryModule[], opaque_macros=InventoryOpaqueMacro[])
-    _foreach_toplevel_item(cst) do x, order, id, parent_module, offset
-        _classify_item!(acc, x, order, id, copy(parent_module), offset, include_targets_by_offset, include_records)
+           includes=InventoryInclude[], modules=InventoryModule[], opaque_macros=InventoryOpaqueMacro[],
+           testitems=InventoryTestItem[])
+    _foreach_toplevel_item(cst) do x, order, id, parent_module, offset, testitem_segment
+        pm = copy(parent_module)
+        if testitem_segment !== nothing
+            kind = _testitem_family_kind(x)
+            kind === nothing || push!(acc.testitems, InventoryTestItem(
+                order, id, kind, _testitem_label(kind, x), testitem_segment, pm))
+        end
+        _classify_item!(acc, x, order, id, pm, offset, include_targets_by_offset, include_records)
     end
-    return FileInventory(acc.items, acc.imports, acc.exports, acc.includes, acc.modules, acc.opaque_macros)
+    return FileInventory(acc.items, acc.imports, acc.exports, acc.includes, acc.modules,
+                         acc.opaque_macros, acc.testitems)
 end
 
 _render_sig(x) = try
@@ -1013,8 +1160,38 @@ Salsa.@derived function derived_item_positions(rt, uri)
     cst = derived_julia_legacy_syntax_tree(rt, uri)
     (cst isa CSTParser.EXPR && CSTParser.headof(cst) === :file) || return result
 
-    _foreach_toplevel_item(cst) do x, _order, id, parent_module, offset
+    _foreach_toplevel_item(cst) do x, _order, id, parent_module, offset, _segment
         result[id] = (expr=x, offset=offset)
+    end
+    return result
+end
+
+"""
+    derived_testitem_segments(rt, uri) -> Dict{UInt64,String}
+
+Map the `objectid` of each testitem-family macrocall EXPR to the module-tree
+segment `derived_file_inventory` recorded for its body.
+
+Volatile and objectid-keyed — the objectids are only valid for the CST instance
+they were built from — so it is deliberately kept OUT of `FileInventory`, which
+must stay position- and identity-free for the cutoff contract. Same shape and
+same lifetime caveat as `derived_include_dict`/`derived_computed_include_ids`,
+and consumed the same way: from inside the semantic pass, which is traversing
+that exact CST. This is how `_handle_testitem` learns the segment the inventory
+walker minted, instead of re-deriving it (and drifting: StaticLint traverses
+everything, the inventory walker only top-level-ish statements).
+"""
+Salsa.@derived function derived_testitem_segments(rt, uri)
+    @debug "derived_testitem_segments" uri=uri
+
+    result = Dict{UInt64,String}()
+
+    derived_has_content(rt, uri) || return result
+    cst = derived_julia_legacy_syntax_tree(rt, uri)
+    (cst isa CSTParser.EXPR && CSTParser.headof(cst) === :file) || return result
+
+    _foreach_toplevel_item(cst) do x, _order, _id, _parent_module, _offset, segment
+        segment === nothing || (result[UInt64(objectid(x))] = segment)
     end
     return result
 end

--- a/src/layer_module_tree.jl
+++ b/src/layer_module_tree.jl
@@ -69,6 +69,13 @@ end
 A module within the tree (including the synthetic root).
 
 - `path`: absolute module path in this root; `String[]` for the root file's top level
+- `kind`: `:root` for the synthetic root node, `:module` for a `module`/`baremodule`,
+  `:testitem` for a `@testitem`/`@testmodule`/`@testsnippet` body (see
+  `InventoryTestItem`). A `:testitem` node is a real runtime module — an `include`
+  inside splices into it — but is NOT a module in any user-facing sense: it declares
+  nothing in its parent, binds no name of its own, and is excluded from workspace
+  symbols and the workspace-package edge walks. Every consumer that must exclude
+  test items tests this field; never the shape of the path segment.
 - `bare`: whether this is a `baremodule` (false for the synthetic root node)
 - `declared_at`: where this module was declared (`nothing` for the synthetic root node)
 - `files`: files whose top level splices here, in include order
@@ -79,6 +86,7 @@ A module within the tree (including the synthetic root).
 """
 @auto_hash_equals struct ModuleNode
     path::Vector{String}               # absolute path in this root; String[] = the root file's own top level
+    kind::Symbol                       # :root | :module | :testitem
     bare::Bool                         # baremodule (false for the synthetic root node)
     declared_at::Union{Nothing,ItemRef}   # nothing for the synthetic root node
     files::Vector{URI}                 # files whose top level splices here, in include order
@@ -95,7 +103,9 @@ The complete module structure of a root file (with its includes).
 
 - `root`: the root file's URI
 - `modules`: all modules (sorted by path for deterministic equality)
-- `file_modules`: for each file, the absolute module path its top level splices into
+- `file_modules`: for each file, the absolute module path its top level splices into.
+  A helper included from several test items is spliced at several paths; this
+  records the FIRST, which is the context the file itself is analyzed in.
 """
 @auto_hash_equals struct ModuleTree
     root::URI
@@ -172,6 +182,7 @@ const _BINDING_ITEM_KINDS = (
 # (pass 2) to populate `imports` with real `ResolvedImport`s. `imports` is
 # empty until pass 2 runs.
 mutable struct _ModuleNodeBuilder
+    kind::Symbol
     bare::Bool
     declared_at::Union{Nothing,ItemRef}
     files::Vector{URI}
@@ -187,7 +198,7 @@ mutable struct _ModuleNodeBuilder
 end
 
 _ModuleNodeBuilder() = _ModuleNodeBuilder(
-    false, nothing, URI[], Dict{String,ItemRef}(), Dict{String,Symbol}(),
+    :module, false, nothing, URI[], Dict{String,ItemRef}(), Dict{String,Symbol}(),
     String[], String[], Tuple{URI,InventoryImport}[], ResolvedImport[])
 
 _is_datatype_kind(k::Symbol) =
@@ -231,6 +242,13 @@ which includes something deep" resolve exactly like running the code would:
 the deepest, textually-last declaration of a name always wins, and a node's
 `files` list is true depth-first pre-order, not level-order.
 
+A `@testitem`/`@testmodule`/`@testsnippet` body opens a `:testitem` node of its
+own (it is a fresh module at runtime), and includes inside it splice there.
+Because the common idiom is many test items in one file each including the same
+helper, splices into a test-item node are admitted per `(target, path)` rather
+than per target — see the `spliced`/`stack` comments below. `file_modules`
+consequently records the FIRST splice path for a multiply-spliced file.
+
 Also collects `using`/`import` statements verbatim, as `(file, InventoryImport)`
 pairs on the declaring node's `raw_imports`, at their absolute module path —
 this pass never inspects import targets, it only records where each one was
@@ -243,15 +261,44 @@ function _build_tree_structure(rt, root::URI)
 
     # Rule 8: the synthetic root node always exists, even for a root file with
     # no content or no includes.
-    ensure_node!(String[])
+    ensure_node!(String[]).kind = :root
 
     file_modules = Dict{URI,Vector{String}}()
 
     # Rule 1: visited-set guarded exactly like `derived_include_closure` —
-    # first include wins in true source order (see below), later includes of
-    # an already-visited file are skipped, and cycles terminate. Seeded with
-    # `root` up front so a file including itself is also caught.
+    # first include wins in true source order (see below), and later includes
+    # of an already-visited file are skipped. Seeded with `root` up front so a
+    # file including itself is also caught.
     visited = Set{URI}([root])
+
+    # Rule 1, test-item exception. A `@testitem` body is a separate runtime
+    # module, and the overwhelmingly common idiom is N test items in one file
+    # each doing `include("shared.jl")` — under plain first-include-wins the
+    # helper would splice into the FIRST test item only and every other body
+    # would see nothing. So a splice into (or under) a `:testitem` node is
+    # admitted once per (target, path) instead of once per target.
+    #
+    # Ordinary paths keep exact first-include-wins semantics. A file included
+    # both inside a test item and at an ordinary top level therefore splices in
+    # both places, which is what actually happens at runtime.
+    #
+    # With per-path admission the global visited set can no longer terminate
+    # cycles (a self-include inside a test item generates a fresh, deeper path
+    # every time), so `stack` — the files on the current DFS chain — does it.
+    spliced = Set{Tuple{URI,Vector{String}}}()
+    stack = Set{URI}([root])
+
+    # Whether `p` is a test-item body or nested inside one. Reads the builders
+    # rather than the finished tree (this IS the pass that builds it): the
+    # `:testitem` event carries a lower `order` than anything in its body, so
+    # the node's kind is always set before its includes are reached.
+    function under_testitem(p::Vector{String})
+        for i in 1:length(p)
+            b = get(builders, p[1:i], nothing)
+            b !== nothing && b.kind === :testitem && return true
+        end
+        return false
+    end
 
     # Recursive DFS splice of one file F at absolute path P. Rules 3 & 5
     # write into the very same `declared` dict (a module's own name enters
@@ -262,8 +309,12 @@ function _build_tree_structure(rt, root::URI)
     # `order` and processed in that single pass, `include` events recursing
     # in-place, to reproduce true textual splice order exactly.
     function splice_file!(F::URI, P::Vector{String})
-        # Rule 7.
-        file_modules[F] = P
+        # Rule 7. `get!`, not assignment: a helper included from several test
+        # items is spliced several times, and `file_modules` records ONE path
+        # per file — the first splice's, which is the context the file itself
+        # is analyzed in. Equivalent to the old assignment for every file that
+        # is spliced exactly once.
+        get!(file_modules, F, P)
 
         # The file's own top level splices at P; recording F here handles
         # both the root file (no includer) and included files uniformly —
@@ -292,6 +343,9 @@ function _build_tree_structure(rt, root::URI)
         for inc in inv.includes
             push!(events, (inc.order, :include, inc))
         end
+        for ti in inv.testitems
+            push!(events, (ti.order, :testitem, ti))
+        end
         # Secondary key: for an assignment-wrapped include (`const DATA =
         # include("data.jl")`), the item and the include share the SAME order —
         # both come from the one top-level statement. Real Julia evaluates
@@ -317,6 +371,19 @@ function _build_tree_structure(rt, root::URI)
                 # ...and the module's own name also enters the *parent*
                 # node's `declared`, exactly like a binding item (rule 5).
                 _declare!(ensure_node!(vcat(P, m.parent_module)), m.name, ItemRef(F, m.id), :module)
+            elseif kind === :testitem
+                # A `@testitem`/`@testmodule`/`@testsnippet` body is a fresh
+                # module at runtime, so it opens a node of its own and the
+                # body's items (recorded by the inventory walker with the
+                # extended `parent_module`) splice into it. Deliberately unlike
+                # the `:module` arm: NO `_declare!` into the parent — a test
+                # item binds no name, so nothing can reference it. Creating the
+                # node here rather than letting it materialise from child items
+                # means an EMPTY body is still represented.
+                ti = payload
+                node = ensure_node!(vcat(P, ti.parent_module, [ti.segment]))
+                node.kind = :testitem
+                node.declared_at = ItemRef(F, ti.id)
             elseif kind === :export
                 # Rule 6.
                 e = payload
@@ -340,10 +407,19 @@ function _build_tree_structure(rt, root::URI)
                 # The node at newP must exist regardless of whether this
                 # particular include resolves (other items may share RP).
                 ensure_node!(newP)
-                inc.target in visited && continue
                 derived_has_content(rt, inc.target) || continue
-                push!(visited, inc.target)
+                inc.target in stack && continue     # cycle
+                if under_testitem(newP)
+                    key = (inc.target, newP)
+                    key in spliced && continue
+                    push!(spliced, key)
+                else
+                    inc.target in visited && continue
+                    push!(visited, inc.target)
+                end
+                push!(stack, inc.target)
                 splice_file!(inc.target, newP)
+                delete!(stack, inc.target)
             end
         end
     end
@@ -492,7 +568,7 @@ Salsa.@derived function derived_module_tree(rt, root)
     _classify_imports!(rt, builders)
 
     modules = ModuleNode[
-        ModuleNode(path, b.bare, b.declared_at, b.files, b.declared, b.exports, b.publics, b.imports)
+        ModuleNode(path, b.kind, b.bare, b.declared_at, b.files, b.declared, b.exports, b.publics, b.imports)
         for (path, b) in builders]
     sort!(modules; by=n -> n.path, alg=Base.Sort.MergeSort)
 
@@ -689,6 +765,43 @@ Salsa.@derived function derived_module_is_bare(rt, root, path)
 end
 
 """
+    derived_module_is_testitem(rt, root, path::Vector{String}) -> Bool
+
+Whether `path` names a `@testitem`/`@testmodule`/`@testsnippet` body rather
+than a real module (`ModuleNode.kind === :testitem`). A per-module `Bool`
+projection for the same cutoff reason as [`derived_module_is_bare`](@ref).
+
+Consumers that need "is this path INSIDE a test item" — including any of its
+enclosing prefixes — want [`is_testitem_path`](@ref) instead.
+"""
+Salsa.@derived function derived_module_is_testitem(rt, root, path)
+    @debug "derived_module_is_testitem" root=root path=path
+
+    node = module_node(derived_module_tree(rt, root), path)
+    return node !== nothing && node.kind === :testitem
+end
+
+"""
+    is_testitem_path(rt, root, path::Vector{String}) -> Bool
+
+Whether `path` lies inside a test-item body: itself a `:testitem` node, or
+nested under one (a `module` declared inside a `@testitem` body, say).
+
+The single place anything asks "is this a test item, not a module". Reads the
+per-module `derived_module_is_testitem` selector for each prefix rather than
+inspecting the path segments, so the naming scheme in
+`_mint_testitem_segment!` stays an implementation detail of the inventory
+walker — and so a consumer inside a per-file analysis frame takes only
+`Bool`-valued dependencies.
+"""
+function is_testitem_path(rt, root, path::Vector{String})
+    for i in 1:length(path)
+        derived_module_is_testitem(rt, root, path[1:i]) && return true
+    end
+    return false
+end
+
+"""
     derived_module_declared_at(rt, root, path::Vector{String}) -> Union{Nothing,ItemRef}
 
 The `ItemRef` of the `module` declaration for the module at `path` — a
@@ -783,10 +896,26 @@ end
 # extend) a name — an `:opaque_macrocall` row named `@foo` is a top-level USAGE
 # of the macro, not a method of it. The keep-predicate and payload live in
 # `emit`; shared by the method-item and external-extension projections.
+#
+# The include-admission rule mirrors `_build_tree_structure`'s exactly,
+# test-item exception included: a helper included from N test items must be
+# emitted at all N paths, or the method/arity sets of every test item but the
+# first would be empty. `titems`/`spliced`/`stack` play the same roles as they
+# do there; the defaults make the top-level call sites read unchanged.
 function _walk_spliced_binding_items!(emit, rt, F::URI, P::Vector{String},
                                       name::Union{Nothing,String}, visited::Set{URI};
-                                      kinds=_BINDING_ITEM_KINDS)
+                                      kinds=_BINDING_ITEM_KINDS,
+                                      titems::Set{Vector{String}}=Set{Vector{String}}(),
+                                      spliced::Set{Tuple{URI,Vector{String}}}=Set{Tuple{URI,Vector{String}}}(),
+                                      stack::Set{URI}=Set{URI}([F]))
     inv = derived_file_inventory(rt, F)
+
+    # Register this file's test-item node paths before walking, so the
+    # under-test-item check below sees them regardless of event order.
+    for ti in inv.testitems
+        push!(titems, vcat(P, ti.parent_module, [ti.segment]))
+    end
+    under_testitem(p) = any(i -> p[1:i] in titems, 1:length(p))
 
     events = Tuple{Int,Symbol,Any}[]
     for item in inv.items
@@ -805,10 +934,21 @@ function _walk_spliced_binding_items!(emit, rt, F::URI, P::Vector{String},
         else
             inc = payload
             inc.target === nothing && continue
-            inc.target in visited && continue
             derived_has_content(rt, inc.target) || continue
-            push!(visited, inc.target)
-            _walk_spliced_binding_items!(emit, rt, inc.target, vcat(P, inc.parent_module), name, visited; kinds)
+            inc.target in stack && continue
+            newP = vcat(P, inc.parent_module)
+            if under_testitem(newP)
+                key = (inc.target, newP)
+                key in spliced && continue
+                push!(spliced, key)
+            else
+                inc.target in visited && continue
+                push!(visited, inc.target)
+            end
+            push!(stack, inc.target)
+            _walk_spliced_binding_items!(emit, rt, inc.target, newP, name, visited;
+                                         kinds, titems, spliced, stack)
+            delete!(stack, inc.target)
         end
     end
     return

--- a/src/layer_symbols.jl
+++ b/src/layer_symbols.jl
@@ -295,7 +295,17 @@ function _get_workspace_symbols(runtime, query::String)
         (isempty(inv.items) && isempty(inv.modules)) && continue
         positions = derived_item_positions(runtime, uri)
 
+        # Names declared inside a `@testitem`/`@testmodule`/`@testsnippet` body
+        # are recorded under that body's tree node (so its `include`s resolve),
+        # but they are test-local and were never workspace symbols before —
+        # keep them out. Matched against the file's own recorded segments, not
+        # by the shape of the segment string.
+        ti_segments = Set{String}(ti.segment for ti in inv.testitems)
+        in_testitem(parent_module) =
+            !isempty(ti_segments) && any(seg -> seg in ti_segments, parent_module)
+
         for it in inv.items
+            in_testitem(it.parent_module) && continue
             # `:opaque_macrocall` rows stand in for isolated-scope macrocalls
             # (`@testitem`/`@testset`/…); the old bindingof walk collected no
             # binding for those, so they are not workspace symbols.
@@ -319,6 +329,7 @@ function _get_workspace_symbols(runtime, query::String)
         # Modules live in `inv.modules`, not `inv.items`; the old bindingof walk
         # collected module names as symbols, so include them to preserve that.
         for m in inv.modules
+            in_testitem(m.parent_module) && continue
             _symbol_matches_query(m.name, query) || continue
             entry = get(positions, m.id, nothing)
             entry === nothing && continue

--- a/src/layer_visibility.jl
+++ b/src/layer_visibility.jl
@@ -1,5 +1,11 @@
 # Layer 3 (env seam) of the inventory architecture: per-module visible
 # names — the names reachable in a module through its classified imports
+#
+# "Module" here includes the `:testitem` nodes a `@testitem`/`@testmodule`/
+# `@testsnippet` body opens (they really are modules at runtime, and a file
+# `include`d in the body is spliced into one). The single difference is that a
+# test-item node records no SELF-binding: its path segment is an opaque tree
+# key, not a name anything can write.
 # (`derived_module_imports`, from layer_module_tree.jl), gated by the
 # workspace's own packages (`derived_workspace_package_roots`) and, for
 # `:external` targets, the SymbolServer-backed environment
@@ -852,8 +858,10 @@ function _visible_names_pass1(rt, root, path::Vector{String}, visited::Set{URI})
     # `origin_module` is the DECLARING module's path (the parent), consistent
     # with every other `:declared` binding, which is exactly why the ledger
     # entry records the denoted module's FULL path separately.
+    # A `:testitem` node is a runtime module but binds no name — its segment is
+    # an opaque tree key, not an identifier — so it gets no self-binding.
     node = module_node(derived_module_tree(rt, root), path)
-    if node !== nothing && !isempty(path)
+    if node !== nothing && !isempty(path) && node.kind !== :testitem
         _record!(result, modtargets, path[end],
             VisibleName(:module, :declared, node.declared_at, path[1:end - 1]),
             ImportTarget(:tree, path))

--- a/test/staticlint/test_testitem_analysis.jl
+++ b/test/staticlint/test_testitem_analysis.jl
@@ -714,3 +714,187 @@ end
     """)
     @test diag_messages(jw) isa Vector
 end
+
+# --- `include(...)` inside a testitem-family body -----------------------------
+#
+# A `@testitem` body is a fresh module at runtime, so an `include` there splices
+# the target into THAT module. The inventory records the body as a `:testitem`
+# node and the ordinary splice machinery does the rest; these tests pin the
+# user-visible consequence.
+
+@testitem "names from a file included in a @testitem body resolve" setup=[TestItemAnalysisWS] begin
+    shared = URI("file:///pkg/test/shared.jl")
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testitem "one" begin
+        include("shared.jl")
+        helper
+    end
+
+    @testitem "two" begin
+        include("shared.jl")
+        helper
+    end
+    """, extra=Dict(shared => "helper(x) = x\n"))
+
+    msgs = diag_messages(jw)
+    # Both bodies, not just the first: the splice rule admits the helper once
+    # per test item.
+    @test !("Missing reference: helper" in msgs)
+end
+
+@testitem "an include in a @testitem body carries transitively" setup=[TestItemAnalysisWS] begin
+    shared = URI("file:///pkg/test/shared.jl")
+    deeper = URI("file:///pkg/test/deeper.jl")
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testitem "t" begin
+        include("shared.jl")
+        deep_helper
+    end
+    """, extra=Dict(
+        shared => "include(\"deeper.jl\")\n",
+        deeper => "deep_helper() = 1\n"))
+
+    @test !("Missing reference: deep_helper" in diag_messages(jw))
+end
+
+@testitem "colon imports in an included helper reach the testitem body" setup=[TestItemAnalysisWS] begin
+    # The shape CSTParser's own `test/shared.jl` uses: the helper's top-level
+    # `using ...: name` bring-ins must be visible too, not just its declarations.
+    shared = URI("file:///pkg/test/shared.jl")
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testitem "t" begin
+        include("shared.jl")
+        ifn
+    end
+    """, extra=Dict(shared => "using MyPkg: ifn\n"))
+
+    @test !("Missing reference: ifn" in diag_messages(jw))
+end
+
+@testitem "an include in a testitem body is not a blanket suppression" setup=[TestItemAnalysisWS] begin
+    shared = URI("file:///pkg/test/shared.jl")
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testitem "t" begin
+        include("shared.jl")
+        helper
+        genuinely_undefined
+    end
+    """, extra=Dict(shared => "helper() = 1\n"))
+
+    msgs = diag_messages(jw)
+    @test !("Missing reference: helper" in msgs)
+    @test "Missing reference: genuinely_undefined" in msgs
+end
+
+@testitem "included names stay inside the test item that includes them" setup=[TestItemAnalysisWS] begin
+    shared = URI("file:///pkg/test/shared.jl")
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    helper
+
+    @testitem "with" begin
+        include("shared.jl")
+        helper
+    end
+
+    @testitem "without" begin
+        helper
+    end
+    """, extra=Dict(shared => "helper() = 1\n"))
+
+    msgs = diag_messages(jw)
+    # Two sites must still report: the file top level and the sibling item that
+    # does not include the helper.
+    @test count(==("Missing reference: helper"), msgs) == 2
+end
+
+@testitem "a helper included by a test item is analyzed, but conservatively" setup=[TestItemAnalysisWS] begin
+    shared = URI("file:///pkg/test/shared.jl")
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testitem "t" begin
+        include("shared.jl")
+    end
+    """, extra=Dict(shared => "helper() = whatever_the_testitem_provides\n"))
+    rt = jw.runtime
+
+    # It now has a module context (it did not before: included only from a body
+    # the inventory refused to descend into, it was spliced nowhere).
+    path = JuliaWorkspaces.derived_file_module_path(rt, TESTF, shared)
+    @test path !== nothing
+    @test JuliaWorkspaces.is_testitem_path(rt, TESTF, path)
+
+    # But the test item's simulated `using Test`/`using MyPkg` are not written
+    # anywhere in the tree, so bare missing-ref reporting there is suppressed
+    # rather than wrong.
+    msgs = [d.message for d in JuliaWorkspaces.derived_file_analysis(rt, TESTF, shared).diagnostics]
+    @test !any(m -> startswith(m, "Missing reference:"), msgs)
+end
+
+@testitem "names declared in a testitem body are not workspace symbols" setup=[TestItemAnalysisWS] begin
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testitem "t" begin
+        a_testitem_local_name() = 1
+    end
+    """)
+    names = [s.name for s in JuliaWorkspaces.get_workspace_symbols(jw, "a_testitem_local_name")]
+    @test isempty(names)
+end
+
+@testitem "a computed include suppresses only its own test item" setup=[TestItemAnalysisWS] begin
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testitem "computed" begin
+        include(some_path_expression)
+        anything_at_all
+    end
+
+    @testitem "plain" begin
+        undefined_in_sibling
+    end
+    """)
+    msgs = diag_messages(jw)
+    # Unknown code is spliced into the first body, so it abstains...
+    @test !("Missing reference: anything_at_all" in msgs)
+    # ...but the sibling test item and the file top level keep reporting.
+    @test "Missing reference: undefined_in_sibling" in msgs
+end
+
+@testitem "a missing include target in a testitem body does not throw" setup=[TestItemAnalysisWS] begin
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testitem "t" begin
+        include("no_such_file.jl")
+    end
+    """)
+    @test diag_messages(jw) isa Vector
+end
+
+@testitem "an include in a @testmodule body reaches referencing test items" setup=[TestItemAnalysisWS] begin
+    setups = URI("file:///pkg/test/setups.jl")
+    shared = URI("file:///pkg/test/shared.jl")
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testitem "t" setup=[TM] begin
+        TM.helper
+    end
+    """, extra=Dict(
+        setups => """
+        @testmodule TM begin
+            include("shared.jl")
+        end
+        """,
+        shared => "helper() = 1\n"))
+
+    @test diag_messages(jw) isa Vector
+end
+
+@testitem "an include inside a @testset stays opaque" setup=[TestItemAnalysisWS] begin
+    # `@testset` introduces no module, so it is deliberately NOT descended into
+    # — the include is invisible to the inventory and the name does not resolve.
+    # Pinned so the known gap is a decision, not a surprise.
+    shared = URI("file:///pkg/test/shared.jl")
+    jw = pkg_ws(entry=DEFAULT_ENTRY, testfile="""
+    @testset "s" begin
+        include("shared.jl")
+        helper
+    end
+    """, extra=Dict(shared => "helper() = 1\n"))
+
+    @test "Missing reference: helper" in diag_messages(jw)
+end

--- a/test/test_file_analysis.jl
+++ b/test/test_file_analysis.jl
@@ -2250,3 +2250,51 @@ end
     @test !any(d -> occursin("method matching", d.message) ||
                     occursin("method call error", d.message), fa.diagnostics)
 end
+
+@testitem "invalidation: a body edit in a testitem-included helper backdates" setup=[FileAnalysisWS] begin
+    import JuliaWorkspaces.Salsa.TraceLogging as TL
+
+    mutable struct TICountReceiver <: TL.AbstractTraceReceiver
+        counts::Dict{String,Int}
+    end
+    TICountReceiver() = TICountReceiver(Dict{String,Int}())
+    TL.receive_span(r::TICountReceiver, span::TL.TraceSpan) =
+        (r.counts[span.name] = get(r.counts, span.name, 0) + 1; nothing)
+
+    TESTS = URI("file:///t/test/tests.jl")
+    SHARED = URI("file:///t/test/shared.jl")
+
+    jw = ws_with(Dict(
+        TESTS => """
+        @testitem "one" begin
+            include("shared.jl")
+            helper(1)
+        end
+        """,
+        SHARED => "helper(x) = x + 1\n",
+    ))
+    rt = jw.runtime
+
+    # untraced baseline
+    fa0 = JuliaWorkspaces.derived_file_analysis(rt, TESTS, TESTS)
+    @test !isempty(fa0.meta)
+    inv0 = JuliaWorkspaces.derived_file_inventory(rt, SHARED)
+    JuliaWorkspaces.derived_module_tree(rt, TESTS)
+
+    # A body-only edit in the helper: the test item's segment must not encode
+    # position, or the inventory would differ and the whole tree would rebuild.
+    JuliaWorkspaces.update_file!(jw, TextFile(SHARED, SourceText("helper(x) = x * 42\n", "julia")))
+    @test isequal(inv0, JuliaWorkspaces.derived_file_inventory(rt, SHARED))
+
+    recv = TICountReceiver()
+    TL.with_tracing(() -> JuliaWorkspaces.derived_file_analysis(rt, TESTS, TESTS), recv)
+    @test get(recv.counts, "derived_file_analysis", 0) == 0
+    @test get(recv.counts, "derived_module_tree", 0) == 0
+
+    # Renaming a top-level name in the helper DOES change what the test item
+    # sees, so that analysis must re-execute.
+    JuliaWorkspaces.update_file!(jw, TextFile(SHARED, SourceText("renamed_helper(x) = x\n", "julia")))
+    recv2 = TICountReceiver()
+    TL.with_tracing(() -> JuliaWorkspaces.derived_file_analysis(rt, TESTS, TESTS), recv2)
+    @test get(recv2.counts, "derived_file_analysis", 0) == 1
+end

--- a/test/test_inventory.jl
+++ b/test/test_inventory.jl
@@ -1,6 +1,6 @@
 @testitem "inventory types: structural equality across separately built instances" begin
     using JuliaWorkspaces: FileInventory, InventoryItem, InventoryImport, InventoryExport,
-        InventoryInclude, InventoryModule, InventoryOpaqueMacro, ImportSymbol
+        InventoryInclude, InventoryModule, InventoryOpaqueMacro, InventoryTestItem, ImportSymbol
     using JuliaWorkspaces.URIs2: URI
 
     make() = FileInventory(
@@ -11,6 +11,7 @@
         [InventoryInclude(5, 105, URI("file:///pkg/src/a.jl"), String[])],
         [InventoryModule(6, 106, "M", false, String[])],
         [InventoryOpaqueMacro(7, 107, ["M"])],
+        [InventoryTestItem(8, 108, :testitem, "t", "#testitem#t#1", String[])],
     )
 
     a = make()
@@ -21,8 +22,13 @@
 
     c = FileInventory(
         [InventoryItem(1, 101, "g", String[], :function, "g(x)", String[], String[])],
-        a.imports, a.exports, a.includes, a.modules, a.opaque_macros)
+        a.imports, a.exports, a.includes, a.modules, a.opaque_macros, a.testitems)
     @test !isequal(a, c)
+
+    # The test-item vector participates in the equality contract too.
+    d = FileInventory(a.items, a.imports, a.exports, a.includes, a.modules, a.opaque_macros,
+        [InventoryTestItem(8, 108, :testitem, "other", "#testitem#other#1", String[])])
+    @test !isequal(a, d)
 end
 
 @testitem "inventory walker: visit order, ids, module nesting, doc unwrap, offsets" begin
@@ -46,7 +52,7 @@ end
     cst = CSTParser.parse(src, true)
 
     visited = []
-    _foreach_toplevel_item(cst) do x, order, id, parent_module, offset
+    _foreach_toplevel_item(cst) do x, order, id, parent_module, offset, _segment
         push!(visited, (order=order, id=id, parent=copy(parent_module), offset=offset,
                         ismod=CSTParser.defines_module(x)))
     end
@@ -100,7 +106,7 @@ end
     cst = CSTParser.parse(src, true)
 
     visited = []
-    _foreach_toplevel_item(cst) do x, order, id, parent_module, offset
+    _foreach_toplevel_item(cst) do x, order, id, parent_module, offset, _segment
         push!(visited, (order=order, id=id, parent=copy(parent_module), offset=offset))
     end
 
@@ -258,6 +264,170 @@ end
     @test only(filter(e -> e.kind === :public, inv.exports)).names == ["g"]
 
     @test only(inv.includes).target == a_uri
+end
+
+@testitem "inventory: testitem-family bodies get their own node" setup=[InventoryWS] begin
+    inv, _ = inventory_of("""
+    top() = 1
+    @testitem "one" begin
+        include("shared.jl")
+        inside() = 2
+        using Foo
+    end
+    @testmodule Setup begin
+        setupfn() = 3
+    end
+    @testsnippet Snip begin
+        snipfn() = 4
+    end
+    """)
+
+    tis = inv.testitems
+    @test [(t.kind, t.label) for t in tis] ==
+        [(:testitem, "one"), (:testmodule, "Setup"), (:testsnippet, "Snip")]
+    @test all(t -> t.parent_module == String[], tis)
+    @test allunique([t.segment for t in tis])
+
+    seg = tis[1].segment
+    # The body's statements are recorded UNDER the test item, not at file level.
+    @test only(filter(i -> i.name == "inside", inv.items)).parent_module == [seg]
+    @test only(inv.includes).parent_module == [seg]
+    @test only(inv.imports).parent_module == [seg]
+    # ...and the enclosing module is untouched.
+    @test only(filter(i -> i.name == "top", inv.items)).parent_module == String[]
+
+    # The macrocall still produces its `:opaque_macrocall` usage row in the
+    # ENCLOSING module — consumers filter on that and must keep seeing it.
+    opaque = filter(i -> i.kind === :opaque_macrocall, inv.items)
+    @test sort([i.name for i in opaque]) == ["@testitem", "@testmodule", "@testsnippet"]
+    @test all(i -> i.parent_module == String[], opaque)
+end
+
+@testitem "inventory: repeated test-item names get distinct segments" setup=[InventoryWS] begin
+    inv, _ = inventory_of("""
+    @testitem "a" begin
+        f1() = 1
+    end
+    @testitem "a" begin
+        f2() = 2
+    end
+    """)
+    segs = [t.segment for t in inv.testitems]
+    @test length(segs) == 2
+    @test allunique(segs)
+    @test only(filter(i -> i.name == "f1", inv.items)).parent_module == [segs[1]]
+    @test only(filter(i -> i.name == "f2", inv.items)).parent_module == [segs[2]]
+
+    # Identical statements in two bodies must still get distinct ids.
+    @test only(filter(i -> i.name == "f1", inv.items)).id !=
+          only(filter(i -> i.name == "f2", inv.items)).id
+end
+
+@testitem "inventory: an empty test-item body still gets a record" setup=[InventoryWS] begin
+    inv, _ = inventory_of("""
+    @testitem "empty" begin
+    end
+    """)
+    @test length(inv.testitems) == 1
+    @test inv.testitems[1].label == "empty"
+end
+
+@testitem "inventory: @testset/@safetestset stay opaque" setup=[InventoryWS] begin
+    inv, _ = inventory_of("""
+    @testset "s" begin
+        include("shared.jl")
+        inner() = 1
+    end
+    @safetestset "t" begin
+        other() = 2
+    end
+    """)
+    @test isempty(inv.testitems)
+    # No descent: nothing from either body reaches the inventory.
+    @test isempty(filter(i -> i.name in ("inner", "other"), inv.items))
+    @test isempty(inv.includes)
+    @test sort([i.name for i in filter(i -> i.kind === :opaque_macrocall, inv.items)]) ==
+        ["@safetestset", "@testset"]
+end
+
+@testitem "inventory: a nested test item nests its segment" setup=[InventoryWS] begin
+    inv, _ = inventory_of("""
+    @testitem "outer" begin
+        @testitem "inner" begin
+            deep() = 1
+        end
+    end
+    """)
+    outer = only(filter(t -> t.label == "outer", inv.testitems))
+    inner = only(filter(t -> t.label == "inner", inv.testitems))
+    @test outer.parent_module == String[]
+    @test inner.parent_module == [outer.segment]
+    @test only(filter(i -> i.name == "deep", inv.items)).parent_module ==
+        [outer.segment, inner.segment]
+end
+
+@testitem "inventory: test items inside a module nest under it" setup=[InventoryWS] begin
+    inv, _ = inventory_of("""
+    module M
+    @testitem "t" begin
+        f() = 1
+    end
+    end
+    """)
+    ti = only(inv.testitems)
+    @test ti.parent_module == ["M"]
+    @test only(filter(i -> i.name == "f", inv.items)).parent_module == ["M", ti.segment]
+end
+
+@testitem "inventory firewall: test-item segments are position-free" setup=[InventoryWS] begin
+    # The segment scheme must not encode offsets: an edit ABOVE a test item, or
+    # inside one's body, has to leave the inventory `isequal` or every root's
+    # module tree would rebuild on each keystroke.
+    base(prefix, body) = """
+    $prefix
+    @testitem "a" begin
+        f(x) = $body
+    end
+    @testitem "a" begin
+        g(x) = x
+    end
+    """
+
+    inv1, _ = inventory_of(base("# comment", "x + 1"))
+    inv2, _ = inventory_of(base("# a much longer comment\n# and another line", "x * 2"))
+    @test isequal(inv1, inv2)
+    @test hash(inv1) == hash(inv2)
+
+    # Renaming a test item IS an API change.
+    inv3, _ = inventory_of(replace(base("# comment", "x + 1"), "\"a\" begin\n    f" => "\"b\" begin\n    f"))
+    @test !isequal(inv1, inv3)
+end
+
+@testitem "testitem segments: keys match the CST's macrocall nodes" setup=[InventoryWS] begin
+    using JuliaWorkspaces.URIs2: URI
+
+    uri = URI("file:///inv/src/F.jl")
+    _, jw = inventory_of("""
+    @testitem "a" begin
+        f() = 1
+    end
+    @testmodule B begin
+        g() = 2
+    end
+    """; uri)
+    rt = jw.runtime
+
+    segs = JuliaWorkspaces.derived_testitem_segments(rt, uri)
+    inv = JuliaWorkspaces.derived_file_inventory(rt, uri)
+    @test sort(collect(values(segs))) == sort([t.segment for t in inv.testitems])
+
+    # Keyed on the macrocall EXPRs of the very CST the semantic pass traverses.
+    cst = JuliaWorkspaces.derived_julia_legacy_syntax_tree(rt, uri)
+    macrocalls = filter(a -> JuliaWorkspaces.CSTParser.ismacrocall(a), cst.args)
+    @test length(macrocalls) == 2
+    for mc in macrocalls
+        @test haskey(segs, UInt64(objectid(mc)))
+    end
 end
 
 @testitem "inventory firewall: body, comment, and docstring edits compare equal" setup=[InventoryWS] begin
@@ -906,7 +1076,7 @@ end
     cst = CSTParser.parse(src, true)
 
     visited = []
-    _foreach_toplevel_item(cst) do x, order, id, parent_module, offset
+    _foreach_toplevel_item(cst) do x, order, id, parent_module, offset, _segment
         push!(visited, (order=order, id=id, head=CSTParser.headof(x), offset=offset))
     end
 
@@ -977,8 +1147,16 @@ end
     @test any(i -> i.kind === :import && i.path == ["SomePkg"], inv.imports)
     # an `include` inside a macro-wrapped `@static if` is a real include event
     @test any(inc -> inc.target == a_uri, inv.includes)
-    # isolating macros (testitem family + testset family) leak nothing
-    @test isempty(filter(i -> i.name in ("leaky1", "leaky2", "leaky3", "leaky4", "leaky5"), inv.items))
+    # The testset family stays fully opaque — nothing from those bodies is
+    # recorded at all.
+    @test isempty(filter(i -> i.name in ("leaky2", "leaky5"), inv.items))
+    # The testitem family IS descended into, but nothing leaks to the enclosing
+    # module: each name is recorded under its own test item's node.
+    segs = Dict(t.label => t.segment for t in inv.testitems)
+    @test byname("leaky1").parent_module == [segs["t"]]
+    @test byname("leaky3").parent_module == [segs["TM"]]
+    @test byname("leaky4").parent_module == [segs["TS"]]
+    @test !any(i -> i.name in ("leaky1", "leaky3", "leaky4") && isempty(i.parent_module), inv.items)
 end
 
 @testitem "inventory parity: typed and parenthesized assignment lhs emit their identifier" setup=[InventoryWS] begin
@@ -1010,12 +1188,17 @@ end
     # StaticLint's `_is_testmodule_macro`/`_is_testsnippet_macro`/
     # `_is_testitem_macro` (macros.jl) all unwrap the qualified `X.@macro`
     # getfield form (mirroring `is_scope_introducing_macrocall`, scope.jl),
-    # so a QUALIFIED form gets the same prebuilt isolating scope a bare one
-    # does — the inventory must stay opaque for all three, identically.
-    names = Set(i.name for i in inv.items)
-    @test !("tm_f" in names)
-    @test !("ts_f" in names)
-    @test !("ti_f" in names)
+    # so a QUALIFIED form gets the same isolating treatment a bare one does:
+    # each body opens its own `:testitem` node, and nothing lands at file level.
+    @test [(t.kind, t.label) for t in inv.testitems] ==
+        [(:testmodule, "TM"), (:testsnippet, "TS"), (:testitem, "t")]
+
+    segs = Dict(t.label => t.segment for t in inv.testitems)
+    byname(n) = only(filter(i -> i.name == n, inv.items))
+    @test byname("tm_f").parent_module == [segs["TM"]]
+    @test byname("ts_f").parent_module == [segs["TS"]]
+    @test byname("ti_f").parent_module == [segs["t"]]
+    @test !any(i -> i.name in ("tm_f", "ts_f", "ti_f") && isempty(i.parent_module), inv.items)
 end
 
 @testitem "macro-declared: name derivation for the modelled macros" begin

--- a/test/test_module_tree.jl
+++ b/test/test_module_tree.jl
@@ -5,11 +5,11 @@
 
     f = URI("file:///t/src/T.jl")
     make() = ModuleTree(f,
-        [ModuleNode(String[], false, nothing, [f],
+        [ModuleNode(String[], :root, false, nothing, [f],
             Dict("g" => ItemRef(f, 2)), ["g"], String[],
             [ResolvedImport(:using, ImportTarget(:external, ["Base64"]),
                             JuliaWorkspaces.ImportSymbol[], nothing, ItemRef(f, 1))]),
-         ModuleNode(["M"], false, ItemRef(f, 3), [f], Dict{String,ItemRef}(), String[], String[], ResolvedImport[])],
+         ModuleNode(["M"], :module, false, ItemRef(f, 3), [f], Dict{String,ItemRef}(), String[], String[], ResolvedImport[])],
         Dict(f => String[]))
 
     a = make(); b = make()
@@ -195,6 +195,120 @@ end
     root_node = module_node(tree, String[])
     @test count(==(a_uri), root_node.files) == 1
     @test root_node.files == [root_uri, a_uri]
+end
+
+@testitem "module tree: a helper splices into EVERY test item that includes it" setup=[ModuleTreeWS] begin
+    # The whole point of the test-item exception to first-include-wins: under
+    # the plain rule only the first body would see `helper`.
+    sh = URI("file:///t/src/shared.jl")
+    tree, root_uri, jw = tree_of("""
+    @testitem "one" begin
+        include("shared.jl")
+    end
+    @testitem "two" begin
+        include("shared.jl")
+    end
+    @testitem "three" begin
+        include("shared.jl")
+    end
+    """; extra_files=Dict(sh => "helper() = 1\n"))
+
+    ti_nodes = filter(n -> n.kind === :testitem, tree.modules)
+    @test length(ti_nodes) == 3
+    @test all(n -> haskey(n.declared, "helper"), ti_nodes)
+    @test all(n -> sh in n.files, ti_nodes)
+
+    # Node kinds are the semantic marker.
+    @test module_node(tree, String[]).kind === :root
+    # The helper's own analysis context is the FIRST splice.
+    @test tree.file_modules[sh] == ti_nodes[1].path
+
+    # Nothing leaks into the enclosing module: neither the helper's names nor
+    # the test items themselves are declared there.
+    root_node = module_node(tree, String[])
+    @test !haskey(root_node.declared, "helper")
+    @test isempty(root_node.declared)
+    for n in ti_nodes
+        @test !haskey(root_node.declared, only(n.path))
+    end
+
+    # ...and they are not visible names of the enclosing module either.
+    vis = JuliaWorkspaces.derived_module_visible_names_idfree(jw.runtime, root_uri, String[])
+    @test !haskey(vis, "helper")
+    @test !any(k -> startswith(k, "#"), keys(vis))
+
+    # A test item binds no self-name inside itself.
+    own = JuliaWorkspaces.derived_module_visible_names_idfree(jw.runtime, root_uri, ti_nodes[1].path)
+    @test haskey(own, "helper")
+    @test !haskey(own, only(ti_nodes[1].path))
+end
+
+@testitem "module tree: is_testitem_path covers nested paths" setup=[ModuleTreeWS] begin
+    using JuliaWorkspaces: is_testitem_path
+
+    tree, root_uri, jw = tree_of("""
+    module M
+    end
+    @testitem "t" begin
+        module Inner
+        end
+    end
+    """)
+    rt = jw.runtime
+    ti = only(filter(n -> n.kind === :testitem, tree.modules))
+
+    @test is_testitem_path(rt, root_uri, ti.path)
+    @test is_testitem_path(rt, root_uri, vcat(ti.path, ["Inner"]))
+    @test !is_testitem_path(rt, root_uri, String[])
+    @test !is_testitem_path(rt, root_uri, ["M"])
+end
+
+@testitem "module tree: methods and arities are visible in every test item" setup=[ModuleTreeWS] begin
+    sh = URI("file:///t/src/shared.jl")
+    tree, root_uri, jw = tree_of("""
+    @testitem "one" begin
+        include("shared.jl")
+    end
+    @testitem "two" begin
+        include("shared.jl")
+    end
+    """; extra_files=Dict(sh => "helper(x) = 1\n"))
+    rt = jw.runtime
+
+    # `_walk_spliced_binding_items!` mirrors the splice rule, so the method and
+    # arity indices must see the helper at BOTH paths, not just the first.
+    for n in filter(n -> n.kind === :testitem, tree.modules)
+        @test !isempty(JuliaWorkspaces.derived_method_items(rt, root_uri, n.path, "helper"))
+        @test !isempty(JuliaWorkspaces.derived_method_arities(rt, root_uri, n.path, "helper"))
+    end
+end
+
+@testitem "module tree: a self-including test item terminates" setup=[ModuleTreeWS] begin
+    # Per-path admission means the global visited set can no longer stop this;
+    # the DFS-chain guard has to.
+    tree, root_uri, _ = tree_of("""
+    @testitem "t" begin
+        include("F.jl")
+    end
+    """)
+    @test module_node(tree, String[]) !== nothing
+    @test length(filter(n -> n.kind === :testitem, tree.modules)) == 1
+end
+
+@testitem "module tree: mutually including files under test items terminate" setup=[ModuleTreeWS] begin
+    a_uri = URI("file:///t/src/a.jl")
+    b_uri = URI("file:///t/src/b.jl")
+    tree, _, _ = tree_of("""
+    @testitem "t" begin
+        include("a.jl")
+    end
+    """; extra_files=Dict(
+        a_uri => "include(\"b.jl\")\nfa() = 1\n",
+        b_uri => "include(\"a.jl\")\nfb() = 2\n",
+    ))
+    ti = only(filter(n -> n.kind === :testitem, tree.modules))
+    @test haskey(ti.declared, "fa")
+    @test haskey(ti.declared, "fb")
 end
 
 @testitem "module tree: include cycles terminate" setup=[ModuleTreeWS] begin


### PR DESCRIPTION
They really need to be their own thing, as they behave like modules somewhat, but aren't really.

This fixes a whole lot of bugs around test items.