### PR TITLE
Compose config file scope over the whole ancestor chain

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -20,9 +20,10 @@ and it applies everywhere. The shared machinery lives in
 
 ## Shared mechanism
 
-### Discovery: the nearest file governs, wholesale
+### Settings: the nearest file governs, wholesale
 
-To resolve configuration for a file, JuliaWorkspaces walks up from that file's
+To resolve the *settings* for a file — `preset`, `[rules]`, `style`,
+`[options]`, `[[override]]` — JuliaWorkspaces walks up from that file's
 directory and uses the **first** config file of the relevant kind it finds. That
 file then applies **as a whole**:
 
@@ -56,13 +57,45 @@ to vary settings by directory**. The normal setup is a single config file of
 each kind at the repository root; when a subtree needs different settings, use
 an [`[[override]]` block](#path-scoped-overrides) in that one file — it changes
 only the keys it names, while a nested file silently resets everything it does
-not restate back to the defaults. Reach for a nested file only when a subtree is
-genuinely independent of the enclosing project and should not follow its
-configuration at all — a vendored repository with its own conventions, say.
+not restate back to the defaults.
 
 Config file names are matched **case-insensitively on the basename**, so
 `JuliaLint.toml` and `julialint.toml` both work. A leading dot does **not**:
 `.JuliaLint.toml` is not recognised.
+
+### Scope: every enclosing file must admit the file
+
+Scope is the one thing that does **not** follow nearest-wins. A file is searched,
+linted or formatted only if **every** config file of that kind above it admits it
+through its [`include`/`exclude`](#file-selection-include-and-exclude) globs,
+each evaluated relative to that config file's own directory.
+
+**A nested config may narrow scope, never widen it.** Given
+
+```
+myproject/
+  JuliaTestItems.toml           # exclude = ["packages/**"]
+  packages/
+    Foo/                        # a vendored repository
+      JuliaTestItems.toml       # include = ["**/*.jl"]
+      src/Foo.jl
+```
+
+`packages/Foo/src/Foo.jl` is **not** searched for test items. The vendored
+config governs the settings of its own subtree, and it may exclude more of it,
+but it cannot take back the enclosing project's decision to leave `packages/`
+alone.
+
+This is how you seal a subtree you do not own: write the exclusion in the
+config file at the root of the project that vendors it. It is also why an
+ancestor's `exclude` is worth reaching for before a nested config file — the
+parent always has the last word on what is in scope.
+
+The rule is the same one git applies to `.gitignore` (a file cannot be
+re-included once a parent directory is excluded), and the same split Ruff makes
+between hierarchical rule settings and top-level file discovery. The alternative
+— letting the innermost file decide scope on its own — hands vendored code a
+veto over the project vendoring it.
 
 ### Precedence within a file
 
@@ -73,7 +106,9 @@ built-in defaults  <  preset / style  <  top-level keys  <  last matching [[over
 ### File selection: `include` and `exclude`
 
 Every config file accepts two top-level glob lists, relative to the directory
-holding the config file:
+holding **that** config file. When several config files of one kind enclose a
+file, each is evaluated against its own directory and the results are
+intersected — see [Scope](#scope-every-enclosing-file-must-admit-the-file):
 
 ```toml
 include = ["src/**", "test/**"]
@@ -84,9 +119,12 @@ exclude = ["**/generated_*.jl"]
 - `exclude` always wins over `include`.
 - An excluded file is not linted / formatted / searched for test items at all.
 
-A config file always validates itself even when its own globs exclude the
+A config file always validates itself even when **its own** globs exclude the
 directory it lives in — otherwise a mistake in `exclude` could hide the very
-diagnostic that would explain it.
+diagnostic that would explain it. That exemption stops at its own file: a config
+inside a subtree an **enclosing** `JuliaLint.toml` excluded reports nothing at
+all, along with the rest of that subtree. Excluding a vendored repository should
+not leave you reading diagnostics about its config files.
 
 ### Glob syntax
 
@@ -105,6 +143,14 @@ Gitignore-style, implemented by
 
 Paths are normalised to `/` before matching, so `test\**` and `test/**` behave
 identically. Matching is case-insensitive on Windows.
+
+One asymmetry in that table is easy to trip over: a pattern **containing** a
+separator anywhere is anchored to the config file's directory even without a
+leading `/`. So `excluded/**` matches `excluded/a.jl` but **not**
+`nested/excluded/a.jl` — write `**/excluded/**` for the latter. Only a pattern
+with no separator at all, like `generated.jl`, matches at every depth. This
+matters more now that a root config's patterns govern subtrees several levels
+down.
 
 ### Path-scoped overrides
 
@@ -143,19 +189,23 @@ does not understand is told to upgrade the tooling.
 
 ### Superseded configuration
 
-Because the nearest config governs wholesale, a config file in a subdirectory
-does not extend the one above it — it *replaces* it, and since nested config
-files are discouraged (use [`[[override]]`](#path-scoped-overrides) instead),
-that replacement is more often an accident than a decision. It is also silent by
-nature, so a config file with another of the same kind in an enclosing directory
-reports a `shadowed_config` diagnostic (`info` by default) naming the file it
-takes over from.
+Because the nearest config governs its settings wholesale, a config file in a
+subdirectory does not extend the one above it — it *replaces* it, and since
+nested config files are discouraged (use
+[`[[override]]`](#path-scoped-overrides) instead), that replacement is more often
+an accident than a decision. It is also silent by nature, so a config file with
+another of the same kind in an enclosing directory reports a `shadowed_config`
+diagnostic (`info` by default) naming the file it takes over from.
 
-This is the price of choosing nearest-wins over cascading. The alternative is
-that a config dropped into a subdirectory — a vendored repository, a copied
-example, a half-finished subpackage extraction — quietly voids the project's own
-configuration for that subtree. It is an ordinary rule, so a project that
-genuinely wants independent subtrees sets `shadowed_config = "off"`.
+Only settings are superseded; the message says so. The outer file's
+`include`/`exclude` keep applying, because
+[scope composes over the whole chain](#scope-every-enclosing-file-must-admit-the-file).
+
+`JuliaTestItems.toml` never reports this: version 1 of that file has nothing but
+scope keys, so a nested one supersedes nothing at all.
+
+It is an ordinary rule, so a project that deliberately keeps nested settings
+files sets `shadowed_config = "off"`.
 
 ### Validation
 
@@ -374,23 +424,44 @@ Note the division of labour: this file decides *where test items are found*,
 while the `testitem_errors` rule in `JuliaLint.toml` decides *whether malformed
 test items are reported as diagnostics*.
 
+Because the file has only scope keys, the
+[chain rule](#scope-every-enclosing-file-must-admit-the-file) is all there is to
+its resolution: a `JuliaTestItems.toml` in a subdirectory can exclude more of
+that subdirectory, and nothing else.
+
+TestItemRunner.jl reads the same file with the same semantics, so
+`@run_package_tests` and the VS Code test explorer agree on which files are
+searched — including when the runner is pointed at a subdirectory, where it
+still honours the config files above it.
+
 ## Implementation notes
 
 ### Query structure
 
-Configuration resolution is split into two Salsa queries per file kind so that
-parsing happens once per config file rather than once per configured file:
+Configuration resolution is split into three Salsa queries per file kind so that
+parsing happens once per config file rather than once per configured file, and so
+that scope and settings invalidate independently:
 
-- `derived_parsed_lint_config(rt, config_uri)` — parses one `JuliaLint.toml`
-  into a `ParsedLintConfig` (preset, rule table, filters, override blocks).
-- `derived_effective_lint_config(rt, uri)` — finds the governing config, then
-  resolves preset < `[rules]` < overrides **for that one file**, yielding an
-  [`EffectiveLintConfig`](@ref).
+- `derived_parsed_lint_config(rt, config_uri)` — parses the *settings* of one
+  `JuliaLint.toml` into a `ParsedLintConfig` (preset, rule table, override
+  blocks).
+- `derived_lint_path_filter(rt, config_uri)` — parses the `include`/`exclude`
+  globs of one `JuliaLint.toml`. Deliberately separate from the above: were the
+  globs part of `ParsedLintConfig`, editing `[rules]` would invalidate every
+  file's scope, and editing `exclude` every file's rules.
+- `derived_effective_lint_config(rt, uri)` — resolves scope over the whole
+  `ancestor_configs` chain, then preset < `[rules]` < overrides from the nearest
+  config alone, yielding an [`EffectiveLintConfig`](@ref).
 
 Editing a config file invalidates only through `derived_toml_syntax_tree`;
 adding or removing one invalidates through `derived_text_files`. Formatting has
-the same shape via `derived_format_configuration`, as does test-item discovery
-via `derived_testitems_selected`.
+the same shape via `derived_format_path_filter` and
+`derived_format_configuration`, as does test-item discovery via
+`derived_testitems_path_filter` and `derived_testitems_selected`.
+
+The list of config files of one kind is sorted, not merely collected: it is a
+dependency of every file's scope, and it is built from a `Set`, so an unsorted
+result would change on unrelated file additions and defeat backdating.
 
 Every value reachable from a config struct has well-defined `==` and `hash`
 (`GlobPattern` compares by its written pattern, not its compiled regex) so that

--- a/src/config_common.jl
+++ b/src/config_common.jl
@@ -3,11 +3,15 @@
 #
 # All three share the same shape:
 #
-#   * the *nearest* config file, walking up from the target file, governs that
-#     file wholesale — keys it does not set fall back to built-in defaults, never
-#     to a value from a config file further up the tree;
-#   * top-level `include`/`exclude` gitignore-style globs select which files the
-#     tool applies to at all;
+#   * *scope* is the intersection over the whole ancestor chain: top-level
+#     `include`/`exclude` gitignore-style globs select which files the tool
+#     applies to at all, and a file is in scope only if *every* enclosing config
+#     file of that kind admits it. A nested config may narrow scope, never widen
+#     it — so a project can seal a subtree (a vendored repository, say) from its
+#     own root config and nothing inside can reclaim it;
+#   * every *other* key comes wholesale from the *nearest* config file — keys it
+#     does not set fall back to built-in defaults, never to a value from a config
+#     file further up the tree;
 #   * repeated `[[override]]` blocks with `paths = [...]` re-scope a subset of
 #     the file's keys, with later blocks winning;
 #   * unknown keys and invalid values are reported as diagnostics on the config
@@ -165,29 +169,89 @@ end
 # ── Config file discovery ───────────────────────────────────────────────────
 
 """
-    nearest_config(config_uris, uri) -> Union{URI,Nothing}
+    ancestor_configs(config_uris, uri) -> Vector{URI}
 
-The config file governing `uri`: the one in the deepest directory that is a
-prefix of `uri`'s directory. Unlike the merging scheme this replaces, only this
-single file applies.
+Every config file of one kind whose directory is a prefix of `uri`'s path,
+outermost first.
+
+Scope is the intersection over this whole chain (see [`scope_selected`](@ref)),
+while every other key comes from the innermost entry alone (see
+[`nearest_config`](@ref)). The result is sorted, so it does not depend on the
+iteration order of `config_uris` — the callers are Salsa queries, and an
+order-dependent result would defeat backdating.
 """
-function nearest_config(config_uris, uri::URI)
-    uri.scheme == "file" || return nothing
+function ancestor_configs(config_uris, uri::URI)
+    uri.scheme == "file" || return URI[]
     target = replace(uri2filepath(uri), '\\' => '/')
 
-    best = nothing
-    best_len = -1
+    res = Tuple{Int,URI}[]
     for config_uri in config_uris
         config_uri.scheme == "file" || continue
-        dir = _normalize_dir(dirname(uri2filepath(config_uri)))
+        dir = config_dir_of(config_uri)
         _path_startswith(target, dir) || continue
-        if length(dir) > best_len
-            best = config_uri
-            best_len = length(dir)
-        end
+        push!(res, (length(dir), config_uri))
     end
+    sort!(res, by = x -> (x[1], string(x[2])))
 
-    return best
+    return URI[x[2] for x in res]
+end
+
+"""
+    strict_ancestor_configs(config_uris, config_uri) -> Vector{URI}
+
+[`ancestor_configs`](@ref) for a config file's own path, minus any config living
+in the same directory as `config_uri` itself. This is the chain that decides
+whether `config_uri` sits inside a subtree an *enclosing* config has excluded,
+without a config file ever excluding itself.
+"""
+function strict_ancestor_configs(config_uris, config_uri::URI)
+    config_uri.scheme == "file" || return URI[]
+    own_dir = config_dir_of(config_uri)
+    return URI[c for c in ancestor_configs(config_uris, config_uri)
+               if length(config_dir_of(c)) < length(own_dir)]
+end
+
+"""
+    nearest_config(config_uris, uri) -> Union{URI,Nothing}
+
+The config file whose non-scope keys govern `uri`: the one in the deepest
+directory that is a prefix of `uri`'s directory. Only this single file applies —
+`preset`, `[rules]`, `style`, `[options]` and `[[override]]` are never merged
+across files.
+
+Scope is the one exception: `include`/`exclude` compose over the whole chain, so
+use [`ancestor_configs`](@ref) with [`scope_selected`](@ref) for that.
+"""
+function nearest_config(config_uris, uri::URI)
+    chain = ancestor_configs(config_uris, uri)
+    return isempty(chain) ? nothing : last(chain)
+end
+
+"""
+    scope_selected(chain, path, filter_for) -> Bool
+
+Whether `path` is in scope, given the [`ancestor_configs`](@ref) `chain` of the
+relevant kind. It is in scope only if *every* config on the chain admits it via
+that config's own `include`/`exclude`, each evaluated relative to that config's
+own directory.
+
+`filter_for(config_uri)` returns the [`PathFilter`](@ref) of one config file.
+Taking it as a callback keeps this function free of Salsa: each caller passes a
+closure over its own per-config query, so the dependency edges land on exactly
+the config files that were consulted.
+
+The consequence is that a nested config file can only ever *narrow* what an
+enclosing one selected. That is deliberate: the alternative lets a config
+dropped into a subdirectory — a vendored repository, most often — overrule the
+enclosing project's decision to leave that subtree alone.
+"""
+function scope_selected(chain, path::AbstractString, filter_for)
+    for config_uri in chain
+        relpath = config_relative_path(config_dir_of(config_uri), path)
+        relpath === nothing && continue   # unreachable: the chain is prefix-matched
+        path_selected(filter_for(config_uri), relpath) || return false
+    end
+    return true
 end
 
 """
@@ -204,12 +268,14 @@ The config file of the same kind that `config_uri` takes over from: the one in
 the nearest strictly-enclosing directory, or `nothing` when `config_uri` is the
 outermost of its kind.
 
-Because the nearest config governs its subtree wholesale, a nested config file
-does not extend the one above it — it replaces it, and the outer file's
-settings stop applying with no other trace. Reporting that is the price of
-choosing this discovery rule over cascading: the alternative is that a config
-dropped into a subdirectory (a vendored repo, a copied example, a half-finished
-subpackage extraction) silently voids the project's own configuration.
+Because the nearest config governs the *non-scope* keys of its subtree
+wholesale, a nested config file does not extend the one above it — it replaces
+it, and the outer file's settings stop applying with no other trace. Reporting
+that is the price of choosing this discovery rule over cascading for settings.
+
+Scope is not affected: `include`/`exclude` compose over the whole chain
+([`scope_selected`](@ref)), so a nested file can only narrow what an enclosing
+one selected, never widen it.
 """
 function shadowed_config(config_uris, config_uri::URI)
     config_uri.scheme == "file" || return nothing
@@ -297,7 +363,8 @@ function shadowing_diagnostic!(res::Vector{Diagnostic}, config_uris, config_uri:
         1:1, :information,
         "This $filename replaces `$outer_path` for everything below this directory, " *
         "rather than adding to it — settings from that file do not apply here. " *
-        "Copy anything you want to keep, or remove this file.",
+        "Its `include`/`exclude` still do: this file can narrow what is covered, " *
+        "but not widen it. Copy anything you want to keep, or remove this file.",
         nothing, Symbol[], "JuliaWorkspaces.jl", :shadowed_config,
     ))
     return res

--- a/src/layer_diagnostics.jl
+++ b/src/layer_diagnostics.jl
@@ -9,10 +9,13 @@ function _is_env_dependent_finding(f::LintFinding)
     return LINT_RULES_BY_ID[f.rule_id].env_dependent
 end
 
+# Sorted: this vector is now a dependency of every file's scope, and
+# `derived_text_files` is a `Set`, so an unsorted result would change on
+# unrelated file adds and defeat Salsa's backdating.
 Salsa.@derived function derived_lintconfig_files(rt)
     files = derived_text_files(rt)
 
-    return [file for file in files if file.scheme=="file" && is_path_lintconfig_file(uri2filepath(file))]
+    return sort!([file for file in files if file.scheme=="file" && is_path_lintconfig_file(uri2filepath(file))], by=string)
 end
 
 
@@ -144,16 +147,20 @@ end
 One `JuliaLint.toml` file, parsed. Kept separate from the per-file
 [`EffectiveLintConfig`](@ref) so that parsing happens once per config file
 rather than once per linted file.
+
+Carries only the keys the *nearest* config decides. The `include`/`exclude`
+globs are deliberately not here: they compose over the whole ancestor chain and
+live in [`derived_lint_path_filter`](@ref), so that editing `[rules]` does not
+invalidate every file's scope, nor an `exclude` edit every file's rules.
 """
 struct ParsedLintConfig
     preset::String
-    filter::PathFilter
     rules::Dict{Symbol,Tuple{Union{Nothing,Symbol},Dict{Symbol,Any}}}
     overrides::Vector{Any}
 end
 
 ParsedLintConfig() = ParsedLintConfig(
-    DEFAULT_LINT_PRESET, PathFilter(),
+    DEFAULT_LINT_PRESET,
     Dict{Symbol,Tuple{Union{Nothing,Symbol},Dict{Symbol,Any}}}(), Any[],
 )
 
@@ -171,18 +178,39 @@ Salsa.@derived function derived_parsed_lint_config(rt, config_uri)
 
     overrides = parse_overrides!(discard, toml_content, (_, _) -> nothing)
 
-    return ParsedLintConfig(String(preset), parse_path_filter!(discard, toml_content), rules, overrides)
+    return ParsedLintConfig(String(preset), rules, overrides)
+end
+
+"""
+    derived_lint_path_filter(rt, config_uri) -> PathFilter
+
+The `include`/`exclude` globs of one `JuliaLint.toml`. Separate from
+[`derived_parsed_lint_config`](@ref) so scope and settings invalidate
+independently.
+"""
+Salsa.@derived function derived_lint_path_filter(rt, config_uri)
+    discard = Diagnostic[]   # diagnostics are reported by derived_lintconfig_diagnostics
+
+    return parse_path_filter!(discard, derived_toml_syntax_tree(rt, config_uri))
 end
 
 Salsa.@derived function derived_effective_lint_config(rt, uri)
     @debug "derived_effective_lint_config" uri=uri
 
-    config_uri = nearest_config(derived_lintconfig_files(rt), uri)
-    config_uri === nothing && return EffectiveLintConfig()
+    # Scope composes over every enclosing `JuliaLint.toml`, so it is resolved
+    # before the nearest-file lookup that decides the preset and rules.
+    config_files = derived_lintconfig_files(rt)
+    selected = uri.scheme == "file" ? scope_selected(
+        ancestor_configs(config_files, uri), uri2filepath(uri),
+        c -> derived_lint_path_filter(rt, c),
+    ) : true
+
+    config_uri = nearest_config(config_files, uri)
+    config_uri === nothing && return EffectiveLintConfig(selected)
 
     parsed = derived_parsed_lint_config(rt, config_uri)
     relpath = config_relative_path(config_dir_of(config_uri), uri2filepath(uri))
-    relpath === nothing && return EffectiveLintConfig()
+    relpath === nothing && return EffectiveLintConfig(selected)
 
     severities = copy(LINT_PRESETS[parsed.preset])
     options = Dict{Symbol,Dict{Symbol,Any}}()
@@ -203,7 +231,7 @@ Salsa.@derived function derived_effective_lint_config(rt, uri)
         apply_rules!(ov_rules)
     end
 
-    return EffectiveLintConfig(severities, options, path_selected(parsed.filter, relpath))
+    return EffectiveLintConfig(severities, options, selected)
 end
 
 # The user-facing messages of every failed dynamic work item whose project
@@ -241,16 +269,25 @@ Salsa.@derived function derived_diagnostics(rt, uri)
 
     results = Diagnostic[]
 
+    # A config file validates itself even when its own globs exclude the
+    # directory it lives in — otherwise a mistake in `exclude` could hide the
+    # very diagnostic that explains it. The exemption covers *self*-exclusion
+    # only: a config inside a subtree an enclosing `JuliaLint.toml` excluded is
+    # part of code the project deliberately set aside (a vendored repository,
+    # typically) and stays silent along with the rest of it.
     is_config_file = uri.scheme == "file" && (
         is_path_lintconfig_file(uri2filepath(uri)) ||
         is_path_formatconfig_file(uri2filepath(uri)) ||
         is_path_testitemsconfig_file(uri2filepath(uri))
     )
 
-    # `include`/`exclude` suppress everything for a file — except a config
-    # file's own validation, so that a config which happens to exclude its own
-    # directory still reports its mistakes.
-    if !lint_config.selected && !is_config_file
+    is_self_validating_config = is_config_file &&
+        scope_selected(
+            strict_ancestor_configs(derived_lintconfig_files(rt), uri), uri2filepath(uri),
+            c -> derived_lint_path_filter(rt, c),
+        )
+
+    if !lint_config.selected && !is_self_validating_config
         return results
     end
 

--- a/src/layer_formatting.jl
+++ b/src/layer_formatting.jl
@@ -1,10 +1,10 @@
 # Formatting layer
 #
 # Native source-code formatting driven by a `JuliaFormat.toml` configuration
-# file. The configuration model (nearest file governs its subtree wholesale,
-# shared `include`/`exclude` globs, `[[override]]` blocks) mirrors the lint
-# configuration in layer_diagnostics.jl; the shared machinery lives in
-# config_common.jl.
+# file. The configuration model (nearest file governs its subtree's settings
+# wholesale, shared `include`/`exclude` globs composing over the whole ancestor
+# chain, `[[override]]` blocks) mirrors the lint configuration in
+# layer_diagnostics.jl; the shared machinery lives in config_common.jl.
 #
 # Supported styles are the JuliaFormatter.jl styles ("default", "yas", "blue",
 # "sciml", "minimal") plus "runic", which routes formatting through Runic.jl.
@@ -25,10 +25,13 @@ const _FORMAT_STYLES_WITHOUT_OPTIONS = ("runic",)
 
 const _FORMAT_CONFIG_TOP_LEVEL_KEYS = ["config-version", "style", "include", "exclude", "options", "override"]
 
+# Sorted: this vector is now a dependency of every file's scope, and
+# `derived_text_files` is a `Set`, so an unsorted result would change on
+# unrelated file adds and defeat Salsa's backdating.
 Salsa.@derived function derived_formatconfig_files(rt)
     files = derived_text_files(rt)
 
-    return [file for file in files if file.scheme=="file" && is_path_formatconfig_file(uri2filepath(file))]
+    return sort!([file for file in files if file.scheme=="file" && is_path_formatconfig_file(uri2filepath(file))], by=string)
 end
 
 # Formatter knobs used to sit at the top level; they now live under `[options]`.
@@ -125,18 +128,38 @@ function _read_format_options(table)
     return out
 end
 
+"""
+    derived_format_path_filter(rt, config_uri) -> PathFilter
+
+The `include`/`exclude` globs of one `JuliaFormat.toml`, kept separate from the
+style and options so that scope and settings invalidate independently.
+"""
+Salsa.@derived function derived_format_path_filter(rt, config_uri)
+    discard = Diagnostic[]   # diagnostics are reported by derived_formatconfig_diagnostics
+
+    return parse_path_filter!(discard, derived_toml_syntax_tree(rt, config_uri))
+end
+
 Salsa.@derived function derived_format_configuration(rt, uri)
     @debug "derived_format_configuration" uri=uri
 
     # Non-file buffers have no folder-based config; defaults apply.
     uri.scheme == "file" || return EffectiveFormatConfig()
 
-    config_uri = nearest_config(derived_formatconfig_files(rt), uri)
-    config_uri === nothing && return EffectiveFormatConfig()
+    # Scope composes over every enclosing `JuliaFormat.toml`, so it is resolved
+    # before the nearest-file lookup that decides style and options.
+    config_files = derived_formatconfig_files(rt)
+    selected = scope_selected(
+        ancestor_configs(config_files, uri), uri2filepath(uri),
+        c -> derived_format_path_filter(rt, c),
+    )
+
+    config_uri = nearest_config(config_files, uri)
+    config_uri === nothing && return EffectiveFormatConfig(_FORMAT_DEFAULT_STYLE, Dict{Symbol,Any}(), selected)
 
     toml_content = derived_toml_syntax_tree(rt, config_uri)
     relpath = config_relative_path(config_dir_of(config_uri), uri2filepath(uri))
-    relpath === nothing && return EffectiveFormatConfig()
+    relpath === nothing && return EffectiveFormatConfig(_FORMAT_DEFAULT_STYLE, Dict{Symbol,Any}(), selected)
 
     style = get(toml_content, "style", _FORMAT_DEFAULT_STYLE)
     (style isa AbstractString && style in _FORMAT_STYLES) || (style = _FORMAT_DEFAULT_STYLE)
@@ -144,7 +167,6 @@ Salsa.@derived function derived_format_configuration(rt, uri)
     options = _read_format_options(get(toml_content, "options", nothing))
 
     discard = Diagnostic[]
-    filter = parse_path_filter!(discard, toml_content)
     overrides = parse_overrides!(discard, toml_content, (_, _) -> nothing)
 
     for ov in applicable_overrides(overrides, relpath)
@@ -155,7 +177,7 @@ Salsa.@derived function derived_format_configuration(rt, uri)
         merge!(options, _read_format_options(get(ov, "options", nothing)))
     end
 
-    return EffectiveFormatConfig(String(style), options, path_selected(filter, relpath))
+    return EffectiveFormatConfig(String(style), options, selected)
 end
 
 function _format_style_object(style::AbstractString)

--- a/src/layer_testitems.jl
+++ b/src/layer_testitems.jl
@@ -16,10 +16,13 @@ end
 # tag filters) are deliberately not part of it yet.
 const _TESTITEMS_CONFIG_TOP_LEVEL_KEYS = ["config-version", "include", "exclude"]
 
+# Sorted: this vector is now a dependency of every file's scope, and
+# `derived_text_files` is a `Set`, so an unsorted result would change on
+# unrelated file adds and defeat Salsa's backdating.
 Salsa.@derived function derived_testitemsconfig_files(rt)
     files = derived_text_files(rt)
 
-    return [file for file in files if file.scheme=="file" && is_path_testitemsconfig_file(uri2filepath(file))]
+    return sort!([file for file in files if file.scheme=="file" && is_path_testitemsconfig_file(uri2filepath(file))], by=string)
 end
 
 Salsa.@derived function derived_testitemsconfig_diagnostics(rt, uri)
@@ -29,7 +32,10 @@ Salsa.@derived function derived_testitemsconfig_diagnostics(rt, uri)
 
     validate_key_set!(res, toml_content, _TESTITEMS_CONFIG_TOP_LEVEL_KEYS, Dict{String,String}(), "test items configuration key")
     validate_config_version!(res, toml_content)
-    shadowing_diagnostic!(res, derived_testitemsconfig_files(rt), uri, "JuliaTestItems.toml")
+    # No `shadowing_diagnostic!` here: v1 of this file has nothing but scope keys,
+    # and scope composes over the whole ancestor chain rather than being replaced
+    # by the nearest file, so a nested `JuliaTestItems.toml` supersedes nothing.
+    # Reinstate the call if execution settings are ever added to the schema.
     parse_glob_list!(res, toml_content, "include")
     parse_glob_list!(res, toml_content, "exclude")
 
@@ -37,24 +43,33 @@ Salsa.@derived function derived_testitemsconfig_diagnostics(rt, uri)
 end
 
 """
+    derived_testitems_path_filter(rt, config_uri) -> PathFilter
+
+The `include`/`exclude` globs of one `JuliaTestItems.toml`. Split out from
+`derived_testitems_selected` so a config is parsed once rather than once per
+file it governs, and so editing a config only invalidates the files whose scope
+actually depends on it.
+"""
+Salsa.@derived function derived_testitems_path_filter(rt, config_uri)
+    discard = Diagnostic[]   # diagnostics are reported by derived_testitemsconfig_diagnostics
+
+    return parse_path_filter!(discard, derived_toml_syntax_tree(rt, config_uri))
+end
+
+"""
     derived_testitems_selected(rt, uri) -> Bool
 
-Whether test items are discovered in `uri` at all, per the governing
-`JuliaTestItems.toml`.
+Whether test items are discovered in `uri` at all. Every `JuliaTestItems.toml`
+enclosing `uri` must admit it: a nested config can narrow discovery further, but
+it cannot resurrect a subtree an enclosing config excluded.
 """
 Salsa.@derived function derived_testitems_selected(rt, uri)
     uri.scheme == "file" || return true
 
-    config_uri = nearest_config(derived_testitemsconfig_files(rt), uri)
-    config_uri === nothing && return true
+    chain = ancestor_configs(derived_testitemsconfig_files(rt), uri)
+    isempty(chain) && return true
 
-    relpath = config_relative_path(config_dir_of(config_uri), uri2filepath(uri))
-    relpath === nothing && return true
-
-    toml_content = derived_toml_syntax_tree(rt, config_uri)
-    discard = Diagnostic[]
-
-    return path_selected(parse_path_filter!(discard, toml_content), relpath)
+    return scope_selected(chain, uri2filepath(uri), c -> derived_testitems_path_filter(rt, c))
 end
 
 """

--- a/src/lint_rules.jl
+++ b/src/lint_rules.jl
@@ -289,7 +289,11 @@ struct EffectiveLintConfig
     selected::Bool
 end
 
-EffectiveLintConfig() = EffectiveLintConfig(copy(_PRESET_DEFAULT), Dict{Symbol,Dict{Symbol,Any}}(), true)
+# Defaults, with scope supplied by the caller: config resolution decides whether
+# a file is in scope from the whole ancestor chain, so it knows `selected` even
+# on the paths where it has no config file to read settings from.
+EffectiveLintConfig(selected::Bool) = EffectiveLintConfig(copy(_PRESET_DEFAULT), Dict{Symbol,Dict{Symbol,Any}}(), selected)
+EffectiveLintConfig() = EffectiveLintConfig(true)
 
 function _lint_config_fields_equal(a::EffectiveLintConfig, b::EffectiveLintConfig, eq)
     eq(a.severities, b.severities) && eq(a.options, b.options) && eq(a.selected, b.selected)

--- a/test/test_config.jl
+++ b/test/test_config.jl
@@ -218,7 +218,7 @@ end
     @test !any(d -> d.code === :shadowed_config, get_diagnostic(jw, URI("file:///sh2/src/JuliaLint.toml")))
 end
 
-@testitem "Config: a nested formatter or test items config reports it too" begin
+@testitem "Config: a nested formatter config reports it too" begin
     using JuliaWorkspaces.URIs2: URI
 
     jw = JuliaWorkspace()
@@ -227,8 +227,15 @@ end
     add_file!(jw, TextFile(URI("file:///sh3/JuliaTestItems.toml"), SourceText("include = [\"src/**\"]\n", "toml")))
     add_file!(jw, TextFile(URI("file:///sh3/src/JuliaTestItems.toml"), SourceText("include = [\"*.jl\"]\n", "toml")))
 
-    @test any(d -> d.code === :shadowed_config, get_diagnostic(jw, URI("file:///sh3/src/JuliaFormat.toml")))
-    @test any(d -> d.code === :shadowed_config, get_diagnostic(jw, URI("file:///sh3/src/JuliaTestItems.toml")))
+    fmt = get_diagnostic(jw, URI("file:///sh3/src/JuliaFormat.toml"))
+    idx = findfirst(d -> d.code === :shadowed_config, fmt)
+    @test idx !== nothing
+    # The message says what still survives the takeover.
+    @test occursin("include", fmt[idx].message) && occursin("narrow", fmt[idx].message)
+
+    # A nested `JuliaTestItems.toml` shadows nothing: v1 of that file has only
+    # scope keys, and scope composes over the chain instead of being replaced.
+    @test !any(d -> d.code === :shadowed_config, get_diagnostic(jw, URI("file:///sh3/src/JuliaTestItems.toml")))
 
     # Different kinds don't shadow each other.
     @test !any(d -> d.code === :shadowed_config, get_diagnostic(jw, URI("file:///sh3/JuliaFormat.toml")))
@@ -258,6 +265,7 @@ end
               diags("JuliaLint.toml", "config-version = \"one\"\n"))
 end
 
+# Settings only — scope composes over the chain instead, see the veto tests below.
 @testitem "Lint config: nearest file governs, no merging" begin
     using JuliaWorkspaces.URIs2: URI
 
@@ -589,4 +597,215 @@ end
     # `ExpandFunction` fixes no rule, so even the most restrictive config keeps it.
     @test "ExpandFunction" in actions_with(nothing)
     @test "ExpandFunction" in actions_with("preset = \"minimal\"")
+end
+
+@testitem "Config chain: ancestor_configs walks outermost to innermost" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    ancestors(uris, u) = JuliaWorkspaces.ancestor_configs(uris, URI(u))
+
+    root = URI("file:///p/JuliaTestItems.toml")
+    mid = URI("file:///p/packages/JuliaTestItems.toml")
+    deep = URI("file:///p/packages/Foo/JuliaTestItems.toml")
+    other = URI("file:///q/JuliaTestItems.toml")
+
+    # Outermost first, and the ordering does not depend on the input order.
+    for input in ([root, mid, deep, other], [deep, other, root, mid])
+        @test ancestors(input, "file:///p/packages/Foo/src/a.jl") == [root, mid, deep]
+    end
+
+    @test ancestors([root, mid, deep], "file:///p/a.jl") == [root]
+    @test isempty(ancestors([root, mid, deep], "file:///elsewhere/a.jl"))
+    @test isempty(ancestors([root], "untitled:Untitled-1"))
+
+    # `nearest_config` is the innermost entry of the same chain.
+    @test JuliaWorkspaces.nearest_config([root, mid, deep], URI("file:///p/packages/Foo/src/a.jl")) == deep
+    @test JuliaWorkspaces.nearest_config([root, mid, deep], URI("file:///elsewhere/a.jl")) === nothing
+
+    # A config never counts as its own strict ancestor.
+    @test JuliaWorkspaces.strict_ancestor_configs([root, mid, deep], deep) == [root, mid]
+    @test isempty(JuliaWorkspaces.strict_ancestor_configs([root, mid, deep], root))
+end
+
+@testitem "Config chain: scope_selected is the intersection over the chain" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    root = URI("file:///p/JuliaTestItems.toml")
+    nested = URI("file:///p/packages/Foo/JuliaTestItems.toml")
+
+    filters = Dict{URI,JuliaWorkspaces.PathFilter}()
+    pf(inc, exc) = JuliaWorkspaces.PathFilter(
+        JuliaWorkspaces.GlobPattern[JuliaWorkspaces.GlobPattern(x) for x in inc],
+        JuliaWorkspaces.GlobPattern[JuliaWorkspaces.GlobPattern(x) for x in exc],
+    )
+    sel(path) = JuliaWorkspaces.scope_selected([root, nested], path, c -> filters[c])
+
+    # The parent excludes the subtree; the nested file cannot take it back.
+    filters[root] = pf(String[], ["packages/**"])
+    filters[nested] = pf(String[], String[])
+    @test !sel("/p/packages/Foo/src/a.jl")
+
+    # Not even with an explicit `include`.
+    filters[nested] = pf(["**/*.jl"], String[])
+    @test !sel("/p/packages/Foo/src/a.jl")
+
+    # A nested file may narrow further.
+    filters[root] = pf(String[], String[])
+    filters[nested] = pf(String[], ["gen/**"])
+    @test sel("/p/packages/Foo/src/a.jl")
+    @test !sel("/p/packages/Foo/gen/a.jl")
+
+    # A nested `include` cannot widen the parent's.
+    filters[root] = pf(["packages/Foo/src/**"], String[])
+    filters[nested] = pf(["**"], String[])
+    @test sel("/p/packages/Foo/src/a.jl")
+    @test !sel("/p/packages/Foo/docs/a.jl")
+end
+
+@testitem "Test items config: a vendored config cannot undo an enclosing exclude" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    content = """
+    module Foo
+    @testitem "t" begin
+        @test true
+    end
+    end
+    """
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///veto/Project.toml"),
+        SourceText("name = \"Veto\"\nuuid = \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee21\"\nversion = \"0.1.0\"\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///veto/JuliaTestItems.toml"),
+        SourceText("exclude = [\"packages/**\"]\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///veto/src/Veto.jl"), SourceText(content, "julia")))
+
+    # A vendored package carrying its own config, which under nearest-wins would
+    # have resurrected the whole subtree.
+    add_file!(jw, TextFile(URI("file:///veto/packages/Foo/Project.toml"),
+        SourceText("name = \"Foo\"\nuuid = \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee22\"\nversion = \"0.1.0\"\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///veto/packages/Foo/JuliaTestItems.toml"),
+        SourceText("include = [\"**/*.jl\"]\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///veto/packages/Foo/src/Foo.jl"), SourceText(content, "julia")))
+
+    @test !isempty(JuliaWorkspaces.derived_testitems(jw.runtime, URI("file:///veto/src/Veto.jl")).testitems)
+    @test isempty(JuliaWorkspaces.derived_testitems(jw.runtime, URI("file:///veto/packages/Foo/src/Foo.jl")).testitems)
+
+    # And the whole-workspace sweep agrees: it is keyed by file, and the
+    # vendored file contributes no test items to it.
+    sweep = JuliaWorkspaces.derived_all_testitems(jw.runtime)
+    @test !isempty(sweep[URI("file:///veto/src/Veto.jl")].testitems)
+    @test isempty(sweep[URI("file:///veto/packages/Foo/src/Foo.jl")].testitems)
+end
+
+@testitem "Test items config: a nested config may still narrow discovery" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    content = """
+    @testitem "t" begin
+        @test true
+    end
+    """
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///narrow/Project.toml"),
+        SourceText("name = \"Narrow\"\nuuid = \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee23\"\nversion = \"0.1.0\"\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///narrow/JuliaTestItems.toml"), SourceText("\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///narrow/sub/JuliaTestItems.toml"),
+        SourceText("exclude = [\"gen/**\"]\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///narrow/sub/src/a.jl"), SourceText(content, "julia")))
+    add_file!(jw, TextFile(URI("file:///narrow/sub/gen/b.jl"), SourceText(content, "julia")))
+
+    @test !isempty(JuliaWorkspaces.derived_testitems(jw.runtime, URI("file:///narrow/sub/src/a.jl")).testitems)
+    @test isempty(JuliaWorkspaces.derived_testitems(jw.runtime, URI("file:///narrow/sub/gen/b.jl")).testitems)
+end
+
+@testitem "Test items config: a nested include cannot widen an enclosing one" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    content = """
+    @testitem "t" begin
+        @test true
+    end
+    """
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///widen/Project.toml"),
+        SourceText("name = \"Widen\"\nuuid = \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee24\"\nversion = \"0.1.0\"\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///widen/JuliaTestItems.toml"),
+        SourceText("include = [\"src/**\"]\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///widen/docs/JuliaTestItems.toml"),
+        SourceText("include = [\"**\"]\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///widen/src/a.jl"), SourceText(content, "julia")))
+    add_file!(jw, TextFile(URI("file:///widen/docs/b.jl"), SourceText(content, "julia")))
+
+    @test !isempty(JuliaWorkspaces.derived_testitems(jw.runtime, URI("file:///widen/src/a.jl")).testitems)
+    @test isempty(JuliaWorkspaces.derived_testitems(jw.runtime, URI("file:///widen/docs/b.jl")).testitems)
+end
+
+@testitem "Lint config: a vendored config cannot undo an enclosing exclude" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///lveto/JuliaLint.toml"),
+        SourceText("exclude = [\"vendor/**\"]\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///lveto/vendor/JuliaLint.toml"),
+        SourceText("preset = \"strict\"\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///lveto/a.jl"), SourceText("function foo() end begin", "julia")))
+    add_file!(jw, TextFile(URI("file:///lveto/vendor/b.jl"), SourceText("function foo() end begin", "julia")))
+    add_file!(jw, TextFile(URI("file:///lveto/nested/JuliaLint.toml"),
+        SourceText("preset = \"strict\"\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///lveto/nested/c.jl"), SourceText("x = 1\n", "julia")))
+
+    @test !isempty(get_diagnostic(jw, URI("file:///lveto/a.jl")))
+    @test isempty(get_diagnostic(jw, URI("file:///lveto/vendor/b.jl")))
+
+    # Settings are unaffected: they still come from the nearest file alone.
+    nested = JuliaWorkspaces.derived_effective_lint_config(jw.runtime, URI("file:///lveto/nested/c.jl"))
+    @test nested.selected
+    @test JuliaWorkspaces.rule_severity(nested, :unused_binding) === :warning
+end
+
+@testitem "Format config: a vendored config cannot undo an enclosing exclude" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///fveto/JuliaFormat.toml"),
+        SourceText("exclude = [\"vendor/**\"]\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///fveto/vendor/JuliaFormat.toml"),
+        SourceText("style = \"blue\"\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///fveto/a.jl"), SourceText("x = 1\n", "julia")))
+    add_file!(jw, TextFile(URI("file:///fveto/vendor/b.jl"), SourceText("x = 1\n", "julia")))
+    add_file!(jw, TextFile(URI("file:///fveto/nested/JuliaFormat.toml"),
+        SourceText("style = \"blue\"\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///fveto/nested/c.jl"), SourceText("x = 1\n", "julia")))
+
+    @test !is_format_excluded(jw, URI("file:///fveto/a.jl"))
+    @test is_format_excluded(jw, URI("file:///fveto/vendor/b.jl"))
+
+    # Style still comes from the nearest file for a file that is in scope.
+    @test JuliaWorkspaces.derived_format_configuration(jw.runtime, URI("file:///fveto/nested/c.jl")).style == "blue"
+end
+
+@testitem "Config: a config file inside an excluded subtree is silent" begin
+    using JuliaWorkspaces.URIs2: URI
+
+    jw = JuliaWorkspace()
+    add_file!(jw, TextFile(URI("file:///quiet/JuliaLint.toml"),
+        SourceText("exclude = [\"vendor/**\"]\n", "toml")))
+    # Deliberately broken configs inside the subtree the project set aside.
+    add_file!(jw, TextFile(URI("file:///quiet/vendor/JuliaTestItems.toml"),
+        SourceText("workers = 4\n", "toml")))
+    add_file!(jw, TextFile(URI("file:///quiet/vendor/JuliaLint.toml"),
+        SourceText("bogus_key = 1\n", "toml")))
+
+    @test isempty(get_diagnostic(jw, URI("file:///quiet/vendor/JuliaTestItems.toml")))
+    @test isempty(get_diagnostic(jw, URI("file:///quiet/vendor/JuliaLint.toml")))
+
+    # But a config excluding its own directory still reports its own mistakes,
+    # or a bad `exclude` could hide the diagnostic that explains it.
+    jw2 = JuliaWorkspace()
+    add_file!(jw2, TextFile(URI("file:///quiet2/JuliaLint.toml"),
+        SourceText("exclude = [\"**\"]\nbogus_key = 1\n", "toml")))
+    @test any(d -> d.code === :config_errors, get_diagnostic(jw2, URI("file:///quiet2/JuliaLint.toml")))
 end


