### PR TITLE
Make test env content hash cover manifest and test project files

### DIFF
--- a/src/layer_testitems.jl
+++ b/src/layer_testitems.jl
@@ -313,7 +313,11 @@ Salsa.@derived function derived_testenv(rt, uri)
     # project (Project + Manifest), the package's own Project.toml and
     # Manifest, and the package's test/Project.toml and test/Manifest.toml
     # (see julia-vscode/julia-vscode#3022).
-    env_content_hash = isnothing(project_uri) ? hash(nothing) : derived_project(rt, project_uri).content_hash
+    # We fold everything with `hash(x, h)`, whose seed argument must be a
+    # `UInt` (32 bit on 32 bit platforms), while `content_hash` fields are
+    # `UInt64`. Keep the accumulator at native `UInt` width by hashing the
+    # stored hash instead of seeding with it directly.
+    env_content_hash = isnothing(project_uri) ? hash(nothing) : hash(derived_project(rt, project_uri).content_hash)
     if package_uri===nothing
         env_content_hash = hash(nothing, env_content_hash)
     else

--- a/src/layer_testitems.jl
+++ b/src/layer_testitems.jl
@@ -308,11 +308,26 @@ Salsa.@derived function derived_testenv(rt, uri)
         project_uri = nothing
     end
 
+    # The test process is only restarted when this hash changes, so it must
+    # cover every input the test environment is built from: the chosen
+    # project (Project + Manifest), the package's own Project.toml and
+    # Manifest, and the package's test/Project.toml and test/Manifest.toml
+    # (see julia-vscode/julia-vscode#3022).
     env_content_hash = isnothing(project_uri) ? hash(nothing) : derived_project(rt, project_uri).content_hash
     if package_uri===nothing
         env_content_hash = hash(nothing, env_content_hash)
     else
-        env_content_hash = hash(derived_package(rt, package_uri).content_hash)
+        env_content_hash = hash(derived_package(rt, package_uri).content_hash, env_content_hash)
+
+        package_project = derived_project(rt, package_uri)
+        env_content_hash = hash(package_project === nothing ? nothing : package_project.content_hash, env_content_hash)
+
+        test_folder_uri = filepath2uri(joinpath(uri2filepath(package_uri), "test"))
+        test_toml_files = derived_project_toml_files(rt, test_folder_uri)
+        for file in (test_toml_files.project_file, test_toml_files.manifest_file)
+            text_file = file === nothing ? nothing : derived_text_file_content(rt, file)
+            env_content_hash = hash(text_file === nothing ? nothing : text_file.content.content, env_content_hash)
+        end
     end
 
     # We construct a string for the env content hash here so that later when we

--- a/test/test_testitems.jl
+++ b/test/test_testitems.jl
@@ -611,6 +611,105 @@ version = "0.1.0"
     end
 end
 
