### PR TITLE
Qualify test item ids by the package they belong to

### DIFF
--- a/src/layer_testitems.jl
+++ b/src/layer_testitems.jl
@@ -79,6 +79,38 @@ function testitem_relative_path(package_uri::Union{URI,Nothing}, uri::URI)
     return string(uri)
 end
 
+"""
+    testitem_id_scope(package, package_uri, uri) -> String
+
+The location half of a test item id: the file's path within its package, qualified by
+the package it belongs to.
+
+The package qualifier is `<name>@<first 8 hex of the uuid>`. The name is what a human
+recognises in a JUnit classname or an MCP call; the uuid fragment separates two
+*different* packages that happen to share a name, such as a vendored copy sitting
+beside a dev checkout. Both are always available — a folder is only a package when its
+Project.toml carries a name, a uuid and a version.
+
+Deliberately scoped to the package rather than the workspace. The *same* package cloned
+into two folders produces the same id from both clones, because the only thing that
+tells those apart is their location, and location differs between a dev checkout and a
+CI runner. An id cannot be both workspace-unique and portable; this one keeps
+portability, and callers that need uniqueness key on `(package_uri, id)` — which is why
+`TestEnvironment` carries the package uri.
+
+Falls back to the bare URI when there is no filesystem path, since a URI is already
+unique on its own and `MyPkg@abcd1234/file:///…` would help nobody.
+"""
+function testitem_id_scope(package, package_uri::Union{URI,Nothing}, uri::URI)
+    relpath = testitem_relative_path(package_uri, uri)
+
+    # The fallback fired: `relpath` is the whole URI, so there is nothing to qualify.
+    package === nothing && return relpath
+    relpath == string(uri) && return relpath
+
+    return string(package.name, '@', first(string(package.uuid), 8), '/', relpath)
+end
+
 function _label_counts(labels)
     counts = Dict{String,Int}()
     for label in labels
@@ -158,12 +190,18 @@ Salsa.@derived function derived_testitems(rt, uri)
         ) for (i,te) in enumerate(testerrors)
     ]
 
-    # Ids are `<path relative to the package>::<label>`, so inserting a test item
-    # above another one no longer renumbers it. A label used more than once in one
-    # file is a definition error, but the run must still degrade rather than break,
-    # so *every* occurrence gets a `#N` suffix — that keeps ids unique, keeps each
-    # item individually addressable, and makes the error state visible in the id.
-    relpath = testitem_relative_path(package_uri, uri)
+    # Ids are `<package>/<path relative to the package>::<label>`, so inserting a test
+    # item above another one no longer renumbers it, and two packages that both contain
+    # `test/runtests.jl` no longer mint the same id. A label used more than once in one
+    # file is a definition error, but the run must still degrade rather than break, so
+    # *every* occurrence gets a `#N` suffix — that keeps ids unique within the file,
+    # keeps each item individually addressable, and makes the error state visible in
+    # the id.
+    relpath = testitem_id_scope(
+        package_uri === nothing ? nothing : derived_package(rt, package_uri),
+        package_uri,
+        uri,
+    )
 
     item_labels = String[ti.name for ti in testitems]
     item_counts = _label_counts(item_labels)

--- a/test/test_testitems.jl
+++ b/test/test_testitems.jl
@@ -722,12 +722,12 @@ end
     @test test_results.testitems[1].option_skip == "VERSION < v\"1.11\""
 end
 
-@testitem "test item ids are package relative and label based" setup=[TestItemPackage] begin
+@testitem "test item ids are package qualified, package relative and label based" setup=[TestItemPackage] begin
     jw, uri = workspace_with("""@testitem "foo" begin end\n@testitem "bar" begin end""")
 
     test_results = get_test_items(jw, uri)
 
-    @test [ti.id for ti in test_results.testitems] == ["test/bar.jl::foo", "test/bar.jl::bar"]
+    @test [ti.id for ti in test_results.testitems] == ["Foo@12345678/test/bar.jl::foo", "Foo@12345678/test/bar.jl::bar"]
 end
 
 @testitem "test item ids are invariant under inserting an item above" setup=[TestItemPackage] begin