### PR DESCRIPTION
Paired with julia-vscode/TestItemRunner.jl#136 — **these two should merge together**, since TestItemRunner's `testitems_config.jl` promises identical semantics and that promise would otherwise be false on `main`.

## The problem

`nearest_config` picked the config whose directory is the longest prefix of the target path, and that one file decided everything — including whether the file was in scope at all. No enclosing config was ever consulted:

```
myproject/
  JuliaTestItems.toml       exclude = ["packages/**"]
  packages/Foo/
    JuliaTestItems.toml     (vendored, ships its own conventions)
    src/Foo.jl              <- searched. The root's exclude is never read.
```

Three things conspired: the disk walk ingests everything outside `.git`/`node_modules`, so the vendored config becomes a discovery candidate; `nearest_config` picks it because it is deepest; and `derived_testitems_selected` reads that one file and nothing else. The same hole let a vendored `JuliaLint.toml` re-enable linting on code the project had deliberately set aside.

There was no way for the parent to say otherwise. Vendored code held a veto over the project vendoring it.

## The change

> **Scope** is the intersection over every enclosing config file of that kind, each evaluated relative to its own directory. A nested config may narrow scope, never widen it.
>
> **Settings** — `preset`, `[rules]`, `style`, `[options]`, `[[override]]` — are unchanged: still wholesale from the nearest file, still no merging.

