### PR TITLE
Adapt CloudIndex to the 1.13 registry API

### DIFF
--- a/src/CloudIndex/registry.jl
+++ b/src/CloudIndex/registry.jl
@@ -23,15 +23,34 @@ end
 
 # julia compat applicable to version `v`: intersection of every `julia` VersionSpec
 # whose VersionRange key contains `v`. `nothing` when no julia compat is declared.
+# Julia 1.13 rekeyed the inner `PkgInfo.compat` dicts from package *name* to package `UUID`.
+# Dispatch on the key type rather than on a version number — the dict itself says which
+# registry format we were handed.
+_julia_compat_entry(entries::AbstractDict{String}) = get(entries, "julia", nothing)
+_julia_compat_entry(entries::AbstractDict{Base.UUID}) =
+    get(entries, Pkg.Registry.JULIA_UUID, nothing)
+
 function _julia_compat_for(compat, v::VersionNumber)
     spec = nothing
     for (range, entries) in compat
         v in range || continue
-        js = get(entries, "julia", nothing)
+        js = _julia_compat_entry(entries)
         js === nothing && continue
         spec = spec === nothing ? js : intersect(spec, js)
     end
     return spec
+end
+
+# Julia 1.13 changed `Pkg.Registry.registry_info` from `(::PkgEntry)` to
+# `(::RegistryInstance, ::PkgEntry)`, and there is exactly one method either way, so calling
+# the old form is a hard MethodError rather than a deprecation. Dispatch on what the running
+# Pkg actually provides instead of on a version number: this is a non-public Pkg API and the
+# signature has already moved once.
+@static if hasmethod(Pkg.Registry.registry_info,
+                     Tuple{Pkg.Registry.RegistryInstance,Pkg.Registry.PkgEntry})
+    _registry_info(reg, entry) = Pkg.Registry.registry_info(reg, entry)
+else
+    _registry_info(_reg, entry) = Pkg.Registry.registry_info(entry)
 end
 
 """
@@ -44,7 +63,7 @@ function enumerate_registry(registry_path::AbstractString)
     reg = Pkg.Registry.RegistryInstance(String(registry_path))
     out = PkgVersion[]
     for (uuid, entry) in reg.pkgs
-        info = Pkg.Registry.registry_info(entry)
+        info = _registry_info(reg, entry)
         for (v, vinfo) in info.version_info
             push!(out, PkgVersion(
                 entry.name,


### PR DESCRIPTION
Two `Pkg.Registry` changes in Julia 1.13 break `CloudIndex`, found by running the JuliaWorkspaces suite with test workers on 1.13.0-rc3.

**1. `registry_info` changed arity.** `(::PkgEntry)` → `(::RegistryInstance, ::PkgEntry)`. There is exactly one method either way, so the old call is a hard `MethodError`, not a deprecation:

```
MethodError: no method matching registry_info(::Pkg.Registry.PkgEntry)
  at enumerate_registry (src/CloudIndex/registry.jl:47)
```

**2. `PkgInfo.compat` was rekeyed from package name to package UUID.**

```
1.12.7:      Dict{VersionRange, Dict{String,    VersionSpec}}
1.13.0-rc3:  Dict{VersionRange, Dict{Base.UUID, VersionSpec}}
```

This one is nastier — it does not throw. `get(entries, "julia", nothing)` just never matches, so every row silently loses its julia compat bound. It only surfaced as a test failure (`in(::VersionNumber, ::Nothing)`) after the first bug was fixed and execution got that far.

## Approach

Dispatch on what the running Pkg actually provides, not on a version number — `hasmethod` for the first, the dict's key type for the second:

```julia
_julia_compat_entry(entries::AbstractDict{String})    = get(entries, "julia", nothing)
_julia_compat_entry(entries::AbstractDict{Base.UUID}) = get(entries, Pkg.Registry.JULIA_UUID, nothing)
```

This is non-public Pkg API whose shape has now moved twice, and a `VERSION` gate would need revisiting each time it moves again. `Pkg.Registry.JULIA_UUID` is defined on 1.11, 1.12 and 1.13, so the UUID branch needs no constant of our own.

## Verification

`CloudIndex` test items, run with `juliati --juliaup-channel`:

| Workers | Before | After |
|---|---|---|
| 1.13.0-rc3 | 2 errored | **28 passed** |
| 1.12.7 | 28 passed | **28 passed** |

For context, the full JuliaWorkspaces suite on 1.13.0-rc3 workers was 1096 ran / 1094 passed / 2 errored, and these were the only two failures.