@@ -737,7 +737,7 @@ end
     id1 = only(get_test_items(jw1, uri).testitems).id
     id2 = get_test_items(jw2, uri).testitems[2].id
 
-    @test id1 == id2 == "test/bar.jl::foo"
+    @test id1 == id2 == "Foo@12345678/test/bar.jl::foo"
 end
 
 @testitem "duplicate test item labels get numbered ids and a definition error" setup=[TestItemPackage] begin
@@ -747,7 +747,7 @@ end
 
     # Every occurrence is suffixed, not just the second one, so the error state is
     # visible in the id itself and each item stays individually addressable.
-    @test [ti.id for ti in test_results.testitems] == ["test/bar.jl::foo#1", "test/bar.jl::foo#2", "test/bar.jl::bar"]
+    @test [ti.id for ti in test_results.testitems] == ["Foo@12345678/test/bar.jl::foo#1", "Foo@12345678/test/bar.jl::foo#2", "Foo@12345678/test/bar.jl::bar"]
 
     @test length(test_results.testerrors) == 2
     @test all(te -> te.name == "foo", test_results.testerrors)
@@ -788,4 +788,79 @@ end
 
     @test length(test_results.testitems) == 0
     @test length(test_results.testerrors) == 1
+end
+
+@testitem "test items in different packages get different ids" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_test_items
+    using JuliaWorkspaces.URIs2: URI
+
+    # The bug this format exists to fix. Both packages contain `test/runtests.jl` with a
+    # test item called "shared", so a package-relative id alone made them byte-identical —
+    # and the runner keys work by id, so one of the two silently never ran.
+    jw = JuliaWorkspace()
+    for (folder, name, uuid) in (
+            ("alpha", "Alpha", "aaaaaaaa-1234-1234-1234-123456789012"),
+            ("beta", "Beta", "bbbbbbbb-1234-1234-1234-123456789012"))
+        add_file!(jw, TextFile(URI("file:///home/$folder/Project.toml"),
+            SourceText("name = \"$name\"\nuuid = \"$uuid\"\nversion = \"0.1.0\"\n", "toml")))
+        add_file!(jw, TextFile(URI("file:///home/$folder/src/$name.jl"),
+            SourceText("module $name\nend\n", "julia")))
+        add_file!(jw, TextFile(URI("file:///home/$folder/test/runtests.jl"),
+            SourceText("""@testitem "shared" begin end""", "julia")))
+    end
+
+    id_a = only(get_test_items(jw, URI("file:///home/alpha/test/runtests.jl")).testitems).id
+    id_b = only(get_test_items(jw, URI("file:///home/beta/test/runtests.jl")).testitems).id
+
+    @test id_a == "Alpha@aaaaaaaa/test/runtests.jl::shared"
+    @test id_b == "Beta@bbbbbbbb/test/runtests.jl::shared"
+    @test id_a != id_b
+end
+
+@testitem "same-named packages with different uuids get different ids" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_test_items
+    using JuliaWorkspaces.URIs2: URI
+
+    # A vendored copy sitting beside a dev checkout: same name, different package. The uuid
+    # fragment is what separates them.
+    jw = JuliaWorkspace()
+    for (folder, uuid) in (("dev", "aaaaaaaa-1234-1234-1234-123456789012"),
+                           ("vendor", "bbbbbbbb-1234-1234-1234-123456789012"))
+        add_file!(jw, TextFile(URI("file:///home/$folder/Project.toml"),
+            SourceText("name = \"Same\"\nuuid = \"$uuid\"\nversion = \"0.1.0\"\n", "toml")))
+        add_file!(jw, TextFile(URI("file:///home/$folder/src/Same.jl"),
+            SourceText("module Same\nend\n", "julia")))
+        add_file!(jw, TextFile(URI("file:///home/$folder/test/runtests.jl"),
+            SourceText("""@testitem "x" begin end""", "julia")))
+    end
+
+    id_dev = only(get_test_items(jw, URI("file:///home/dev/test/runtests.jl")).testitems).id
+    id_vendor = only(get_test_items(jw, URI("file:///home/vendor/test/runtests.jl")).testitems).id
+
+    @test id_dev != id_vendor
+end
+
+@testitem "the same package cloned twice mints the same id, by design" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_test_items
+    using JuliaWorkspaces.URIs2: URI
+
+    # Two worktrees of one package share a name AND a uuid, so their ids are identical.
+    # That is deliberate and not a bug to "fix" here: the only thing separating two clones
+    # is their location, and location differs between a dev checkout and a CI runner, so an
+    # id cannot be both workspace-unique and portable. This one keeps portability; callers
+    # that need uniqueness key on `(package_uri, id)`.
+    jw = JuliaWorkspace()
+    for folder in ("wt-a", "wt-b")
+        add_file!(jw, TextFile(URI("file:///home/$folder/Project.toml"),
+            SourceText("name = \"Clone\"\nuuid = \"cccccccc-1234-1234-1234-123456789012\"\nversion = \"0.1.0\"\n", "toml")))
+        add_file!(jw, TextFile(URI("file:///home/$folder/src/Clone.jl"),
+            SourceText("module Clone\nend\n", "julia")))
+        add_file!(jw, TextFile(URI("file:///home/$folder/test/runtests.jl"),
+            SourceText("""@testitem "x" begin end""", "julia")))
+    end
+
+    id_a = only(get_test_items(jw, URI("file:///home/wt-a/test/runtests.jl")).testitems).id
+    id_b = only(get_test_items(jw, URI("file:///home/wt-b/test/runtests.jl")).testitems).id
+
+    @test id_a == id_b == "Clone@cccccccc/test/runtests.jl::x"
 end