+@testitem "test env content hash covers manifests and test project files" begin
+    using JuliaWorkspaces: JuliaWorkspace, add_file!, update_file!, TextFile, SourceText, get_test_env
+    using JuliaWorkspaces.URIs2: URI
+
+    project_toml = """
+    [deps]
+    Inner = "6b0e2f31-8d55-4f2a-9d10-2b6c5e8f9a22"
+    """
+
+    manifest_toml = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+
+    [[deps.Inner]]
+    deps = []
+    path = "Inner"
+    uuid = "6b0e2f31-8d55-4f2a-9d10-2b6c5e8f9a22"
+    version = "2.0.0"
+    """
+
+    inner_project = """
+    name = "Inner"
+    uuid = "6b0e2f31-8d55-4f2a-9d10-2b6c5e8f9a22"
+    version = "2.0.0"
+    """
+
+    inner_test_project = """
+    [deps]
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    """
+
+    # Scenario 1: the package is deved into an active project (no manifest of its own)
+    outer_manifest_uri = URI("file:///hashenv/Manifest.toml")
+    inner_test_project_uri = URI("file:///hashenv/Inner/test/Project.toml")
+    inner_src_uri = URI("file:///hashenv/Inner/src/Inner.jl")
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///hashenv/Project.toml"), SourceText(project_toml, "toml")))
+    add_file!(jw, TextFile(outer_manifest_uri, SourceText(manifest_toml, "toml")))
+    add_file!(jw, TextFile(URI("file:///hashenv/Inner/Project.toml"), SourceText(inner_project, "toml")))
+    add_file!(jw, TextFile(inner_test_project_uri, SourceText(inner_test_project, "toml")))
+    add_file!(jw, TextFile(inner_src_uri, SourceText("module Inner end", "julia")))
+    JuliaWorkspaces.set_input_active_project!(jw.runtime, URI("file:///hashenv"))
+
+    env0 = get_test_env(jw, inner_src_uri)
+    @test env0.package_uri == URI("file:///hashenv/Inner")
+    @test env0.project_uri == URI("file:///hashenv")
+    hash0 = env0.env_content_hash
+    @test hash0 isa String
+    @test startswith(hash0, "x")
+
+    # Stable when nothing relevant changes, and across an unrelated src edit
+    @test get_test_env(jw, inner_src_uri).env_content_hash == hash0
+    update_file!(jw, TextFile(inner_src_uri, SourceText("module Inner
+x = 1
+end", "julia")))
+    @test get_test_env(jw, inner_src_uri).env_content_hash == hash0
+
+    # (a) the active project's Manifest.toml changes
+    update_file!(jw, TextFile(outer_manifest_uri, SourceText(manifest_toml * "
+# edited
+", "toml")))
+    hash1 = get_test_env(jw, inner_src_uri).env_content_hash
+    @test hash1 != hash0
+
+    # (b) test/Project.toml under the package changes
+    update_file!(jw, TextFile(inner_test_project_uri, SourceText(inner_test_project * "
+# edited
+", "toml")))
+    hash2 = get_test_env(jw, inner_src_uri).env_content_hash
+    @test hash2 != hash1
+    @test hash2 != hash0
+
+    # Scenario 2: a standalone package with its own Manifest.toml
+    pkg_manifest = """
+    julia_version = "1.11.0"
+    manifest_format = "2.0"
+    """
+    pkg_manifest_uri = URI("file:///hashpkg/Manifest.toml")
+    pkg_src_uri = URI("file:///hashpkg/src/Inner.jl")
+
+    jw2 = JuliaWorkspace()
+    add_file!(jw2, TextFile(URI("file:///hashpkg/Project.toml"), SourceText(inner_project, "toml")))
+    add_file!(jw2, TextFile(pkg_manifest_uri, SourceText(pkg_manifest, "toml")))
+    add_file!(jw2, TextFile(pkg_src_uri, SourceText("module Inner end", "julia")))
+
+    env3 = get_test_env(jw2, pkg_src_uri)
+    @test env3.package_uri == URI("file:///hashpkg")
+    hash3 = env3.env_content_hash
+    @test get_test_env(jw2, pkg_src_uri).env_content_hash == hash3
+
+    # (c) the package folder's own Manifest.toml changes
+    update_file!(jw2, TextFile(pkg_manifest_uri, SourceText(pkg_manifest * "
+# edited
+", "toml")))
+    hash4 = get_test_env(jw2, pkg_src_uri).env_content_hash
+    @test hash4 != hash3
+end
+
 @testitem "derived_testenv for a file in a deved package of a project" begin
     using JuliaWorkspaces: JuliaWorkspace, add_file!, TextFile, SourceText, get_test_env
     using JuliaWorkspaces.URIs2: URI


### PR DESCRIPTION
## Summary

The test-item controller only restarts a pooled test process when the test env's `env_content_hash` changes. Two problems in `derived_testenv` (`src/layer_testitems.jl`) meant that hash missed most of the inputs a test process actually depends on:

- The project's content hash (Project + Manifest of the chosen project) was computed and then **overwritten** by `hash(derived_package(...).content_hash)` instead of being combined with it, so edits to the active project's `Manifest.toml` never changed the hash.
- `derived_package(...).content_hash` only covers the package's `Project.toml` text, so the package folder's own `Manifest.toml` and `test/Project.toml` / `test/Manifest.toml` were not part of the hash at all.

Users therefore kept getting stale test environments (e.g. after `Pkg.add`/`Pkg.update` in the test env) until they manually restarted the test processes.

## Fix

`derived_testenv` now hashes, nested and deterministically: the chosen project's content hash (if any), the package `Project.toml` hash, the package folder's own manifest-backed project hash (if any), and the text of `test/Project.toml` and `test/Manifest*.toml` under the package (found via the existing `derived_project_toml_files` helper; missing files hash as `nothing`). The `"x…"` string form and `JuliaTestEnv` return are unchanged.

## Tests

New testitem `test env content hash covers manifests and test project files` in `test/test_testitems.jl` asserts the hash from `get_test_env` changes when (a) the active project's Manifest.toml changes, (b) the package's `test/Project.toml` changes, (c) the package folder's own Manifest.toml changes, and is stable across an unrelated `src/` edit. Full suite via `juliati`: 1062 tests ran, 1062 passed.

Fixes julia-vscode/julia-vscode#3022

🤖 Generated with [Claude Code](https://claude.com/claude-code)