Applies to all three config kinds, since the vendoring problem is identical for each and the shared grammar's selling point is that the rule is learned once.

This is the split every comparable tool makes. gitignore states it outright (*"it is not possible to re-include a file if a parent directory is excluded"*); Ruff keeps rule settings hierarchical but honours `exclude` only in the top-level configuration; ESLint v9 makes `ignores` global; pytest never descends into `norecursedirs`, so a nested `conftest.py` is not even loaded.

New shared machinery in `config_common.jl`: `ancestor_configs`, `strict_ancestor_configs`, `scope_selected`. `nearest_config` is now the innermost entry of the same chain, so there is one source of truth.

## Three consequences worth review attention

**`JuliaTestItems.toml` no longer reports `shadowed_config`.** Version 1 of that file has nothing but scope keys, so under the new rule a nested one supersedes nothing and the message would simply be false. The message for the other two kinds is reworded to say what still survives the takeover.

**A config inside an ancestor-excluded subtree reports nothing at all.** Excluding a vendored repository should not leave you reading diagnostics about its config files. The existing "a config validates itself even when its own globs exclude its directory" carve-out is kept but narrowed to *self*-exclusion. Note this is keyed off the `JuliaLint.toml` chain, so a root `exclude = ["vendor/**"]` there silences all three config kinds under `vendor/` — one rule rather than three per-kind ones.

