### PR TITLE
Update README to include LintApp.jl reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://github.com/julia-vscode/JuliaWorkspaces.jl/actions/workflows/juliaci.yml/badge.svg?branch=main)](https://github.com/julia-vscode/JuliaWorkspaces.jl/actions/workflows/juliaci.yml)
 
 The analysis engine that powers [LanguageServer.jl](https://github.com/julia-vscode/LanguageServer.jl).
+See also [LintApp.jl](https://github.com/julia-vscode/LintApp.jl) a standalone command-line application that using JuliaWorkspaces to do linting.
 
 JuliaWorkspaces.jl takes a set of files — Julia sources, `Project.toml` /
 `Manifest.toml`, configuration files — and answers questions about them:


### PR DESCRIPTION
I was trying to find out if there was a commandline version by looking in docs and read me and couldn't find reference to one.
Then i thought to look in the org and i found LintApp