### PR DESCRIPTION
Fixes a collision found during the VS Code integration.

## The bug

Ids were `<path relative to the package>::<label>`. Two packages that each contain `test/runtests.jl` with a test item of the same name therefore minted **byte-identical ids**.

The failure was silent. TestItemControllers keys its work by id, so the two items collapsed into one: one ran, the other never ran, never reported, and never appeared in the results. No error, no skip, nothing in the report.

## The format

```
<Name>@<first 8 hex of the uuid>/<relpath>::<label>
```

e.g. `TestItemControllers@340407ab/test/test_junit.jl::JUnit XML basic structure`

- **name** — what a human recognises in a JUnit classname, an MCP call or a filter.
- **uuid fragment** — separates two *different* packages that share a name, e.g. a vendored copy beside a dev checkout. Both fields are always available: a folder is only a package when its Project.toml carries a name, a uuid and a version, and discovery already rejects test items outside a package.
- **relpath, `::label`, `#N`** — unchanged.

## Deliberately package-scoped, not workspace-unique

The **same** package cloned into two folders — two worktrees, say — still mints one id from both. That is by design, and there is a test asserting it.

The only thing separating two clones is their location, and location differs between a dev checkout and a CI runner. So no single string can be both workspace-unique and portable across machines. This id keeps portability; callers that need uniqueness key on `(package_uri, id)`, which is why `TestEnvironment` carries the package uri. Companion changes in TestItemControllers and JuliaMCP widen the few dictionaries that were keyed on the id alone.

## Why unconditional rather than only-on-collision

Detecting a collision needs workspace-wide knowledge, but `derived_testitems` is a *per-file* Salsa query. Making it depend on the global package set would invalidate every file's ids whenever any package was added or removed — an incrementality regression and a source of id churn, to solve something unconditional qualification solves for free.

## Tests

Full suite: **7179 pass, 8 broken** (pre-existing), unchanged from `main`.

Three new cases beyond updating the existing assertions: two different packages get different ids (the reported bug); two same-named packages with different uuids get different ids; and the same package cloned twice gets the *same* id, asserted so the tradeoff is pinned rather than accidental.

## Downstream

Breaking for anything persisting ids. Lockstep updates needed in TestItemControllers (`tr.test_items` keyed by `(id, package_uri)`, plus a guard), JuliaMCP (`item_package_info`/`env_id_for_item`), and the VS Code extension (node ids become `packageUri|id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)