**Two Salsa changes that are load-bearing, not cleanup.** `include`/`exclude` move out of `ParsedLintConfig` into `derived_lint_path_filter` (and equivalents for the other two kinds) — otherwise editing `[rules]` invalidates every file's scope and editing `exclude` invalidates every file's rules. And the three `derived_*config_files` vectors are now sorted: they are built from a `Set`, so their order could shift on unrelated file adds, which was harmless when the result fed a single `max` but would recompute scope workspace-wide now that every file's scope depends on the whole vector.

## Not in scope

The disk walk (`read_path_into_textdocuments`) still ingests excluded subtrees. Pruning it is tempting for perf but wrong here: it is kind-agnostic, and a subtree excluded for test items must still be read for lint, formatting, workspace symbols, include resolution and goto-definition. The real blocker is Salsa — unread files are not inputs, so nothing connects "the root config's `exclude` line" to "these files were never loaded", and un-excluding a subtree would need a full disk re-walk that nothing currently triggers.

## Verification

Full suite green: 5181 passed, 0 failed, 0 errored, 8 broken (the same 8 as `main`).

New coverage in `test/test_config.jl`: `ancestor_configs` ordering and order-independence, `scope_selected` intersection semantics, the headline vendoring case for test items, nested-narrows and nested-cannot-widen, the lint and format equivalents with settings asserted still nearest-wins, and the silent-config-in-excluded-subtree behaviour alongside the preserved self-validation.

End to end, against a scratch workspace with a root `exclude = ["packages/**"]` and a vendored package carrying `include = ["**/*.jl"]`: `main` discovers `vendored test`, this branch discovers only `host test`.