### PR TITLE
Don't re-declare the jl_module_names ccall

### DIFF
--- a/shared/symbolserver/utils.jl
+++ b/shared/symbolserver/utils.jl
@@ -432,19 +432,25 @@ extends_methods(f) = false
 extends_methods(f::FunctionStore) = f.name != f.extends
 get_top_module(vr::VarRef) = vr.parent === nothing ? vr.name : get_top_module(vr.parent)
 
-# Sorting is the main performance of calling `names`
+# Sorting is the main cost of calling `names`, so go to Base's unsorted entry point.
+#
+# Do NOT re-declare the `jl_module_names` ccall here. Its C signature is not stable —
+# 1.12 added `usings`, 1.13 added `world` — and calling it with the wrong arity is
+# undefined behaviour that does not error: it reads a garbage `world` off the stack and
+# returns a silently truncated, run-to-run varying name list. That made the crawl miss
+# most of Base and Core on 1.13, which surfaced far downstream as `load_core` failing on
+# a `VarRef` where it expected a `ModuleStore`. `Base.unsorted_names` tracks the
+# signature for us and exists on every version we support.
 @static if VERSION < v"1.12-"
-    _jl_module_names(m, all, imported, _) =
-        ccall(:jl_module_names, Array{Symbol,1}, (Any, Cint, Cint), m, all, imported)
+    _unsorted_names(m, all, imported, _) = Base.unsorted_names(m; all, imported)
 else
-    _jl_module_names(m, all, imported, usings) =
-        ccall(:jl_module_names, Array{Symbol,1}, (Any, Cint, Cint, Cint), m, all, imported, usings)
+    _unsorted_names(m, all, imported, usings) = Base.unsorted_names(m; all, imported, usings)
 end
 
 # bindings are world-age partitioned from 1.12 onwards, so an
 # in-frame call misses bindings committed later in the same frame.
 unsorted_names(m::Module; all::Bool=false, imported::Bool=false, usings=false) =
-    Base.invokelatest(_jl_module_names, m, all, imported, usings)
+    Base.invokelatest(_unsorted_names, m, all, imported, usings)
 
 ## recursive_copy
 #

--- a/test/test_symbolserver.jl
+++ b/test/test_symbolserver.jl
@@ -1117,6 +1117,24 @@ end
     @test :nonexported_helper in commit_then_enumerate()
 end
 
+@testitem "SymbolServer: unsorted_names agrees with Base.names" begin
+    using JuliaWorkspaces.SymbolServer: unsorted_names
+
+    # unsorted_names used to re-declare the `jl_module_names` ccall itself. That C
+    # signature is not stable — 1.12 added `usings`, 1.13 added `world` — and calling it
+    # with the wrong arity does not error: it reads a garbage `world` off the stack and
+    # returns a silently truncated, run-to-run varying list. On 1.13 that made the crawl
+    # miss most of Base, which only surfaced much later as `load_core` finding a `VarRef`
+    # where it expected a `ModuleStore`. Compare against Base so a future signature change
+    # fails here instead.
+    for m in (Base, Core)
+        @test sort(unsorted_names(m; all=true)) == sort(names(m; all=true))
+        @test sort(unsorted_names(m)) == sort(names(m))
+    end
+    @test :_apply in unsorted_names(Core; all=true)
+    @test :MainInclude in unsorted_names(Base; all=true)
+end
+
 @testitem "SymbolServer: ModuleStore splits exported vs public names" begin
     using JuliaWorkspaces.SymbolServer: ModuleStore
     # `public` is a 1.11+ keyword; the exported/public split only exists there.


### PR DESCRIPTION
Julia 1.13 added a fifth `world::UInt` argument to `jl_module_names`. `unsorted_names` declared its own 4-arg ccall for `VERSION >= v"1.12-"`, so on 1.13 the `world` argument was whatever happened to be on the stack.

That does not error. It returns a silently truncated, run-to-run varying name list:

```
VV BEFORE unsorted(Base)=1210 names(Base)=7135     # julia 1.13.0-rc3, same expression
VV BEFORE unsorted(Base)=7032 names(Base)=7032     # julia 1.12.7
```

The crawl then missed most of Base and Core, and the damage surfaced far downstream in `load_core` as `MethodError: no method matching haskey(::VarRef, ::Symbol)` — `Base.MainInclude` had degraded from a `ModuleStore` to a `VarRef`, and `cache[:Core][:_apply]` had vanished entirely.

The nondeterminism is why it looked platform-specific. On TestItemApp's CI, JuliaWorkspaces failed to precompile on the `ubuntu-latest` (x64 and x86) and `macos-26-intel` rc legs while `windows-latest` and `macos-26` passed — same code, same Julia, garbage world argument.

## Fix

Call `Base.unsorted_names`. It exists on every version we support (1.11, 1.12, 1.13), skips the `sort!` exactly as the hand-rolled version did, and tracks the C signature for us — 1.12 added `usings`, 1.13 added `world`, and there is no reason to assume that is the end of it. Only the `usings` keyword still needs a version gate.

The `Base.invokelatest` wrapper stays: bindings are world-age partitioned from 1.12 on, and the existing test for that behaviour still passes.

## Verification

Precompiled JuliaWorkspaces 13.1.0 with only this file swapped in, in Linux containers:

| Julia | before | after |
|---|---|---|
| 1.11.9 | ✓ | ✓ |
| 1.12.7 | ✓ | ✓ |
| 1.13.0-rc3 | **failed to precompile** | ✓ precompiles and loads |

`SymbolServer` test items on 1.12: 46 passed, 46 ran.

Adds a regression test comparing `unsorted_names` against `Base.names` for `Base` and `Core`, so a future signature change fails loudly here instead of silently corrupting the symbol cache.